### PR TITLE
feat: optimize string literal tostack behavior

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -59,7 +59,8 @@ import {
   isConstNegZero,
   isConstExpressionNaN,
   ensureType,
-  createType
+  createType,
+  getConstValueInteger
 } from "./module";
 
 import {
@@ -451,6 +452,8 @@ export class Compiler extends DiagnosticEmitter {
   memorySegments: MemorySegment[] = [];
   /** Map of already compiled static string segments. */
   stringSegments: Map<string,MemorySegment> = new Map();
+  /** Set of static GC object offsets. tostack is unnecessary for them. */
+  staticGcObjectOffsets: Map<i32, Set<i32>> = new Map();
   /** Function table being compiled. First elem is blank. */
   functionTable: Function[] = [];
   /** Arguments length helper global. */
@@ -1939,7 +1942,16 @@ export class Compiler extends DiagnosticEmitter {
       stringSegment = this.addRuntimeMemorySegment(buf);
       segments.set(stringValue, stringSegment);
     }
-    return i64_add(stringSegment.offset, i64_new(totalOverhead));
+    let stringOffset = i64_add(stringSegment.offset, i64_new(totalOverhead));
+    let staticGcObjectOffsets = this.staticGcObjectOffsets;
+    if (staticGcObjectOffsets.has(i64_high(stringOffset))) {
+      assert(staticGcObjectOffsets.get(i64_high(stringOffset))).add(i64_low(stringOffset));
+    } else {
+      let s = new Set<i32>();
+      s.add(i64_low(stringOffset));
+      staticGcObjectOffsets.set(i64_high(stringOffset), s);
+    }
+    return stringOffset;
   }
 
   /** Writes a series of static values of the specified type to a buffer. */
@@ -6754,6 +6766,21 @@ export class Compiler extends DiagnosticEmitter {
     stub.set(CommonFlags.Compiled);
   }
 
+  private needToStack(expr: ExpressionRef): bool {
+    const precomp = this.module.runExpression(expr, ExpressionRunnerFlags.Default);
+    // cannot precompute, so must go to stack
+    if (precomp == 0) return true;
+    const value = getConstValueInteger(precomp, this.options.isWasm64);
+    // zero constant doesn't need to go to stack
+    if (i64_eq(value, i64_zero)) return false;
+    // static GC objects doesn't need to go to stack
+    let staticGcObjectOffsets = this.staticGcObjectOffsets;
+    if (staticGcObjectOffsets.has(i64_high(value))) {
+      if (assert(staticGcObjectOffsets.get(i64_high(value))).has(i64_low(value))) return false;
+    }
+    return true;
+  }
+
   /** Marks managed call operands for the shadow stack. */
   private operandsTostack(signature: Signature, operands: ExpressionRef[]): void {
     if (!this.options.stackSize) return;
@@ -6763,8 +6790,7 @@ export class Compiler extends DiagnosticEmitter {
     if (thisType) {
       if (thisType.isManaged) {
         let operand = operands[0];
-        let precomp = module.runExpression(operand, ExpressionRunnerFlags.Default);
-        if (!precomp || !isConstZero(precomp)) { // otherwise unnecessary
+        if (this.needToStack(operand)) {
           operands[operandIndex] = module.tostack(operand);
         }
       }
@@ -6777,8 +6803,7 @@ export class Compiler extends DiagnosticEmitter {
       let paramType = parameterTypes[parameterIndex];
       if (paramType.isManaged) {
         let operand = operands[operandIndex];
-        let precomp = module.runExpression(operand, ExpressionRunnerFlags.Default);
-        if (!precomp || !isConstZero(precomp)) { // otherwise unnecessary
+        if (this.needToStack(operand)) {
           operands[operandIndex] = module.tostack(operand);
         }
       }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -55,7 +55,6 @@ import {
   SideEffects,
   SwitchBuilder,
   ExpressionRunnerFlags,
-  isConstZero,
   isConstNegZero,
   isConstExpressionNaN,
   ensureType,

--- a/src/module.ts
+++ b/src/module.ts
@@ -3038,6 +3038,18 @@ export function getConstValueI64High(expr: ExpressionRef): i32 {
   return binaryen._BinaryenConstGetValueI64High(expr);
 }
 
+export function getConstValueInteger(expr: ExpressionRef, isWasm64: bool): i64 {
+    let lo: i32 = 0;
+    let hi: i32 = 0;
+    if (isWasm64) {
+      lo = getConstValueI64Low(expr);
+      hi = getConstValueI64High(expr);
+    } else {
+      lo = getConstValueI32(expr);
+    }
+    return i64_new(lo, hi);
+}
+
 export function getConstValueF32(expr: ExpressionRef): f32 {
   return binaryen._BinaryenConstGetValueF32(expr);
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -3039,15 +3039,15 @@ export function getConstValueI64High(expr: ExpressionRef): i32 {
 }
 
 export function getConstValueInteger(expr: ExpressionRef, isWasm64: bool): i64 {
-    let lo: i32 = 0;
-    let hi: i32 = 0;
-    if (isWasm64) {
-      lo = getConstValueI64Low(expr);
-      hi = getConstValueI64High(expr);
-    } else {
-      lo = getConstValueI32(expr);
-    }
-    return i64_new(lo, hi);
+  let lo: i32 = 0;
+  let hi: i32 = 0;
+  if (isWasm64) {
+    lo = getConstValueI64Low(expr);
+    hi = getConstValueI64High(expr);
+  } else {
+    lo = getConstValueI32(expr);
+  }
+  return i64_new(lo, hi);
 }
 
 export function getConstValueF32(expr: ExpressionRef): f32 {

--- a/tests/compiler/NonNullable.debug.wat
+++ b/tests/compiler/NonNullable.debug.wat
@@ -357,28 +357,15 @@
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   i32.const 32
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
   i32.const 32
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -390,17 +377,7 @@
    unreachable
   end
   i32.const 112
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
   i32.const 112
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -412,17 +389,7 @@
    unreachable
   end
   i32.const 144
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
   i32.const 144
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -436,7 +403,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $NonNullable/z
   local.tee $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   if (result i32)
    local.get $0
@@ -462,7 +429,7 @@
   local.get $1
   call $NonNullable/safetyCheck<~lib/string/String|null>
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/NonNullable.release.wat
+++ b/tests/compiler/NonNullable.release.wat
@@ -22,7 +22,7 @@
  (start $~start)
  (func $~start
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -33,15 +33,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -54,12 +45,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store offset=4
    i32.const 1136
    i32.const 1136
    call $~lib/string/String.__eq
@@ -72,12 +57,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store offset=4
    i32.const 1168
    i32.const 1168
    call $~lib/string/String.__eq
@@ -92,7 +71,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 1248
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 1248
    i32.store
@@ -126,7 +105,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -124,6 +124,27 @@
  (export "functionFunction" (func $export:bindings/esm/functionFunction))
  (func $start:bindings/esm~anonymous|0
  )
+ (func $start:bindings/esm
+  i32.const 128
+  i32.const 1
+  f64.const 42
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $~lib/builtins/trace
+  i32.const 160
+  call $~lib/bindings/dom/console.log
+  global.get $~lib/bindings/dom/Math.E
+  call $~lib/bindings/dom/Math.log
+  drop
+  global.get $bindings/esm/immutableGlobal
+  drop
+  global.get $bindings/esm/immutableGlobalNested
+  drop
+  call $bindings/esm/Date_getTimezoneOffset
+  drop
+ )
  (func $bindings/esm/plainFunction (param $a i32) (param $b i32) (result i32)
   local.get $a
   local.get $b
@@ -3080,50 +3101,6 @@
    call $~lib/builtins/abort
    unreachable
   end
- )
- (func $start:bindings/esm
-  (local $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  i32.const 128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  i32.const 1
-  f64.const 42
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $~lib/builtins/trace
-  i32.const 160
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/bindings/dom/console.log
-  global.get $~lib/bindings/dom/Math.E
-  call $~lib/bindings/dom/Math.log
-  drop
-  global.get $bindings/esm/immutableGlobal
-  drop
-  global.get $bindings/esm/immutableGlobalNested
-  drop
-  call $bindings/esm/Date_getTimezoneOffset
-  drop
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $bindings/esm/bufferFunction (param $a i32) (param $b i32) (result i32)
   (local $aByteLength i32)

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -2053,27 +2053,6 @@
   end
   i32.const 1
   global.set $~started
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2276
-  i32.lt_s
-  if
-   i32.const 35072
-   i32.const 35120
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1152
-  i32.store
   i32.const 1152
   i32.const 1
   f64.const 42
@@ -2082,9 +2061,6 @@
   f64.const 0
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1184
-  i32.store
   i32.const 1184
   call $~lib/bindings/dom/console.log
   global.get $~lib/bindings/dom/Math.E
@@ -2092,10 +2068,6 @@
   drop
   call $bindings/esm/Date_getTimezoneOffset
   drop
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
   memory.size
   i32.const 16
   i32.shl
@@ -2192,7 +2164,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$285
+   block $__inlined_func$~lib/string/String#concat$284
     local.get $1
     i32.const 20
     i32.sub
@@ -2211,7 +2183,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$285
+     br $__inlined_func$~lib/string/String#concat$284
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2925,7 +2897,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$270
+   block $__inlined_func$~lib/rt/itcms/__renew$269
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2968,7 +2940,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$270
+     br $__inlined_func$~lib/rt/itcms/__renew$269
     end
     local.get $3
     local.get $4

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -124,6 +124,27 @@
  (export "functionFunction" (func $export:bindings/esm/functionFunction))
  (func $start:bindings/esm~anonymous|0
  )
+ (func $start:bindings/esm
+  i32.const 128
+  i32.const 1
+  f64.const 42
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  f64.const 0
+  call $~lib/builtins/trace
+  i32.const 160
+  call $~lib/bindings/dom/console.log
+  global.get $~lib/bindings/dom/Math.E
+  call $~lib/bindings/dom/Math.log
+  drop
+  global.get $bindings/esm/immutableGlobal
+  drop
+  global.get $bindings/esm/immutableGlobalNested
+  drop
+  call $bindings/esm/Date_getTimezoneOffset
+  drop
+ )
  (func $start:bindings/raw
   call $start:bindings/esm
  )
@@ -3083,50 +3104,6 @@
    call $~lib/builtins/abort
    unreachable
   end
- )
- (func $start:bindings/esm
-  (local $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  i32.const 128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  i32.const 1
-  f64.const 42
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  f64.const 0
-  call $~lib/builtins/trace
-  i32.const 160
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/bindings/dom/console.log
-  global.get $~lib/bindings/dom/Math.E
-  call $~lib/bindings/dom/Math.log
-  drop
-  global.get $bindings/esm/immutableGlobal
-  drop
-  global.get $bindings/esm/immutableGlobalNested
-  drop
-  call $bindings/esm/Date_getTimezoneOffset
-  drop
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $bindings/esm/bufferFunction (param $a i32) (param $b i32) (result i32)
   (local $aByteLength i32)

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -2053,27 +2053,6 @@
   end
   i32.const 1
   global.set $~started
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2276
-  i32.lt_s
-  if
-   i32.const 35072
-   i32.const 35120
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1152
-  i32.store
   i32.const 1152
   i32.const 1
   f64.const 42
@@ -2082,9 +2061,6 @@
   f64.const 0
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1184
-  i32.store
   i32.const 1184
   call $~lib/bindings/dom/console.log
   global.get $~lib/bindings/dom/Math.E
@@ -2092,10 +2068,6 @@
   drop
   call $bindings/esm/Date_getTimezoneOffset
   drop
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
   memory.size
   i32.const 16
   i32.shl
@@ -2192,7 +2164,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$286
+   block $__inlined_func$~lib/string/String#concat$285
     local.get $1
     i32.const 20
     i32.sub
@@ -2211,7 +2183,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$286
+     br $__inlined_func$~lib/string/String#concat$285
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2

--- a/tests/compiler/builtins.debug.wat
+++ b/tests/compiler/builtins.debug.wat
@@ -549,16 +549,13 @@
   (local $52 i32)
   (local $53 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   i32.const 1
   drop
   i32.const 0
@@ -2551,7 +2548,7 @@
   local.set $53
   global.get $~lib/memory/__stack_pointer
   local.get $53
-  i32.store offset=8
+  i32.store offset=4
   local.get $53
   call $~lib/function/Function<%28i32%2Ci32%29=>i32>#get:name
   local.set $53
@@ -2560,11 +2557,6 @@
   i32.store
   local.get $53
   i32.const 32
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2615,7 +2607,7 @@
   local.set $53
   global.get $~lib/memory/__stack_pointer
   local.get $53
-  i32.store offset=8
+  i32.store offset=4
   local.get $53
   call $~lib/function/Function<%28i32%2Ci32%29=>i32>#toString
   local.set $53
@@ -2624,11 +2616,6 @@
   i32.store
   local.get $53
   i32.const 176
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3270,11 +3257,6 @@
   i32.const 52
   local.set $52
   i32.const 256
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 5
   local.get $48
   f64.convert_i32_u
@@ -3336,17 +3318,7 @@
    unreachable
   end
   i32.const 352
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 352
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3358,17 +3330,7 @@
    unreachable
   end
   i32.const 352
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 352
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3380,17 +3342,7 @@
    unreachable
   end
   i32.const 400
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 400
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3402,17 +3354,7 @@
    unreachable
   end
   i32.const 432
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 432
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3424,17 +3366,7 @@
    unreachable
   end
   i32.const 464
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 464
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3446,17 +3378,7 @@
    unreachable
   end
   i32.const 496
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 496
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3468,17 +3390,7 @@
    unreachable
   end
   i32.const 528
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 528
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3490,17 +3402,7 @@
    unreachable
   end
   i32.const 560
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 560
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3512,17 +3414,7 @@
    unreachable
   end
   i32.const 592
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 592
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3534,17 +3426,7 @@
    unreachable
   end
   i32.const 624
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 624
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3556,17 +3438,7 @@
    unreachable
   end
   i32.const 656
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 656
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3578,17 +3450,7 @@
    unreachable
   end
   i32.const 688
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 688
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3600,17 +3462,7 @@
    unreachable
   end
   i32.const 720
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 720
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3622,17 +3474,7 @@
    unreachable
   end
   i32.const 752
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 752
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3644,17 +3486,7 @@
    unreachable
   end
   i32.const 784
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 784
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3666,17 +3498,7 @@
    unreachable
   end
   i32.const 816
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 816
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3688,17 +3510,7 @@
    unreachable
   end
   i32.const 848
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 848
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3710,17 +3522,7 @@
    unreachable
   end
   i32.const 880
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 880
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3732,17 +3534,7 @@
    unreachable
   end
   i32.const 432
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 432
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3754,17 +3546,7 @@
    unreachable
   end
   i32.const 352
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store
-  local.get $53
   i32.const 352
-  local.set $53
-  global.get $~lib/memory/__stack_pointer
-  local.get $53
-  i32.store offset=4
-  local.get $53
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3902,7 +3684,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/builtins.release.wat
+++ b/tests/compiler/builtins.release.wat
@@ -246,7 +246,7 @@
  )
  (func $start:builtins
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -263,9 +263,6 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   i32.const 1
   global.set $builtins/i
   i32.const 0
@@ -652,13 +649,10 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1168
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 1056
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   i32.const 1056
   i32.const 1056
   call $~lib/string/String.__eq
@@ -679,13 +673,10 @@
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 1168
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   i32.const 1200
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1200
-  i32.store offset=4
   i32.const 1200
   i32.const 1200
   call $~lib/string/String.__eq
@@ -767,9 +758,6 @@
   i32.const 8
   f64.const 1
   f64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1280
-  i32.store
   i32.const 1280
   i32.const 5
   f64.const 0
@@ -778,12 +766,6 @@
   f64.const 52
   f64.const 52
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1376
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1376
-  i32.store offset=4
   i32.const 1376
   i32.const 1376
   call $~lib/string/String.__eq
@@ -796,12 +778,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1376
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1376
-  i32.store offset=4
   i32.const 1376
   i32.const 1376
   call $~lib/string/String.__eq
@@ -814,12 +790,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1424
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1424
-  i32.store offset=4
   i32.const 1424
   i32.const 1424
   call $~lib/string/String.__eq
@@ -832,12 +802,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1456
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1456
-  i32.store offset=4
   i32.const 1456
   i32.const 1456
   call $~lib/string/String.__eq
@@ -850,12 +814,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1488
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1488
-  i32.store offset=4
   i32.const 1488
   i32.const 1488
   call $~lib/string/String.__eq
@@ -868,12 +826,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1520
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1520
-  i32.store offset=4
   i32.const 1520
   i32.const 1520
   call $~lib/string/String.__eq
@@ -886,12 +838,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1552
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1552
-  i32.store offset=4
   i32.const 1552
   i32.const 1552
   call $~lib/string/String.__eq
@@ -904,12 +850,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1584
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1584
-  i32.store offset=4
   i32.const 1584
   i32.const 1584
   call $~lib/string/String.__eq
@@ -922,12 +862,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1616
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1616
-  i32.store offset=4
   i32.const 1616
   i32.const 1616
   call $~lib/string/String.__eq
@@ -940,12 +874,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1648
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1648
-  i32.store offset=4
   i32.const 1648
   i32.const 1648
   call $~lib/string/String.__eq
@@ -958,12 +886,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1680
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1680
-  i32.store offset=4
   i32.const 1680
   i32.const 1680
   call $~lib/string/String.__eq
@@ -976,12 +898,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1712
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1712
-  i32.store offset=4
   i32.const 1712
   i32.const 1712
   call $~lib/string/String.__eq
@@ -994,12 +910,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1744
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1744
-  i32.store offset=4
   i32.const 1744
   i32.const 1744
   call $~lib/string/String.__eq
@@ -1012,12 +922,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1776
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1776
-  i32.store offset=4
   i32.const 1776
   i32.const 1776
   call $~lib/string/String.__eq
@@ -1030,12 +934,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1808
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1808
-  i32.store offset=4
   i32.const 1808
   i32.const 1808
   call $~lib/string/String.__eq
@@ -1048,12 +946,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1840
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1840
-  i32.store offset=4
   i32.const 1840
   i32.const 1840
   call $~lib/string/String.__eq
@@ -1066,12 +958,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1872
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1872
-  i32.store offset=4
   i32.const 1872
   i32.const 1872
   call $~lib/string/String.__eq
@@ -1084,12 +970,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1904
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1904
-  i32.store offset=4
   i32.const 1904
   i32.const 1904
   call $~lib/string/String.__eq
@@ -1102,12 +982,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1456
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1456
-  i32.store offset=4
   i32.const 1456
   i32.const 1456
   call $~lib/string/String.__eq
@@ -1120,12 +994,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1376
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1376
-  i32.store offset=4
   i32.const 1376
   i32.const 1376
   call $~lib/string/String.__eq
@@ -1139,7 +1007,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -3074,16 +3074,13 @@
  (func $start:class-overloading-cast
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store offset=8
   memory.size
   i32.const 16
   i32.shl
@@ -3114,7 +3111,7 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   i32.const 1
   call $class-overloading-cast/A<i32>#foo@override
@@ -3124,11 +3121,6 @@
   i32.store
   local.get $0
   i32.const 464
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3143,7 +3135,7 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   i32.const 1
   call $"class-overloading-cast/B<i32,~lib/string/String>#foo"
@@ -3153,11 +3145,6 @@
   i32.store
   local.get $0
   i32.const 464
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3172,7 +3159,7 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   f64.const 1.1
   call $class-overloading-cast/A<f64>#foo@override
@@ -3182,11 +3169,6 @@
   i32.store
   local.get $0
   i32.const 464
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3204,14 +3186,9 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   i32.const 576
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  local.get $0
   call $class-overloading-cast/A<~lib/string/String>#foo@override
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3219,11 +3196,6 @@
   i32.store
   local.get $0
   i32.const 432
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3238,14 +3210,9 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   i32.const 576
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  local.get $0
   call $class-overloading-cast/A<~lib/string/String>#foo@override
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3253,11 +3220,6 @@
   i32.store
   local.get $0
   i32.const 432
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3273,7 +3235,7 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   f32.const 2.5
   call $class-overloading-cast/D#bar
@@ -3283,11 +3245,6 @@
   i32.store
   local.get $0
   i32.const 608
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3299,7 +3256,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -1678,7 +1678,7 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -1689,9 +1689,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
    memory.size
    i32.const 16
    i32.shl
@@ -1849,7 +1846,7 @@
     global.get $~lib/memory/__stack_pointer
     global.get $class-overloading-cast/v
     local.tee $0
-    i32.store offset=8
+    i32.store offset=4
     block $default
      block $case1
       local.get $0
@@ -1876,9 +1873,6 @@
    end
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1488
-   i32.store offset=4
    local.get $0
    i32.const 1488
    call $~lib/string/String.__eq
@@ -1893,13 +1887,10 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $class-overloading-cast/v2
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 1488
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1488
-   i32.store offset=4
    i32.const 1488
    i32.const 1488
    call $~lib/string/String.__eq
@@ -1917,7 +1908,7 @@
     global.get $~lib/memory/__stack_pointer
     global.get $class-overloading-cast/v3
     local.tee $0
-    i32.store offset=8
+    i32.store offset=4
     i32.const 1488
     local.get $0
     i32.const 8
@@ -1931,9 +1922,6 @@
    end
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1488
-   i32.store offset=4
    local.get $0
    i32.const 1488
    call $~lib/string/String.__eq
@@ -2009,10 +1997,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $class-overloading-cast/c
    local.tee $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1600
-   i32.store offset=12
+   i32.store offset=4
    local.get $0
    i32.const 8
    i32.sub
@@ -2021,9 +2006,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1456
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1456
-   i32.store offset=4
    i32.const 1456
    i32.const 1456
    call $~lib/string/String.__eq
@@ -2039,10 +2021,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $class-overloading-cast/c
    local.tee $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1600
-   i32.store offset=12
+   i32.store offset=4
    local.get $0
    i32.const 8
    i32.sub
@@ -2051,9 +2030,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1456
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1456
-   i32.store offset=4
    i32.const 1456
    i32.const 1456
    call $~lib/string/String.__eq
@@ -2156,13 +2132,10 @@
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 1632
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1632
-   i32.store offset=4
    i32.const 1632
    i32.const 1632
    call $~lib/string/String.__eq
@@ -2176,7 +2149,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 16
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -3118,13 +3118,13 @@
  (func $class-overloading/C#a<i32> (param $this i32) (param $a i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -3140,11 +3140,6 @@
   i32.store
   local.get $2
   i32.const 496
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3158,7 +3153,7 @@
   i32.const 592
   global.set $class-overloading/which
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -3431,13 +3426,13 @@
  (func $start:class-overloading
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   memory.size
   i32.const 16
   i32.shl
@@ -3473,11 +3468,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3505,11 +3495,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3537,11 +3522,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3569,11 +3549,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3604,11 +3579,6 @@
   i32.store
   local.get $0
   i32.const 592
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3636,11 +3606,6 @@
   i32.store
   local.get $0
   i32.const 592
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3668,11 +3633,6 @@
   i32.store
   local.get $0
   i32.const 592
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3698,11 +3658,6 @@
   i32.store
   local.get $0
   i32.const 592
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3733,11 +3688,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3765,11 +3715,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3797,11 +3742,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3827,11 +3767,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3862,11 +3797,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3894,11 +3824,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3926,11 +3851,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3956,11 +3876,6 @@
   i32.store
   local.get $0
   i32.const 496
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3991,11 +3906,6 @@
   i32.store
   local.get $0
   i32.const 624
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4023,11 +3933,6 @@
   i32.store
   local.get $0
   i32.const 624
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4055,11 +3960,6 @@
   i32.store
   local.get $0
   i32.const 624
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4087,11 +3987,6 @@
   i32.store
   local.get $0
   i32.const 624
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4121,11 +4016,6 @@
   i32.store
   local.get $0
   i32.const 656
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4155,11 +4045,6 @@
   i32.store
   local.get $0
   i32.const 688
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4192,7 +4077,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -1770,7 +1770,7 @@
  )
  (func $class-overloading/C#a<i32> (param $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -1785,8 +1785,8 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
@@ -1795,9 +1795,6 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 1520
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1520
-  i32.store offset=4
   i32.const 1520
   i32.const 1520
   call $~lib/string/String.__eq
@@ -1813,7 +1810,7 @@
   i32.const 1616
   global.set $class-overloading/which
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -1905,7 +1902,7 @@
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
@@ -1914,8 +1911,8 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    memory.size
    i32.const 16
    i32.shl
@@ -1961,9 +1958,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2014,9 +2008,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2067,9 +2058,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2120,9 +2108,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2177,9 +2162,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1616
-   i32.store offset=4
    local.get $0
    i32.const 1616
    call $~lib/string/String.__eq
@@ -2202,9 +2184,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1616
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1616
-   i32.store offset=4
    i32.const 1616
    i32.const 1616
    call $~lib/string/String.__eq
@@ -2227,9 +2206,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1616
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1616
-   i32.store offset=4
    i32.const 1616
    i32.const 1616
    call $~lib/string/String.__eq
@@ -2250,9 +2226,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1616
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1616
-   i32.store offset=4
    i32.const 1616
    i32.const 1616
    call $~lib/string/String.__eq
@@ -2280,9 +2253,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2333,9 +2303,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2386,9 +2353,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2437,9 +2401,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2467,9 +2428,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2520,9 +2478,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2573,9 +2528,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2624,9 +2576,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1520
-   i32.store offset=4
    local.get $0
    i32.const 1520
    call $~lib/string/String.__eq
@@ -2681,9 +2630,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1648
-   i32.store offset=4
    local.get $0
    i32.const 1648
    call $~lib/string/String.__eq
@@ -2734,9 +2680,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1648
-   i32.store offset=4
    local.get $0
    i32.const 1648
    call $~lib/string/String.__eq
@@ -2787,9 +2730,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1648
-   i32.store offset=4
    local.get $0
    i32.const 1648
    call $~lib/string/String.__eq
@@ -2840,9 +2780,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1648
-   i32.store offset=4
    local.get $0
    i32.const 1648
    call $~lib/string/String.__eq
@@ -2922,9 +2859,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1680
-   i32.store offset=4
    local.get $0
    i32.const 1680
    call $~lib/string/String.__eq
@@ -3004,9 +2938,6 @@
    global.get $class-overloading/which
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -3209,7 +3140,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -4112,13 +4112,13 @@
   (local $33 i32)
   (local $34 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 148
+  i32.const 144
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 148
+  i32.const 144
   memory.fill
   memory.size
   i32.const 16
@@ -4647,11 +4647,6 @@
   i32.store offset=4
   local.get $34
   i32.const 624
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $field-initialization/SomeObject#set:b
   local.get $21
   i32.const 0
@@ -4681,7 +4676,7 @@
   local.set $34
   global.get $~lib/memory/__stack_pointer
   local.get $34
-  i32.store offset=100
+  i32.store offset=80
   local.get $34
   call $field-initialization/SomeObject#get:b
   local.set $34
@@ -4690,11 +4685,6 @@
   i32.store offset=4
   local.get $34
   i32.const 624
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4710,7 +4700,7 @@
   i32.const 0
   call $field-initialization/SomeObject#constructor
   local.tee $23
-  i32.store offset=104
+  i32.store offset=100
   local.get $23
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -4726,15 +4716,10 @@
   i32.store offset=4
   local.get $34
   i32.const 656
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $field-initialization/SomeObject#set:b
   local.get $23
   local.tee $24
-  i32.store offset=108
+  i32.store offset=104
   local.get $24
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -4757,7 +4742,7 @@
   local.set $34
   global.get $~lib/memory/__stack_pointer
   local.get $34
-  i32.store offset=100
+  i32.store offset=80
   local.get $34
   call $field-initialization/SomeObject#get:b
   local.set $34
@@ -4766,11 +4751,6 @@
   i32.store offset=4
   local.get $34
   i32.const 656
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4786,7 +4766,7 @@
   i32.const 0
   call $field-initialization/SomeOtherObject#constructor
   local.tee $25
-  i32.store offset=112
+  i32.store offset=108
   local.get $25
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -4794,11 +4774,6 @@
   i32.store offset=4
   local.get $34
   i32.const 688
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $field-initialization/SomeOtherObject#set:c
   local.get $25
   i32.const 0
@@ -4808,7 +4783,7 @@
   i32.store offset=4
   local.get $25
   local.tee $26
-  i32.store offset=116
+  i32.store offset=112
   local.get $26
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -4854,7 +4829,7 @@
   local.set $34
   global.get $~lib/memory/__stack_pointer
   local.get $34
-  i32.store offset=100
+  i32.store offset=80
   local.get $34
   call $field-initialization/SomeOtherObject#get:c
   local.set $34
@@ -4863,11 +4838,6 @@
   i32.store offset=4
   local.get $34
   i32.const 688
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4883,7 +4853,7 @@
   i32.const 0
   call $field-initialization/SomeOtherObject#constructor
   local.tee $27
-  i32.store offset=120
+  i32.store offset=116
   local.get $27
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -4899,11 +4869,6 @@
   i32.store offset=4
   local.get $34
   i32.const 720
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $field-initialization/SomeObject#set:b
   local.get $27
   local.set $34
@@ -4912,15 +4877,10 @@
   i32.store offset=4
   local.get $34
   i32.const 752
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $field-initialization/SomeOtherObject#set:c
   local.get $27
   local.tee $28
-  i32.store offset=124
+  i32.store offset=120
   local.get $28
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -4943,7 +4903,7 @@
   local.set $34
   global.get $~lib/memory/__stack_pointer
   local.get $34
-  i32.store offset=100
+  i32.store offset=80
   local.get $34
   call $field-initialization/SomeObject#get:b
   local.set $34
@@ -4952,11 +4912,6 @@
   i32.store offset=4
   local.get $34
   i32.const 720
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4971,7 +4926,7 @@
   local.set $34
   global.get $~lib/memory/__stack_pointer
   local.get $34
-  i32.store offset=100
+  i32.store offset=80
   local.get $34
   call $field-initialization/SomeOtherObject#get:c
   local.set $34
@@ -4980,11 +4935,6 @@
   i32.store offset=4
   local.get $34
   i32.const 752
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=80
-  local.get $34
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5000,7 +4950,7 @@
   i32.const 1
   call $field-initialization/Flow_Balanced#constructor
   local.tee $29
-  i32.store offset=128
+  i32.store offset=124
   local.get $29
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -5030,7 +4980,7 @@
    i32.const 24
    call $~lib/rt/itcms/__new
    local.tee $30
-   i32.store offset=132
+   i32.store offset=128
   end
   local.get $30
   local.set $34
@@ -5049,7 +4999,7 @@
   call $field-initialization/Ref_Init_InlineCtor#set:a
   local.get $30
   local.tee $31
-  i32.store offset=136
+  i32.store offset=132
   local.get $31
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -5079,7 +5029,7 @@
    i32.const 25
    call $~lib/rt/itcms/__new
    local.tee $32
-   i32.store offset=140
+   i32.store offset=136
   end
   local.get $32
   local.set $34
@@ -5106,7 +5056,7 @@
   call $field-initialization/Ref_InlineCtor_Init#set:a
   local.get $32
   local.tee $33
-  i32.store offset=144
+  i32.store offset=140
   local.get $33
   local.set $34
   global.get $~lib/memory/__stack_pointer
@@ -5126,7 +5076,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 148
+  i32.const 144
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -1990,7 +1990,7 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 148
+  i32.const 144
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -2000,7 +2000,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 148
+   i32.const 144
    memory.fill
    memory.size
    i32.const 16
@@ -3002,9 +3002,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1648
-   i32.store offset=80
    local.get $1
    i32.const 1648
    i32.store offset=4
@@ -3031,15 +3028,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=100
+   i32.store offset=80
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.load offset=4
    local.tee $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1648
-   i32.store offset=80
    local.get $0
    i32.const 1648
    call $~lib/string/String.__eq
@@ -3057,7 +3051,7 @@
    i32.const 0
    call $field-initialization/SomeObject#constructor
    local.tee $1
-   i32.store offset=104
+   i32.store offset=100
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3067,9 +3061,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1680
-   i32.store offset=80
    local.get $1
    i32.const 1680
    i32.store offset=4
@@ -3077,7 +3068,7 @@
    i32.const 1680
    call $~lib/rt/itcms/__link
    local.get $1
-   i32.store offset=108
+   i32.store offset=104
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3095,15 +3086,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=100
+   i32.store offset=80
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.load offset=4
    local.tee $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1680
-   i32.store offset=80
    local.get $0
    i32.const 1680
    call $~lib/string/String.__eq
@@ -3120,13 +3108,10 @@
    global.get $~lib/memory/__stack_pointer
    call $field-initialization/SomeOtherObject#constructor
    local.tee $1
-   i32.store offset=112
+   i32.store offset=108
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=80
    local.get $1
    i32.const 1712
    i32.store offset=8
@@ -3140,7 +3125,7 @@
    i32.const 0
    i32.store offset=4
    local.get $1
-   i32.store offset=116
+   i32.store offset=112
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3176,15 +3161,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=100
+   i32.store offset=80
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.load offset=8
    local.tee $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=80
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -3201,7 +3183,7 @@
    global.get $~lib/memory/__stack_pointer
    call $field-initialization/SomeOtherObject#constructor
    local.tee $1
-   i32.store offset=120
+   i32.store offset=116
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3211,9 +3193,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1744
-   i32.store offset=80
    local.get $1
    i32.const 1744
    i32.store offset=4
@@ -3223,9 +3202,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1776
-   i32.store offset=80
    local.get $1
    i32.const 1776
    i32.store offset=8
@@ -3233,7 +3209,7 @@
    i32.const 1776
    call $~lib/rt/itcms/__link
    local.get $1
-   i32.store offset=124
+   i32.store offset=120
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3251,15 +3227,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=100
+   i32.store offset=80
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.load offset=4
    local.tee $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1744
-   i32.store offset=80
    local.get $0
    i32.const 1744
    call $~lib/string/String.__eq
@@ -3274,15 +3247,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=100
+   i32.store offset=80
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.load offset=8
    local.tee $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1776
-   i32.store offset=80
    local.get $0
    i32.const 1776
    call $~lib/string/String.__eq
@@ -3344,7 +3314,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=128
+   i32.store offset=124
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3365,7 +3335,7 @@
    i32.const 24
    call $~lib/rt/itcms/__new
    local.tee $1
-   i32.store offset=132
+   i32.store offset=128
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3381,7 +3351,7 @@
    local.get $2
    call $~lib/rt/itcms/__link
    local.get $1
-   i32.store offset=136
+   i32.store offset=132
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3402,7 +3372,7 @@
    i32.const 25
    call $~lib/rt/itcms/__new
    local.tee $1
-   i32.store offset=140
+   i32.store offset=136
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3427,7 +3397,7 @@
    local.get $2
    call $~lib/rt/itcms/__link
    local.get $1
-   i32.store offset=144
+   i32.store offset=140
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3443,7 +3413,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 148
+   i32.const 144
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -2406,16 +2406,13 @@
  (func $issues/1095/Foo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   local.get $this
   i32.eqz
   if
@@ -2443,16 +2440,11 @@
   i32.store offset=4
   local.get $1
   i32.const 432
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $issues/1095/Foo#set:bar
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -1664,7 +1664,7 @@
    i32.const 1344
    global.set $~lib/rt/itcms/fromSpace
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -1674,9 +1674,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 4
@@ -1717,14 +1714,11 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1456
-   i32.store offset=8
    local.get $0
    i32.const 1456
    call $issues/1095/Foo#set:bar
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/issues/1714.debug.wat
+++ b/tests/compiler/issues/1714.debug.wat
@@ -276,13 +276,13 @@
  (func $start:issues/1714
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   call $"issues/1714/foo<i32,i64>"
   i32.const 0
   i32.eq
@@ -302,11 +302,6 @@
   i32.store
   local.get $0
   i32.const 80
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -318,7 +313,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/issues/1714.release.wat
+++ b/tests/compiler/issues/1714.release.wat
@@ -12,7 +12,7 @@
  (start $~start)
  (func $~start
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -21,14 +21,11 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1104
+   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 1104
-   i32.store offset=4
+   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -45,7 +42,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -2365,6 +2365,46 @@
   i32.const 0
   return
  )
+ (func $issues/2166/Test2166Ref1<~lib/string/String>#fn<i32> (param $this i32) (param $a1 i32) (param $a2 i32)
+  i32.const 464
+  i32.const 464
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 496
+   i32.const 9
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+  i32.const 544
+  i32.const 544
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 496
+   i32.const 10
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $issues/2166/Test2166Ref2<i32>#bar<~lib/string/String> (param $this i32) (param $i i32)
+  i32.const 464
+  i32.const 464
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 496
+   i32.const 22
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   i32.const 224
@@ -2567,79 +2607,17 @@
   local.get $3
   return
  )
- (func $issues/2166/Test2166Ref1<~lib/string/String>#fn<i32> (param $this i32) (param $a1 i32) (param $a2 i32)
-  (local $3 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  i32.const 464
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
-  i32.const 464
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=4
-  local.get $3
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 496
-   i32.const 9
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 544
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
-  i32.const 544
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=4
-  local.get $3
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 496
-   i32.const 10
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
  (func $issues/2166/testfunc2166<i64>
   (local $a i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   call $issues/2166/Test2166Ref1<~lib/string/String>#constructor
@@ -2652,103 +2630,8 @@
   i32.store offset=4
   local.get $1
   i32.const 432
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   i32.const 1
   call $issues/2166/Test2166Ref1<~lib/string/String>#fn<i32>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
- (func $issues/2166/Test2166Ref2<i32>#constructor (param $this i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
-  local.get $this
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $this
-   i32.store
-  end
-  i32.const 544
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 544
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 496
-   i32.const 18
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
- )
- (func $issues/2166/Test2166Ref2<i32>#bar<~lib/string/String> (param $this i32) (param $i i32)
-  (local $2 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  i32.const 464
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store
-  local.get $2
-  i32.const 464
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 496
-   i32.const 22
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
@@ -2757,13 +2640,13 @@
  (func $start:issues/2166
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   memory.size
   i32.const 16
   i32.shl
@@ -2790,14 +2673,9 @@
   i32.store
   local.get $0
   i32.const 576
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $issues/2166/Test2166Ref2<i32>#bar<~lib/string/String>
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -2820,6 +2698,46 @@
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store
+  end
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $issues/2166/Test2166Ref2<i32>#constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.const 5
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store
+  end
+  i32.const 544
+  i32.const 544
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 496
+   i32.const 18
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
   end
   local.get $this
   local.set $1

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -126,7 +126,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$123
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$122
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -150,7 +150,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$123
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$122
     end
     local.get $1
     i32.load offset=8
@@ -1412,7 +1412,7 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -1421,8 +1421,8 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    memory.size
    i32.const 16
    i32.shl
@@ -1456,7 +1456,7 @@
    i32.const 1344
    global.set $~lib/rt/itcms/fromSpace
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -1466,9 +1466,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -1525,26 +1522,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1456
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1660
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1488
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1488
-   i32.store offset=4
    i32.const 1488
    i32.const 1488
    call $~lib/string/String.__eq
@@ -1557,12 +1534,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=4
    i32.const 1568
    i32.const 1568
    call $~lib/string/String.__eq
@@ -1580,11 +1551,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -1592,22 +1559,13 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.store offset=8
+   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 5
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=8
    i32.const 1568
    i32.const 1568
    call $~lib/string/String.__eq
@@ -1621,32 +1579,12 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1600
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1660
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1488
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1488
-   i32.store offset=4
    i32.const 1488
    i32.const 1488
    call $~lib/string/String.__eq
@@ -1660,11 +1598,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/issues/2873.debug.wat
+++ b/tests/compiler/issues/2873.debug.wat
@@ -4961,16 +4961,13 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store offset=8
   memory.size
   i32.const 16
   i32.shl
@@ -4997,11 +4994,6 @@
   i32.store
   local.get $2
   i32.const 1968
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5021,11 +5013,6 @@
   i32.store
   local.get $2
   i32.const 1968
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5040,14 +5027,9 @@
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=8
+  i32.store offset=4
   local.get $2
   i32.const 2160
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   call $~lib/array/Array<f32>#join
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -5055,11 +5037,6 @@
   i32.store
   local.get $2
   i32.const 2192
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5074,14 +5051,9 @@
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=8
+  i32.store offset=4
   local.get $2
   i32.const 2160
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   call $~lib/array/Array<f64>#join
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -5089,11 +5061,6 @@
   i32.store
   local.get $2
   i32.const 2192
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5105,7 +5072,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/issues/2873.release.wat
+++ b/tests/compiler/issues/2873.release.wat
@@ -2963,7 +2963,7 @@
   (local $5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -2974,9 +2974,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
    memory.size
    i32.const 16
    i32.shl
@@ -3015,9 +3012,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2992
-   i32.store offset=4
    local.get $1
    i32.const 2992
    call $~lib/string/String.__eq
@@ -3036,9 +3030,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2992
-   i32.store offset=4
    local.get $1
    i32.const 2992
    call $~lib/string/String.__eq
@@ -3053,10 +3044,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 3104
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3184
-   i32.store offset=12
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -3231,9 +3219,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3216
-   i32.store offset=4
    local.get $1
    i32.const 3216
    call $~lib/string/String.__eq
@@ -3248,10 +3233,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 3312
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3184
-   i32.store offset=12
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -3430,9 +3412,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3216
-   i32.store offset=4
    local.get $1
    i32.const 3216
    call $~lib/string/String.__eq
@@ -3446,7 +3425,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 16
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -3117,16 +3117,13 @@
  (func $object-literal/testManaged (param $managed i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   local.get $managed
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3149,7 +3146,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=8
+  i32.store offset=4
   local.get $1
   call $object-literal/Managed#get:baz
   local.set $1
@@ -3158,11 +3155,6 @@
   i32.store
   local.get $1
   i32.const 32
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3174,7 +3166,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -3330,13 +3322,13 @@
  (func $object-literal/testUnmanaged (param $unmanaged i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $unmanaged
   call $object-literal/Unmanaged#get:bar
   i32.const 123
@@ -3358,11 +3350,6 @@
   i32.store
   local.get $1
   i32.const 576
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3376,7 +3363,7 @@
   local.get $unmanaged
   call $~lib/rt/tlsf/__free
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -3870,16 +3857,13 @@
  (func $object-literal/testMixedOmitted (param $omitted i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   local.get $omitted
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3902,7 +3886,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=8
+  i32.store offset=4
   local.get $1
   call $object-literal/MixedOmitted#get:complexType
   local.set $1
@@ -3911,11 +3895,6 @@
   i32.store
   local.get $1
   i32.const 608
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3945,23 +3924,20 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
  (func $object-literal/OmittedFoo#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   local.get $this
   i32.eqz
   if
@@ -3989,11 +3965,6 @@
   i32.store offset=4
   local.get $1
   i32.const 640
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $object-literal/OmittedFoo#set:bar
   local.get $this
   local.set $1
@@ -4002,11 +3973,6 @@
   i32.store offset=4
   local.get $1
   i32.const 672
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $object-literal/OmittedFoo#set:baz
   local.get $this
   local.set $1
@@ -4075,7 +4041,7 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -4083,21 +4049,18 @@
  (func $object-literal/testOmittedFoo (param $foo i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   local.get $foo
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=8
+  i32.store offset=4
   local.get $1
   call $object-literal/OmittedFoo#get:bar
   local.set $1
@@ -4106,11 +4069,6 @@
   i32.store
   local.get $1
   i32.const 640
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4125,7 +4083,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=8
+  i32.store offset=4
   local.get $1
   call $object-literal/OmittedFoo#get:baz
   local.set $1
@@ -4134,11 +4092,6 @@
   i32.store
   local.get $1
   i32.const 672
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4324,7 +4277,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -4336,13 +4289,13 @@
   (local $4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 24
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 28
+  i32.const 24
   memory.fill
   i32.const 128
   call $~lib/rt/itcms/initLazy
@@ -4381,11 +4334,6 @@
   i32.store offset=8
   local.get $5
   i32.const 32
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=12
-  local.get $5
   call $object-literal/Managed#set:baz
   local.get $0
   local.set $5
@@ -4402,11 +4350,6 @@
   call $object-literal/Unmanaged#set:bar
   local.get $1
   i32.const 32
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=8
-  local.get $5
   i32.const 0
   i32.const 5
   call $~lib/string/String#substring
@@ -4422,7 +4365,7 @@
   i32.const 0
   call $object-literal/OmittedTypes#constructor
   local.tee $2
-  i32.store offset=16
+  i32.store offset=12
   local.get $2
   i32.const 0
   i32.store
@@ -4476,7 +4419,7 @@
   i32.const 0
   call $object-literal/MixedOmitted#constructor
   local.tee $3
-  i32.store offset=20
+  i32.store offset=16
   local.get $3
   local.set $5
   global.get $~lib/memory/__stack_pointer
@@ -4492,11 +4435,6 @@
   i32.store offset=8
   local.get $5
   i32.const 608
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=12
-  local.get $5
   call $object-literal/MixedOmitted#set:complexType
   local.get $3
   f64.const 0
@@ -4512,7 +4450,7 @@
   i32.const 0
   call $object-literal/OmittedFoo#constructor
   local.tee $4
-  i32.store offset=24
+  i32.store offset=20
   local.get $4
   i32.const 0
   i32.store offset=8
@@ -4545,7 +4483,7 @@
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 24
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -2054,7 +2054,7 @@
  (func $object-literal/testOmittedFoo (param $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2072,19 +2072,13 @@
   i64.const 0
   i64.store
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.load
   local.tee $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1664
-  i32.store offset=4
   local.get $1
   i32.const 1664
   call $~lib/string/String.__eq
@@ -2099,15 +2093,12 @@
   end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.load offset=4
   local.tee $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1696
-  i32.store offset=4
   local.get $1
   i32.const 1696
   call $~lib/string/String.__eq
@@ -2269,7 +2260,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -2280,7 +2271,7 @@
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 24
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
@@ -2290,7 +2281,7 @@
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 28
+   i32.const 24
    memory.fill
    i32.const 1156
    i32.const 1152
@@ -2380,9 +2371,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=12
    local.get $1
    i32.const 1056
    i32.store offset=4
@@ -2393,7 +2381,7 @@
    local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2403,9 +2391,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -2423,15 +2408,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.load offset=4
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    local.get $0
    i32.const 1056
    call $~lib/string/String.__eq
@@ -2445,7 +2427,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/rt/tlsf/ROOT
@@ -2467,9 +2449,6 @@
    local.get $1
    i32.const 123
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -2567,7 +2546,7 @@
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2575,8 +2554,8 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    local.get $1
    i32.load
    i32.const 123
@@ -2594,9 +2573,6 @@
    i32.load offset=4
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1600
-   i32.store offset=4
    local.get $0
    i32.const 1600
    call $~lib/string/String.__eq
@@ -2612,7 +2588,7 @@
    local.get $1
    call $~lib/rt/tlsf/__free
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2730,7 +2706,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=16
+   i32.store offset=12
    local.get $0
    i32.const 0
    i32.store
@@ -2830,7 +2806,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=20
+   i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
@@ -2840,9 +2816,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1632
-   i32.store offset=12
    local.get $1
    i32.const 1632
    i32.store offset=4
@@ -2856,7 +2829,7 @@
    local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2866,9 +2839,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -2884,15 +2854,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.load offset=4
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1632
-   i32.store offset=4
    local.get $0
    i32.const 1632
    call $~lib/string/String.__eq
@@ -2921,12 +2888,12 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2936,9 +2903,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 40
    i32.const 7
@@ -2956,9 +2920,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1664
-   i32.store offset=8
    local.get $0
    i32.const 1664
    i32.store
@@ -2968,9 +2929,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1696
-   i32.store offset=8
    local.get $0
    i32.const 1696
    i32.store offset=4
@@ -3044,11 +3002,11 @@
    i32.const -1
    i32.store offset=36
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=24
+   i32.store offset=20
    local.get $0
    i32.const 0
    i32.store offset=8
@@ -3111,7 +3069,7 @@
    i32.add
    global.set $~lib/rt/itcms/threshold
    global.get $~lib/memory/__stack_pointer
-   i32.const 28
+   i32.const 24
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -5875,14 +5875,16 @@
  (func $start:resolve-binary
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.const 20
-  memory.fill
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
   i32.const 1
   i32.const 2
   i32.lt_s
@@ -5894,11 +5896,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5920,11 +5917,6 @@
   i32.store
   local.get $0
   i32.const 64
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5946,11 +5938,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5972,11 +5959,6 @@
   i32.store
   local.get $0
   i32.const 64
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5998,11 +5980,6 @@
   i32.store
   local.get $0
   i32.const 64
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6024,11 +6001,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6067,11 +6039,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6095,11 +6062,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6123,11 +6085,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6151,11 +6108,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6181,11 +6133,6 @@
   i32.store
   local.get $0
   i32.const 9696
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6211,11 +6158,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6239,11 +6181,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6267,11 +6204,6 @@
   i32.store
   local.get $0
   i32.const 9728
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6295,11 +6227,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6323,11 +6250,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6351,11 +6273,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6379,11 +6296,6 @@
   i32.store
   local.get $0
   i32.const 9760
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6407,11 +6319,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6433,11 +6340,6 @@
   i32.store
   local.get $0
   i32.const 9760
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6459,11 +6361,6 @@
   i32.store
   local.get $0
   i32.const 9792
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6485,11 +6382,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6511,11 +6403,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6537,11 +6424,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6563,11 +6445,6 @@
   i32.store
   local.get $0
   i32.const 9728
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6589,11 +6466,6 @@
   i32.store
   local.get $0
   i32.const 9696
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6615,11 +6487,6 @@
   i32.store
   local.get $0
   i32.const 9696
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6641,11 +6508,6 @@
   i32.store
   local.get $0
   i32.const 9728
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6667,11 +6529,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6693,11 +6550,6 @@
   i32.store
   local.get $0
   i32.const 9760
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6719,11 +6571,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6745,11 +6592,6 @@
   i32.store
   local.get $0
   i32.const 9760
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6771,11 +6613,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6800,11 +6637,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6829,11 +6661,6 @@
   i32.store
   local.get $0
   i32.const 352
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6858,11 +6685,6 @@
   i32.store
   local.get $0
   i32.const 2336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6887,11 +6709,6 @@
   i32.store
   local.get $0
   i32.const 2368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6909,19 +6726,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#lt
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -6930,11 +6747,6 @@
   i32.store
   local.get $0
   i32.const 9824
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6949,19 +6761,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#gt
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -6970,11 +6782,6 @@
   i32.store
   local.get $0
   i32.const 9856
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6989,19 +6796,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#le
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7010,11 +6817,6 @@
   i32.store
   local.get $0
   i32.const 9888
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7029,19 +6831,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#ge
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7050,11 +6852,6 @@
   i32.store
   local.get $0
   i32.const 9920
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7069,19 +6866,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#eq
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7090,11 +6887,6 @@
   i32.store
   local.get $0
   i32.const 9952
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7109,19 +6901,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#ne
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7130,11 +6922,6 @@
   i32.store
   local.get $0
   i32.const 9984
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7149,19 +6936,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#add
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7170,11 +6957,6 @@
   i32.store
   local.get $0
   i32.const 10016
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7189,19 +6971,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo.sub
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7210,11 +6992,6 @@
   i32.store
   local.get $0
   i32.const 10048
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7229,19 +7006,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#mul
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7250,11 +7027,6 @@
   i32.store
   local.get $0
   i32.const 10080
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7269,19 +7041,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#div
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7290,11 +7062,6 @@
   i32.store
   local.get $0
   i32.const 10112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7309,19 +7076,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#rem
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7330,11 +7097,6 @@
   i32.store
   local.get $0
   i32.const 10144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7349,19 +7111,19 @@
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   global.get $resolve-binary/foo
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=12
   local.get $0
   call $resolve-binary/Foo#pow
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   call $~lib/string/String#toString
   local.set $0
@@ -7370,11 +7132,6 @@
   i32.store
   local.get $0
   i32.const 10176
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7515,7 +7272,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -3113,7 +3113,7 @@
  (func $start:resolve-binary
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -3122,15 +3122,14 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.const 20
-   memory.fill
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -3146,9 +3145,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1088
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1088
-   i32.store offset=4
    i32.const 1088
    i32.const 1088
    call $~lib/string/String.__eq
@@ -3164,9 +3160,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -3182,9 +3175,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1088
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1088
-   i32.store offset=4
    i32.const 1088
    i32.const 1088
    call $~lib/string/String.__eq
@@ -3200,9 +3190,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1088
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1088
-   i32.store offset=4
    i32.const 1088
    i32.const 1088
    call $~lib/string/String.__eq
@@ -3218,9 +3205,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -3273,9 +3257,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3298,9 +3279,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3323,9 +3301,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3348,9 +3323,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3368,9 +3340,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10720
-   i32.store offset=4
    local.get $0
    i32.const 10720
    call $~lib/string/String.__eq
@@ -3393,9 +3362,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3418,9 +3384,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3443,9 +3406,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10752
-   i32.store offset=4
    local.get $0
    i32.const 10752
    call $~lib/string/String.__eq
@@ -3468,9 +3428,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3493,9 +3450,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3518,9 +3472,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3543,9 +3494,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10784
-   i32.store offset=4
    local.get $0
    i32.const 10784
    call $~lib/string/String.__eq
@@ -3568,9 +3516,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3589,9 +3534,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10784
-   i32.store offset=4
    local.get $0
    i32.const 10784
    call $~lib/string/String.__eq
@@ -3610,9 +3552,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10816
-   i32.store offset=4
    local.get $0
    i32.const 10816
    call $~lib/string/String.__eq
@@ -3631,9 +3570,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3652,9 +3588,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3673,9 +3606,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3694,9 +3624,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10752
-   i32.store offset=4
    local.get $0
    i32.const 10752
    call $~lib/string/String.__eq
@@ -3714,9 +3641,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10720
-   i32.store offset=4
    local.get $0
    i32.const 10720
    call $~lib/string/String.__eq
@@ -3734,9 +3658,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10720
-   i32.store offset=4
    local.get $0
    i32.const 10720
    call $~lib/string/String.__eq
@@ -3755,9 +3676,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10752
-   i32.store offset=4
    local.get $0
    i32.const 10752
    call $~lib/string/String.__eq
@@ -3776,9 +3694,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3797,9 +3712,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10784
-   i32.store offset=4
    local.get $0
    i32.const 10784
    call $~lib/string/String.__eq
@@ -3818,9 +3730,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3839,9 +3748,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10784
-   i32.store offset=4
    local.get $0
    i32.const 10784
    call $~lib/string/String.__eq
@@ -3860,9 +3766,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3881,9 +3784,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3902,9 +3802,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1376
-   i32.store offset=4
    local.get $0
    i32.const 1376
    call $~lib/string/String.__eq
@@ -3923,9 +3820,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -3944,9 +3838,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -3992,19 +3883,16 @@
    global.set $resolve-binary/foo
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10848
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 10848
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 10848
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 10848
+   i32.store
    i32.const 10848
    i32.const 10848
    call $~lib/string/String.__eq
@@ -4019,19 +3907,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10880
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 10880
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 10880
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 10880
+   i32.store
    i32.const 10880
    i32.const 10880
    call $~lib/string/String.__eq
@@ -4046,19 +3931,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10912
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 10912
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 10912
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 10912
+   i32.store
    i32.const 10912
    i32.const 10912
    call $~lib/string/String.__eq
@@ -4073,19 +3955,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10944
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 10944
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 10944
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 10944
+   i32.store
    i32.const 10944
    i32.const 10944
    call $~lib/string/String.__eq
@@ -4100,19 +3979,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10976
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 10976
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 10976
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 10976
+   i32.store
    i32.const 10976
    i32.const 10976
    call $~lib/string/String.__eq
@@ -4127,19 +4003,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11008
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 11008
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 11008
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11008
+   i32.store
    i32.const 11008
    i32.const 11008
    call $~lib/string/String.__eq
@@ -4154,19 +4027,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11040
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 11040
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 11040
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11040
+   i32.store
    i32.const 11040
    i32.const 11040
    call $~lib/string/String.__eq
@@ -4181,19 +4051,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11072
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 11072
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 11072
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11072
+   i32.store
    i32.const 11072
    i32.const 11072
    call $~lib/string/String.__eq
@@ -4208,19 +4075,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11104
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 11104
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 11104
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11104
+   i32.store
    i32.const 11104
    i32.const 11104
    call $~lib/string/String.__eq
@@ -4235,19 +4099,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11136
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 11136
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 11136
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11136
+   i32.store
    i32.const 11136
    i32.const 11136
    call $~lib/string/String.__eq
@@ -4262,19 +4123,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11168
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 11168
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 11168
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11168
+   i32.store
    i32.const 11168
    i32.const 11168
    call $~lib/string/String.__eq
@@ -4289,19 +4147,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-binary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   global.get $resolve-binary/foo
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11200
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 11200
-   i32.store
+   global.get $resolve-binary/foo
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 11200
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11200
+   i32.store
    i32.const 11200
    i32.const 11200
    call $~lib/string/String.__eq
@@ -4421,7 +4276,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 20
+   i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -4927,13 +4927,13 @@
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 24
+  i32.const 20
   memory.fill
   memory.size
   i32.const 16
@@ -4978,7 +4978,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
@@ -4990,11 +4990,6 @@
   i32.store
   local.get $4
   i32.const 2144
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5009,7 +5004,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 1
   call $~lib/typedarray/Float32Array#__get
@@ -5021,11 +5016,6 @@
   i32.store
   local.get $4
   i32.const 2256
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5039,12 +5029,12 @@
   global.get $~lib/memory/__stack_pointer
   global.get $resolve-elementaccess/arr
   local.tee $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 0
   local.tee $1
@@ -5052,7 +5042,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 0
   call $~lib/typedarray/Float32Array#__get
@@ -5063,7 +5053,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   local.get $1
   call $~lib/typedarray/Float32Array#__get
@@ -5075,11 +5065,6 @@
   i32.store
   local.get $4
   i32.const 2288
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5153,7 +5138,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
@@ -5165,11 +5150,6 @@
   i32.store
   local.get $4
   i32.const 3696
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5184,7 +5164,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 1
   call $~lib/typedarray/Uint8Array#__get
@@ -5196,11 +5176,6 @@
   i32.store
   local.get $4
   i32.const 3728
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5214,12 +5189,12 @@
   global.get $~lib/memory/__stack_pointer
   global.get $resolve-elementaccess/buf
   local.tee $2
-  i32.store offset=20
+  i32.store offset=16
   local.get $2
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 0
   local.tee $3
@@ -5227,7 +5202,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 0
   call $~lib/typedarray/Uint8Array#__get
@@ -5238,7 +5213,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   local.get $3
   call $~lib/typedarray/Uint8Array#__get
@@ -5250,11 +5225,6 @@
   i32.store
   local.get $4
   i32.const 3760
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5303,7 +5273,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -3420,7 +3420,7 @@
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -3430,7 +3430,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 24
+   i32.const 20
    memory.fill
    memory.size
    i32.const 16
@@ -3515,7 +3515,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/arr
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    call $~lib/typedarray/Float32Array#__get
@@ -3524,9 +3524,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3168
-   i32.store offset=4
    local.get $0
    i32.const 3168
    call $~lib/string/String.__eq
@@ -3542,7 +3539,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/arr
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 1
    call $~lib/typedarray/Float32Array#__get
@@ -3551,9 +3548,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3280
-   i32.store offset=4
    local.get $0
    i32.const 3280
    call $~lib/string/String.__eq
@@ -3569,14 +3563,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/arr
    local.tee $0
-   i32.store offset=12
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/arr
    local.tee $1
-   i32.store offset=16
+   i32.store offset=12
    local.get $0
    i32.const 0
    local.get $1
@@ -3587,7 +3581,7 @@
    call $~lib/typedarray/Float32Array#__set
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    call $~lib/typedarray/Float32Array#__get
@@ -3596,9 +3590,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3312
-   i32.store offset=4
    local.get $0
    i32.const 3312
    call $~lib/string/String.__eq
@@ -3726,7 +3717,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/buf
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    call $~lib/typedarray/Uint8Array#__get
@@ -3735,9 +3726,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4720
-   i32.store offset=4
    local.get $0
    i32.const 4720
    call $~lib/string/String.__eq
@@ -3753,7 +3741,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/buf
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 1
    call $~lib/typedarray/Uint8Array#__get
@@ -3762,9 +3750,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4752
-   i32.store offset=4
    local.get $0
    i32.const 4752
    call $~lib/string/String.__eq
@@ -3780,14 +3765,14 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/buf
    local.tee $0
-   i32.store offset=20
+   i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-elementaccess/buf
    local.tee $1
-   i32.store offset=16
+   i32.store offset=12
    local.get $0
    i32.const 0
    local.get $1
@@ -3798,7 +3783,7 @@
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    call $~lib/typedarray/Uint8Array#__get
@@ -3807,9 +3792,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4784
-   i32.store offset=4
    local.get $0
    i32.const 4784
    call $~lib/string/String.__eq
@@ -3856,7 +3838,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -2992,13 +2992,13 @@
  (func $start:resolve-function-expression
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
@@ -3064,11 +3064,6 @@
   i32.store
   local.get $0
   i32.const 2384
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3080,7 +3075,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -1842,7 +1842,7 @@
   (local $4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
@@ -1851,8 +1851,8 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    i32.const 2
    i32.const 1056
    i32.load
@@ -1922,9 +1922,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $5
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3408
-   i32.store offset=4
    block $__inlined_func$~lib/string/String.__eq$1 (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -2074,7 +2071,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/resolve-propertyaccess.debug.wat
+++ b/tests/compiler/resolve-propertyaccess.debug.wat
@@ -3041,7 +3041,7 @@
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
@@ -3049,8 +3049,8 @@
   i64.const 0
   i64.store
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store offset=8
+  i32.const 0
+  i32.store offset=8
   memory.size
   i32.const 16
   i32.shl
@@ -3077,11 +3077,6 @@
   i32.store
   local.get $1
   i32.const 2208
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3101,11 +3096,6 @@
   i32.store
   local.get $1
   i32.const 2320
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3125,11 +3115,6 @@
   i32.store
   local.get $1
   i32.const 2352
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3149,11 +3134,6 @@
   i32.store
   local.get $1
   i32.const 2384
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3173,11 +3153,6 @@
   i32.store
   local.get $1
   i32.const 2416
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3197,11 +3172,6 @@
   i32.store
   local.get $1
   i32.const 2448
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3221,11 +3191,6 @@
   i32.store
   local.get $1
   i32.const 2480
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3245,11 +3210,6 @@
   i32.store
   local.get $1
   i32.const 2512
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3269,11 +3229,6 @@
   i32.store
   local.get $1
   i32.const 2544
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3293,11 +3248,6 @@
   i32.store
   local.get $1
   i32.const 2576
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3312,12 +3262,12 @@
   i32.const 0
   call $resolve-propertyaccess/Class#constructor
   local.tee $0
-  i32.store offset=8
+  i32.store offset=4
   local.get $0
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $resolve-propertyaccess/Class#get:instanceField
   i32.const 10
@@ -3328,11 +3278,6 @@
   i32.store
   local.get $1
   i32.const 2608
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3347,7 +3292,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $resolve-propertyaccess/Class#get:instanceProperty
   i32.const 10
@@ -3358,11 +3303,6 @@
   i32.store
   local.get $1
   i32.const 2640
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3374,7 +3314,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -1981,7 +1981,7 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -1993,8 +1993,8 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
+   i32.const 0
+   i32.store offset=8
    memory.size
    i32.const 16
    i32.shl
@@ -2033,9 +2033,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3232
-   i32.store offset=4
    local.get $0
    i32.const 3232
    call $~lib/string/String.__eq
@@ -2054,9 +2051,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3344
-   i32.store offset=4
    local.get $0
    i32.const 3344
    call $~lib/string/String.__eq
@@ -2075,9 +2069,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3376
-   i32.store offset=4
    local.get $0
    i32.const 3376
    call $~lib/string/String.__eq
@@ -2096,9 +2087,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3408
-   i32.store offset=4
    local.get $0
    i32.const 3408
    call $~lib/string/String.__eq
@@ -2117,9 +2105,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3440
-   i32.store offset=4
    local.get $0
    i32.const 3440
    call $~lib/string/String.__eq
@@ -2138,9 +2123,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3472
-   i32.store offset=4
    local.get $0
    i32.const 3472
    call $~lib/string/String.__eq
@@ -2159,9 +2141,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3504
-   i32.store offset=4
    local.get $0
    i32.const 3504
    call $~lib/string/String.__eq
@@ -2180,9 +2159,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3536
-   i32.store offset=4
    local.get $0
    i32.const 3536
    call $~lib/string/String.__eq
@@ -2201,9 +2177,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3568
-   i32.store offset=4
    local.get $0
    i32.const 3568
    call $~lib/string/String.__eq
@@ -2222,9 +2195,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3600
-   i32.store offset=4
    local.get $0
    i32.const 3600
    call $~lib/string/String.__eq
@@ -2297,10 +2267,10 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=12
+   i32.store offset=8
    local.get $0
    i32.load
    call $~lib/number/I32#toString
@@ -2308,9 +2278,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3632
-   i32.store offset=4
    local.get $1
    i32.const 3632
    call $~lib/string/String.__eq
@@ -2325,16 +2292,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=12
+   i32.store offset=8
    i32.const 8
    call $~lib/number/I32#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3664
-   i32.store offset=4
    local.get $0
    i32.const 3664
    call $~lib/string/String.__eq
@@ -2348,7 +2312,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 16
+   i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -4397,13 +4397,13 @@
  (func $start:resolve-ternary
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   memory.size
   i32.const 16
   i32.shl
@@ -4435,11 +4435,6 @@
   i32.store
   local.get $0
   i32.const 2208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4464,11 +4459,6 @@
   i32.store
   local.get $0
   i32.const 3440
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4546,7 +4536,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -2492,7 +2492,7 @@
   (local $5 i64)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
@@ -2501,8 +2501,8 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    memory.size
    i32.const 16
    i32.shl
@@ -2562,9 +2562,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3232
-   i32.store offset=4
    local.get $0
    i32.const 3232
    call $~lib/string/String.__eq
@@ -2710,9 +2707,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4464
-   i32.store offset=4
    local.get $0
    i32.const 4464
    call $~lib/string/String.__eq
@@ -2768,7 +2762,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -3163,13 +3163,13 @@
   (local $5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 24
+  i32.const 20
   memory.fill
   memory.size
   i32.const 16
@@ -3197,11 +3197,6 @@
   i32.store
   local.get $6
   i32.const 2208
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3221,11 +3216,6 @@
   i32.store
   local.get $6
   i32.const 2304
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3249,11 +3239,6 @@
   i32.store
   local.get $6
   i32.const 2336
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3277,11 +3262,6 @@
   i32.store
   local.get $6
   i32.const 2304
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3302,11 +3282,6 @@
   i32.store
   local.get $6
   i32.const 2400
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3328,11 +3303,6 @@
   i32.store
   local.get $6
   i32.const 2368
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3354,11 +3324,6 @@
   i32.store
   local.get $6
   i32.const 2432
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3383,11 +3348,6 @@
   i32.store
   local.get $6
   i32.const 2304
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3412,11 +3372,6 @@
   i32.store
   local.get $6
   i32.const 2336
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3434,13 +3389,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Foo#plus
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3449,11 +3404,6 @@
   i32.store
   local.get $6
   i32.const 2464
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3468,13 +3418,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Foo#minus
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3483,11 +3433,6 @@
   i32.store
   local.get $6
   i32.const 2496
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3554,13 +3499,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Foo#not
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3569,11 +3514,6 @@
   i32.store
   local.get $6
   i32.const 2528
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3588,13 +3528,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Foo#bitwise_not
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3603,11 +3543,6 @@
   i32.store
   local.get $6
   i32.const 2560
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3621,7 +3556,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $resolve-unary/foo
   local.tee $2
-  i32.store offset=16
+  i32.store offset=12
   local.get $2
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -3651,7 +3586,7 @@
   global.get $~lib/memory/__stack_pointer
   global.get $resolve-unary/foo
   local.tee $3
-  i32.store offset=20
+  i32.store offset=16
   local.get $3
   local.set $6
   global.get $~lib/memory/__stack_pointer
@@ -3685,13 +3620,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Bar.prefix_inc
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3700,11 +3635,6 @@
   i32.store
   local.get $6
   i32.const 2592
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3719,13 +3649,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Bar.prefix_dec
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3734,11 +3664,6 @@
   i32.store
   local.get $6
   i32.const 2624
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3753,13 +3678,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Bar.postfix_inc
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3768,11 +3693,6 @@
   i32.store
   local.get $6
   i32.const 2656
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3787,13 +3707,13 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=12
+  i32.store offset=8
   local.get $6
   call $resolve-unary/Bar.postfix_dec
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=8
+  i32.store offset=4
   local.get $6
   call $~lib/string/String#toString
   local.set $6
@@ -3802,11 +3722,6 @@
   i32.store
   local.get $6
   i32.const 2688
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3820,24 +3735,14 @@
   i32.const 1
   drop
   i32.const 2720
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store
-  local.get $6
   call $~lib/string/String#get:length
   drop
   i32.const 2752
   drop
   i32.const 2784
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store
-  local.get $6
   call $resolve-unary/generic<~lib/string/String>
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -2039,7 +2039,7 @@
  (func $start:resolve-unary
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -2049,7 +2049,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 24
+   i32.const 20
    memory.fill
    memory.size
    i32.const 16
@@ -2089,9 +2089,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3232
-   i32.store offset=4
    local.get $0
    i32.const 3232
    call $~lib/string/String.__eq
@@ -2110,9 +2107,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3328
-   i32.store offset=4
    local.get $0
    i32.const 3328
    call $~lib/string/String.__eq
@@ -2135,9 +2129,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -2160,9 +2151,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3328
-   i32.store offset=4
    local.get $0
    i32.const 3328
    call $~lib/string/String.__eq
@@ -2182,9 +2170,6 @@
    select
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3424
-   i32.store offset=4
    local.get $0
    i32.const 3424
    call $~lib/string/String.__eq
@@ -2204,9 +2189,6 @@
    select
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -2227,9 +2209,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    local.get $0
    i32.const 3456
    call $~lib/string/String.__eq
@@ -2253,9 +2232,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3328
-   i32.store offset=4
    local.get $0
    i32.const 3328
    call $~lib/string/String.__eq
@@ -2279,9 +2255,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store offset=4
    local.get $0
    i32.const 3360
    call $~lib/string/String.__eq
@@ -2327,16 +2300,13 @@
    global.set $resolve-unary/foo
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3488
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3488
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3488
-   i32.store offset=4
+   i32.store
    i32.const 3488
    i32.const 3488
    call $~lib/string/String.__eq
@@ -2351,16 +2321,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3520
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3520
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3520
-   i32.store offset=4
+   i32.store
    i32.const 3520
    i32.const 3520
    call $~lib/string/String.__eq
@@ -2417,16 +2384,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3552
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3552
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3552
-   i32.store offset=4
+   i32.store
    i32.const 3552
    i32.const 3552
    call $~lib/string/String.__eq
@@ -2441,16 +2405,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/foo
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3584
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3584
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3584
-   i32.store offset=4
+   i32.store
    i32.const 3584
    i32.const 3584
    call $~lib/string/String.__eq
@@ -2466,7 +2427,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/foo
    local.tee $0
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -2489,7 +2450,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/foo
    local.tee $0
-   i32.store offset=20
+   i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -2542,16 +2503,13 @@
    global.set $resolve-unary/bar
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/bar
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3616
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3616
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3616
-   i32.store offset=4
+   i32.store
    i32.const 3616
    i32.const 3616
    call $~lib/string/String.__eq
@@ -2566,16 +2524,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/bar
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3648
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3648
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3648
-   i32.store offset=4
+   i32.store
    i32.const 3648
    i32.const 3648
    call $~lib/string/String.__eq
@@ -2590,16 +2545,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/bar
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3680
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3680
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3680
-   i32.store offset=4
+   i32.store
    i32.const 3680
    i32.const 3680
    call $~lib/string/String.__eq
@@ -2614,16 +2566,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $resolve-unary/bar
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3712
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 3712
-   i32.store
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 3712
-   i32.store offset=4
+   i32.store
    i32.const 3712
    i32.const 3712
    call $~lib/string/String.__eq
@@ -2636,17 +2585,11 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3744
-   i32.store
    i32.const 3740
    i32.load
    drop
    global.get $~lib/memory/__stack_pointer
-   i32.const 3808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/array-access.debug.wat
+++ b/tests/compiler/std/array-access.debug.wat
@@ -541,21 +541,18 @@
  (func $std/array-access/stringArrayMethodCall (param $a i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   local.get $a
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=8
+  i32.store offset=4
   local.get $1
   i32.const 0
   call $~lib/array/Array<~lib/string/String>#__get
@@ -565,16 +562,11 @@
   i32.store
   local.get $1
   i32.const 272
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   i32.const 0
   call $~lib/string/String#startsWith
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -692,7 +684,7 @@
  (func $std/array-access/stringArrayArrayMethodCall (param $a i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
@@ -700,20 +692,20 @@
   i64.const 0
   i64.store
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store offset=8
+  i32.const 0
+  i32.store offset=8
   local.get $a
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 0
   call $~lib/array/Array<~lib/array/Array<~lib/string/String>>#__get
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=8
+  i32.store offset=4
   local.get $1
   i32.const 1
   call $~lib/array/Array<~lib/string/String>#__get
@@ -723,16 +715,11 @@
   i32.store
   local.get $1
   i32.const 272
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   i32.const 0
   call $~lib/string/String#startsWith
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 16
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1

--- a/tests/compiler/std/array-access.release.wat
+++ b/tests/compiler/std/array-access.release.wat
@@ -379,7 +379,7 @@
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -390,11 +390,8 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/array/Array<i32>>#__get
@@ -402,13 +399,10 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1296
-   i32.store offset=4
    local.get $0
    call $~lib/string/String#startsWith
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -505,7 +499,7 @@
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 16
+   i32.const 12
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -516,18 +510,18 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
+   i32.const 0
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=12
+   i32.store offset=8
    local.get $0
    i32.const 0
    call $~lib/array/Array<~lib/array/Array<i32>>#__get
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 1
    call $~lib/array/Array<~lib/array/Array<i32>>#__get
@@ -535,13 +529,10 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1296
-   i32.store offset=4
    local.get $0
    call $~lib/string/String#startsWith
    global.get $~lib/memory/__stack_pointer
-   i32.const 16
+   i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -26356,14 +26356,16 @@
   (local $x f64)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 10544
   local.tee $result
@@ -26383,19 +26385,9 @@
     i32.store offset=4
     local.get $4
     global.get $std/array/charset
-    local.set $4
-    global.get $~lib/memory/__stack_pointer
-    local.get $4
-    i32.store offset=12
-    local.get $4
     block $~lib/math/NativeMath.floor|inlined.0 (result f64)
      call $~lib/math/NativeMath.random
      global.get $std/array/charset
-     local.set $4
-     global.get $~lib/memory/__stack_pointer
-     local.get $4
-     i32.store offset=16
-     local.get $4
      call $~lib/string/String#get:length
      f64.convert_i32_s
      f64.mul
@@ -26424,7 +26416,7 @@
   local.get $result
   local.set $4
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $4
@@ -30020,13 +30012,13 @@
  (func $~lib/array/Array<i32>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -30034,15 +30026,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<i32>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -30279,13 +30266,13 @@
  (func $~lib/array/Array<i8>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -30293,15 +30280,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<i8>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -30538,13 +30520,13 @@
  (func $~lib/array/Array<u16>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -30552,15 +30534,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<u16>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -30797,13 +30774,13 @@
  (func $~lib/array/Array<i16>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -30811,15 +30788,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<i16>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -31056,13 +31028,13 @@
  (func $~lib/array/Array<u64>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -31070,15 +31042,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<u64>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -31317,13 +31284,13 @@
  (func $~lib/array/Array<i64>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -31331,15 +31298,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<i64>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -31348,13 +31310,13 @@
  (func $~lib/array/Array<~lib/string/String|null>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -31362,15 +31324,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<~lib/string/String|null>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -31627,13 +31584,13 @@
  (func $~lib/array/Array<~lib/array/Array<i32>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -31641,15 +31598,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<~lib/array/Array<i32>>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -31959,13 +31911,13 @@
  (func $~lib/array/Array<u8>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -31973,15 +31925,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<u8>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -32238,13 +32185,13 @@
  (func $~lib/array/Array<~lib/array/Array<u8>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -32252,15 +32199,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<~lib/array/Array<u8>>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -32415,13 +32357,13 @@
  (func $~lib/array/Array<u32>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -32429,15 +32371,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<u32>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -32694,13 +32631,13 @@
  (func $~lib/array/Array<~lib/array/Array<u32>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -32708,15 +32645,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<~lib/array/Array<u32>>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -32973,13 +32905,13 @@
  (func $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -32987,15 +32919,10 @@
   i32.store
   local.get $1
   i32.const 10832
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -33923,13 +33850,13 @@
   (local $295 i32)
   (local $296 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 448
+  i32.const 444
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 448
+  i32.const 444
   memory.fill
   i32.const 0
   i32.const 0
@@ -34027,11 +33954,6 @@
    unreachable
   end
   i32.const 640
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store
-  local.get $296
   call $~lib/array/Array.isArray<~lib/string/String>
   i32.eqz
   i32.eqz
@@ -43345,14 +43267,9 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 10832
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<bool>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43360,11 +43277,6 @@
   i32.store
   local.get $296
   i32.const 10864
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43383,14 +43295,9 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 10544
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<i32>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43398,11 +43305,6 @@
   i32.store
   local.get $296
   i32.const 10944
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43421,14 +43323,9 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 11008
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<u32>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43436,11 +43333,6 @@
   i32.store
   local.get $296
   i32.const 10944
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43459,14 +43351,9 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 11072
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<i32>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43474,11 +43361,6 @@
   i32.store
   local.get $296
   i32.const 11104
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43497,14 +43379,9 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 11264
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<f64>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43512,11 +43389,6 @@
   i32.store
   local.get $296
   i32.const 12432
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43535,14 +43407,9 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 10544
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<~lib/string/String|null>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43550,11 +43417,6 @@
   i32.store
   local.get $296
   i32.const 12544
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43573,7 +43435,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $235
-  i32.store offset=336
+  i32.store offset=332
   local.get $235
   i32.const 0
   i32.const 0
@@ -43592,19 +43454,14 @@
   call $~lib/array/Array<std/array/Ref|null>#__set
   local.get $235
   local.tee $236
-  i32.store offset=340
+  i32.store offset=336
   local.get $236
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 10832
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<std/array/Ref|null>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43612,11 +43469,6 @@
   i32.store
   local.get $296
   i32.const 12672
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43635,7 +43487,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $237
-  i32.store offset=344
+  i32.store offset=340
   local.get $237
   i32.const 0
   i32.const 0
@@ -43650,19 +43502,14 @@
   call $~lib/array/Array<std/array/Ref>#__set
   local.get $237
   local.tee $238
-  i32.store offset=348
+  i32.store offset=344
   local.get $238
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   i32.const 10832
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=332
-  local.get $296
   call $~lib/array/Array<std/array/Ref>#join
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -43670,11 +43517,6 @@
   i32.store
   local.get $296
   i32.const 12768
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43692,7 +43534,7 @@
   i32.const 12864
   call $~lib/rt/__newArray
   local.tee $240
-  i32.store offset=352
+  i32.store offset=348
   global.get $~lib/memory/__stack_pointer
   i32.const 1
   i32.const 2
@@ -43700,7 +43542,7 @@
   i32.const 12896
   call $~lib/rt/__newArray
   local.tee $242
-  i32.store offset=356
+  i32.store offset=352
   global.get $~lib/memory/__stack_pointer
   i32.const 2
   i32.const 2
@@ -43708,7 +43550,7 @@
   i32.const 12928
   call $~lib/rt/__newArray
   local.tee $244
-  i32.store offset=360
+  i32.store offset=356
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.const 2
@@ -43716,12 +43558,12 @@
   i32.const 12960
   call $~lib/rt/__newArray
   local.tee $246
-  i32.store offset=364
+  i32.store offset=360
   local.get $240
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i32>#toString
   local.set $296
@@ -43730,11 +43572,6 @@
   i32.store
   local.get $296
   i32.const 10544
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43749,7 +43586,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i32>#toString
   local.set $296
@@ -43758,11 +43595,6 @@
   i32.store
   local.get $296
   i32.const 12544
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43777,7 +43609,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i32>#toString
   local.set $296
@@ -43786,11 +43618,6 @@
   i32.store
   local.get $296
   i32.const 13008
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43805,7 +43632,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i32>#toString
   local.set $296
@@ -43814,11 +43641,6 @@
   i32.store
   local.get $296
   i32.const 13040
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43837,7 +43659,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i8>#toString
   local.set $296
@@ -43846,11 +43668,6 @@
   i32.store
   local.get $296
   i32.const 13120
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43869,7 +43686,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i8>#toString
   local.set $296
@@ -43878,11 +43695,6 @@
   i32.store
   local.get $296
   i32.const 13184
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43901,7 +43713,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<u16>#toString
   local.set $296
@@ -43910,11 +43722,6 @@
   i32.store
   local.get $296
   i32.const 13264
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43933,7 +43740,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i16>#toString
   local.set $296
@@ -43942,11 +43749,6 @@
   i32.store
   local.get $296
   i32.const 13344
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43965,7 +43767,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i32>#toString
   local.set $296
@@ -43974,11 +43776,6 @@
   i32.store
   local.get $296
   i32.const 13424
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -43997,7 +43794,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<u64>#toString
   local.set $296
@@ -44006,11 +43803,6 @@
   i32.store
   local.get $296
   i32.const 13536
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44029,7 +43821,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<i64>#toString
   local.set $296
@@ -44038,11 +43830,6 @@
   i32.store
   local.get $296
   i32.const 13680
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44060,12 +43847,12 @@
   i32.const 13840
   call $~lib/rt/__newArray
   local.tee $255
-  i32.store offset=368
+  i32.store offset=364
   local.get $255
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<~lib/string/String|null>#toString
   local.set $296
@@ -44074,11 +43861,6 @@
   i32.store
   local.get $296
   i32.const 13888
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44097,7 +43879,7 @@
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<~lib/string/String|null>#toString
   local.set $296
@@ -44106,11 +43888,6 @@
   i32.store
   local.get $296
   i32.const 14048
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44129,7 +43906,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $257
-  i32.store offset=372
+  i32.store offset=368
   local.get $257
   i32.const 0
   i32.const 2
@@ -44148,12 +43925,12 @@
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $257
   local.tee $260
-  i32.store offset=376
+  i32.store offset=372
   local.get $260
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#toString
   local.set $296
@@ -44162,11 +43939,6 @@
   i32.store
   local.get $296
   i32.const 14144
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44185,7 +43957,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $261
-  i32.store offset=380
+  i32.store offset=376
   local.get $261
   i32.const 0
   i32.const 2
@@ -44204,12 +43976,12 @@
   call $~lib/array/Array<~lib/array/Array<u8>>#__set
   local.get $261
   local.tee $264
-  i32.store offset=384
+  i32.store offset=380
   local.get $264
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<~lib/array/Array<u8>>#toString
   local.set $296
@@ -44218,11 +43990,6 @@
   i32.store
   local.get $296
   i32.const 14144
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44241,7 +44008,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $265
-  i32.store offset=388
+  i32.store offset=384
   local.get $265
   i32.const 0
   global.get $~lib/memory/__stack_pointer
@@ -44251,7 +44018,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $266
-  i32.store offset=392
+  i32.store offset=388
   local.get $266
   i32.const 0
   i32.const 1
@@ -44264,12 +44031,12 @@
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#__set
   local.get $265
   local.tee $268
-  i32.store offset=396
+  i32.store offset=392
   local.get $268
   local.set $296
   global.get $~lib/memory/__stack_pointer
   local.get $296
-  i32.store offset=48
+  i32.store offset=8
   local.get $296
   call $~lib/array/Array<~lib/array/Array<~lib/array/Array<u32>>>#toString
   local.set $296
@@ -44278,11 +44045,6 @@
   i32.store
   local.get $296
   i32.const 12544
-  local.set $296
-  global.get $~lib/memory/__stack_pointer
-  local.get $296
-  i32.store offset=8
-  local.get $296
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -44301,7 +44063,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $269
-  i32.store offset=400
+  i32.store offset=396
   local.get $269
   i32.const 0
   i32.const 1
@@ -44336,7 +44098,7 @@
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $269
   local.tee $274
-  i32.store offset=404
+  i32.store offset=400
   global.get $~lib/memory/__stack_pointer
   local.get $274
   local.set $296
@@ -44346,7 +44108,7 @@
   local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
   local.tee $275
-  i32.store offset=408
+  i32.store offset=404
   local.get $275
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -44406,7 +44168,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $277
-  i32.store offset=412
+  i32.store offset=408
   local.get $277
   i32.const 0
   i32.const 1
@@ -44441,7 +44203,7 @@
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#__set
   local.get $277
   local.tee $282
-  i32.store offset=416
+  i32.store offset=412
   global.get $~lib/memory/__stack_pointer
   local.get $282
   local.set $296
@@ -44451,7 +44213,7 @@
   local.get $296
   call $~lib/array/Array<~lib/array/Array<~lib/string/String|null>>#flat
   local.tee $283
-  i32.store offset=420
+  i32.store offset=416
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.const 2
@@ -44459,7 +44221,7 @@
   i32.const 14768
   call $~lib/rt/__newArray
   local.tee $285
-  i32.store offset=424
+  i32.store offset=420
   local.get $283
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -44542,7 +44304,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $287
-  i32.store offset=428
+  i32.store offset=424
   local.get $287
   i32.const 0
   i32.const 0
@@ -44561,7 +44323,7 @@
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $287
   local.tee $290
-  i32.store offset=432
+  i32.store offset=428
   local.get $290
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -44594,7 +44356,7 @@
   i32.const 0
   call $~lib/rt/__newArray
   local.tee $291
-  i32.store offset=436
+  i32.store offset=432
   local.get $291
   i32.const 0
   i32.const 1
@@ -44613,7 +44375,7 @@
   call $~lib/array/Array<~lib/array/Array<i32>>#__set
   local.get $291
   local.tee $294
-  i32.store offset=440
+  i32.store offset=436
   global.get $~lib/memory/__stack_pointer
   local.get $294
   local.set $296
@@ -44635,7 +44397,7 @@
   local.get $296
   call $~lib/array/Array<~lib/array/Array<i32>>#flat
   local.tee $295
-  i32.store offset=444
+  i32.store offset=440
   local.get $295
   local.set $296
   global.get $~lib/memory/__stack_pointer
@@ -44740,7 +44502,7 @@
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 448
+  i32.const 444
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -16119,7 +16119,7 @@
  )
  (func $~lib/array/Array<i32>#toString (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -16134,19 +16134,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11856
-  i32.store offset=4
   local.get $0
   i32.const 11856
   call $~lib/array/Array<i32>#join
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -16158,7 +16155,7 @@
   (local $5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -16167,14 +16164,11 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -16344,429 +16338,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
-  end
-  i32.const 48992
-  i32.const 49040
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
- )
- (func $~lib/array/Array<u16>#toString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
    i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   i32.load offset=4
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   i32.load offset=12
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
-    local.get $0
-    i32.const 1
-    i32.sub
-    local.tee $6
-    i32.const 0
-    i32.lt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     i32.const 11568
-     local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
-    end
-    local.get $6
-    i32.eqz
-    if
-     local.get $5
-     i32.load16_u
-     call $~lib/util/number/utoa32
-     local.set $0
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 11856
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 11852
-    i32.load
-    i32.const 1
-    i32.shr_u
-    local.tee $4
-    i32.const 10
-    i32.add
-    local.get $6
-    i32.mul
-    i32.const 10
-    i32.add
-    local.tee $2
-    i32.const 1
-    i32.shl
-    i32.const 2
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store offset=4
-    loop $for-loop|0
-     local.get $3
-     local.get $6
-     i32.lt_s
-     if
-      local.get $0
-      local.get $1
-      i32.const 1
-      i32.shl
-      i32.add
-      local.get $5
-      local.get $3
-      i32.const 1
-      i32.shl
-      i32.add
-      i32.load16_u
-      call $~lib/util/number/itoa_buffered<u16>
-      local.get $1
-      i32.add
-      local.set $1
-      local.get $4
-      if
-       local.get $0
-       local.get $1
-       i32.const 1
-       i32.shl
-       i32.add
-       i32.const 11856
-       local.get $4
-       i32.const 1
-       i32.shl
-       memory.copy
-       local.get $1
-       local.get $4
-       i32.add
-       local.set $1
-      end
-      local.get $3
-      i32.const 1
-      i32.add
-      local.set $3
-      br $for-loop|0
-     end
-    end
-    local.get $0
-    local.get $1
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $5
-    local.get $6
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    call $~lib/util/number/itoa_buffered<u16>
-    local.get $1
-    i32.add
-    local.tee $1
-    local.get $2
-    i32.lt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $0
-     local.get $1
-     call $~lib/string/String#substring
-     local.set $0
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
-  end
-  i32.const 48992
-  i32.const 49040
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
- )
- (func $~lib/array/Array<i16>#toString (param $0 i32) (result i32)
-  (local $1 i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   i32.load offset=4
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   i32.load offset=12
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
-    local.get $0
-    i32.const 1
-    i32.sub
-    local.tee $6
-    i32.const 0
-    i32.lt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     i32.const 11568
-     local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
-    end
-    local.get $6
-    i32.eqz
-    if
-     local.get $5
-     i32.load16_s
-     call $~lib/util/number/itoa32
-     local.set $0
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 11856
-    i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 11852
-    i32.load
-    i32.const 1
-    i32.shr_u
-    local.tee $4
-    i32.const 11
-    i32.add
-    local.get $6
-    i32.mul
-    i32.const 11
-    i32.add
-    local.tee $2
-    i32.const 1
-    i32.shl
-    i32.const 2
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store offset=4
-    loop $for-loop|0
-     local.get $3
-     local.get $6
-     i32.lt_s
-     if
-      local.get $0
-      local.get $1
-      i32.const 1
-      i32.shl
-      i32.add
-      local.get $5
-      local.get $3
-      i32.const 1
-      i32.shl
-      i32.add
-      i32.load16_s
-      call $~lib/util/number/itoa_buffered<i16>
-      local.get $1
-      i32.add
-      local.set $1
-      local.get $4
-      if
-       local.get $0
-       local.get $1
-       i32.const 1
-       i32.shl
-       i32.add
-       i32.const 11856
-       local.get $4
-       i32.const 1
-       i32.shl
-       memory.copy
-       local.get $1
-       local.get $4
-       i32.add
-       local.set $1
-      end
-      local.get $3
-      i32.const 1
-      i32.add
-      local.set $3
-      br $for-loop|0
-     end
-    end
-    local.get $0
-    local.get $1
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $5
-    local.get $6
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_s
-    call $~lib/util/number/itoa_buffered<i16>
-    local.get $1
-    i32.add
-    local.tee $1
-    local.get $2
-    i32.lt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $0
-     local.get $1
-     call $~lib/string/String#substring
-     local.set $0
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
-    end
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.add
-    global.set $~lib/memory/__stack_pointer
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
@@ -17092,7 +16664,7 @@
  )
  (func $~lib/array/Array<~lib/string/String|null>#toString (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -17107,19 +16679,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11856
-  i32.store offset=4
   local.get $0
   i32.const 11856
   call $~lib/array/Array<~lib/string/String|null>#join
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -17131,7 +16700,7 @@
   (local $5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -17140,14 +16709,11 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -17317,7 +16883,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
@@ -17332,7 +16898,7 @@
  )
  (func $~lib/array/Array<u32>#toString (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -17347,19 +16913,16 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11856
-  i32.store offset=4
   local.get $0
   i32.const 11856
   call $~lib/array/Array<u32>#join
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -17371,7 +16934,7 @@
   (local $5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
@@ -17380,14 +16943,11 @@
    i32.lt_s
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -17576,7 +17136,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
@@ -17811,7 +17371,7 @@
   (local $13 i32)
   (local $14 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 448
+  i32.const 444
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner2
@@ -17821,7 +17381,7 @@
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 448
+   i32.const 444
    memory.fill
    memory.size
    i32.const 16
@@ -17974,9 +17534,6 @@
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1664
    i32.store
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
@@ -27885,7 +27442,7 @@
      i32.trunc_sat_f64_s
      local.set $10
      global.get $~lib/memory/__stack_pointer
-     i32.const 20
+     i32.const 12
      i32.sub
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
@@ -27893,9 +27450,11 @@
      i32.lt_s
      br_if $folding-inner2
      global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
      i32.const 0
-     i32.const 20
-     memory.fill
+     i32.store offset=8
      i32.const 11568
      local.set $0
      global.get $~lib/memory/__stack_pointer
@@ -27912,13 +27471,7 @@
        local.get $0
        i32.store offset=4
        global.get $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       i32.const 10032
-       i32.store offset=12
        call $~lib/math/NativeMath.random
-       global.get $~lib/memory/__stack_pointer
-       i32.const 10032
-       i32.store offset=16
        i32.const 10028
        i32.load
        i32.const 1
@@ -27993,7 +27546,7 @@
       end
      end
      global.get $~lib/memory/__stack_pointer
-     i32.const 20
+     i32.const 12
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
@@ -28059,10 +27612,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=332
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -28265,9 +27815,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11888
-   i32.store offset=8
    local.get $2
    i32.const 11888
    call $~lib/string/String.__eq
@@ -28288,10 +27835,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11568
-   i32.store offset=332
+   i32.store offset=8
    local.get $0
    i32.const 11568
    call $~lib/array/Array<i32>#join
@@ -28299,9 +27843,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11968
-   i32.store offset=8
    local.get $0
    i32.const 11968
    call $~lib/string/String.__eq
@@ -28322,10 +27863,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12032
-   i32.store offset=332
+   i32.store offset=8
    local.get $0
    i32.const 12032
    call $~lib/array/Array<u32>#join
@@ -28333,9 +27871,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11968
-   i32.store offset=8
    local.get $0
    i32.const 11968
    call $~lib/string/String.__eq
@@ -28356,10 +27891,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12096
-   i32.store offset=332
+   i32.store offset=8
    local.get $0
    i32.const 12096
    call $~lib/array/Array<i32>#join
@@ -28367,9 +27899,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12128
-   i32.store offset=8
    local.get $0
    i32.const 12128
    call $~lib/string/String.__eq
@@ -28390,10 +27919,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12288
-   i32.store offset=332
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -28427,9 +27953,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13456
-   i32.store offset=8
    local.get $0
    i32.const 13456
    call $~lib/string/String.__eq
@@ -28450,10 +27973,7 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11568
-   i32.store offset=332
+   i32.store offset=8
    local.get $0
    i32.const 11568
    call $~lib/array/Array<~lib/string/String|null>#join
@@ -28461,9 +27981,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13568
-   i32.store offset=8
    local.get $0
    i32.const 13568
    call $~lib/string/String.__eq
@@ -28484,7 +28001,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=336
+   i32.store offset=332
    local.get $1
    i32.const 0
    i32.const 0
@@ -28500,22 +28017,16 @@
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=340
+   i32.store offset=336
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=332
+   i32.store offset=8
    local.get $1
    call $~lib/array/Array<std/array/Ref|null>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13696
-   i32.store offset=8
    local.get $0
    i32.const 13696
    call $~lib/string/String.__eq
@@ -28536,7 +28047,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=344
+   i32.store offset=340
    local.get $1
    i32.const 0
    i32.const 0
@@ -28548,22 +28059,16 @@
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=348
+   i32.store offset=344
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=332
+   i32.store offset=8
    local.get $1
    call $~lib/array/Array<std/array/Ref|null>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13792
-   i32.store offset=8
    local.get $0
    i32.const 13792
    call $~lib/string/String.__eq
@@ -28583,7 +28088,7 @@
    i32.const 13888
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=352
+   i32.store offset=348
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 2
@@ -28591,7 +28096,7 @@
    i32.const 13920
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=356
+   i32.store offset=352
    global.get $~lib/memory/__stack_pointer
    i32.const 2
    i32.const 2
@@ -28599,7 +28104,7 @@
    i32.const 13952
    call $~lib/rt/__newArray
    local.tee $2
-   i32.store offset=360
+   i32.store offset=356
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 2
@@ -28607,19 +28112,16 @@
    i32.const 13984
    call $~lib/rt/__newArray
    local.tee $4
-   i32.store offset=364
+   i32.store offset=360
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    local.get $0
    call $~lib/array/Array<i32>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11568
-   i32.store offset=8
    local.get $0
    i32.const 11568
    call $~lib/string/String.__eq
@@ -28634,16 +28136,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
+   i32.store offset=8
    local.get $1
    call $~lib/array/Array<i32>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13568
-   i32.store offset=8
    local.get $0
    i32.const 13568
    call $~lib/string/String.__eq
@@ -28658,16 +28157,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=48
+   i32.store offset=8
    local.get $2
    call $~lib/array/Array<i32>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14032
-   i32.store offset=8
    local.get $0
    i32.const 14032
    call $~lib/string/String.__eq
@@ -28682,16 +28178,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $4
-   i32.store offset=48
+   i32.store offset=8
    local.get $4
    call $~lib/array/Array<i32>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14064
-   i32.store offset=8
    local.get $0
    i32.const 14064
    call $~lib/string/String.__eq
@@ -28712,16 +28205,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    local.get $0
    call $~lib/array/Array<i8>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14144
-   i32.store offset=8
    local.get $0
    i32.const 14144
    call $~lib/string/String.__eq
@@ -28742,16 +28232,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    local.get $0
    call $~lib/array/Array<i8>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14208
-   i32.store offset=8
    local.get $0
    i32.const 14208
    call $~lib/string/String.__eq
@@ -28769,20 +28256,206 @@
    i32.const 11
    i32.const 14256
    call $~lib/rt/__newArray
+   local.set $1
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=8
+   i32.const 0
    local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=48
-   local.get $0
-   call $~lib/array/Array<u16>#toString
-   local.set $0
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner2
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 14288
-   i32.store offset=8
-   local.get $0
+   local.get $1
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner2
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
+   i32.load offset=4
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
+   i32.load offset=12
+   local.set $1
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11856
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner2
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+    local.get $1
+    i32.const 1
+    i32.sub
+    local.tee $1
+    i32.const 0
+    i32.lt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     i32.const 11568
+     local.set $2
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+    end
+    local.get $1
+    i32.eqz
+    if
+     local.get $4
+     i32.load16_u
+     call $~lib/util/number/utoa32
+     local.set $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+    end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 11856
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 11852
+    i32.load
+    i32.const 1
+    i32.shr_u
+    local.tee $8
+    i32.const 10
+    i32.add
+    local.get $1
+    i32.mul
+    i32.const 10
+    i32.add
+    local.tee $9
+    i32.const 1
+    i32.shl
+    i32.const 2
+    call $~lib/rt/itcms/__new
+    local.tee $2
+    i32.store offset=4
+    loop $for-loop|03
+     local.get $1
+     local.get $3
+     i32.gt_s
+     if
+      local.get $2
+      local.get $0
+      i32.const 1
+      i32.shl
+      i32.add
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_u
+      call $~lib/util/number/itoa_buffered<u16>
+      local.get $0
+      i32.add
+      local.set $0
+      local.get $8
+      if
+       local.get $2
+       local.get $0
+       i32.const 1
+       i32.shl
+       i32.add
+       i32.const 11856
+       local.get $8
+       i32.const 1
+       i32.shl
+       memory.copy
+       local.get $0
+       local.get $8
+       i32.add
+       local.set $0
+      end
+      local.get $3
+      i32.const 1
+      i32.add
+      local.set $3
+      br $for-loop|03
+     end
+    end
+    local.get $9
+    local.get $2
+    local.get $0
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $4
+    local.get $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_u
+    call $~lib/util/number/itoa_buffered<u16>
+    local.get $0
+    i32.add
+    local.tee $0
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
+     local.get $0
+     call $~lib/string/String#substring
+     local.set $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+    end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store
+   local.get $2
    i32.const 14288
    call $~lib/string/String.__eq
    i32.eqz
@@ -28799,20 +28472,208 @@
    i32.const 39
    i32.const 14336
    call $~lib/rt/__newArray
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=48
-   local.get $0
-   call $~lib/array/Array<i16>#toString
+   local.get $1
+   i32.store offset=8
+   i32.const 0
    local.set $0
+   i32.const 0
+   local.set $3
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner2
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 14368
-   i32.store offset=8
-   local.get $0
+   local.get $1
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner2
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
+   i32.load offset=4
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
+   i32.load offset=12
+   local.set $1
+   global.get $~lib/memory/__stack_pointer
+   i32.const 11856
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner2
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+    local.get $1
+    i32.const 1
+    i32.sub
+    local.tee $1
+    i32.const 0
+    i32.lt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     i32.const 11568
+     local.set $2
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+    end
+    local.get $1
+    i32.eqz
+    if
+     local.get $4
+     i32.load16_s
+     call $~lib/util/number/itoa32
+     local.set $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+    end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 11856
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 11852
+    i32.load
+    i32.const 1
+    i32.shr_u
+    local.tee $8
+    i32.const 11
+    i32.add
+    local.get $1
+    i32.mul
+    i32.const 11
+    i32.add
+    local.tee $9
+    i32.const 1
+    i32.shl
+    i32.const 2
+    call $~lib/rt/itcms/__new
+    local.tee $2
+    i32.store offset=4
+    loop $for-loop|05
+     local.get $1
+     local.get $3
+     i32.gt_s
+     if
+      local.get $2
+      local.get $0
+      i32.const 1
+      i32.shl
+      i32.add
+      local.get $4
+      local.get $3
+      i32.const 1
+      i32.shl
+      i32.add
+      i32.load16_s
+      call $~lib/util/number/itoa_buffered<i16>
+      local.get $0
+      i32.add
+      local.set $0
+      local.get $8
+      if
+       local.get $2
+       local.get $0
+       i32.const 1
+       i32.shl
+       i32.add
+       i32.const 11856
+       local.get $8
+       i32.const 1
+       i32.shl
+       memory.copy
+       local.get $0
+       local.get $8
+       i32.add
+       local.set $0
+      end
+      local.get $3
+      i32.const 1
+      i32.add
+      local.set $3
+      br $for-loop|05
+     end
+    end
+    local.get $9
+    local.get $2
+    local.get $0
+    i32.const 1
+    i32.shl
+    i32.add
+    local.get $4
+    local.get $1
+    i32.const 1
+    i32.shl
+    i32.add
+    i32.load16_s
+    call $~lib/util/number/itoa_buffered<i16>
+    local.get $0
+    i32.add
+    local.tee $0
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
+     local.get $0
+     call $~lib/string/String#substring
+     local.set $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+    end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store
+   local.get $2
    i32.const 14368
    call $~lib/string/String.__eq
    i32.eqz
@@ -28832,16 +28693,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    local.get $0
    call $~lib/array/Array<i32>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14448
-   i32.store offset=8
    local.get $0
    i32.const 14448
    call $~lib/string/String.__eq
@@ -28862,9 +28720,9 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -28872,14 +28730,11 @@
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -28911,15 +28766,12 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14560
-   i32.store offset=8
    local.get $0
    i32.const 14560
    call $~lib/string/String.__eq
@@ -28940,9 +28792,9 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -28950,14 +28802,11 @@
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -28986,6 +28835,8 @@
    i32.store
    i32.const 0
    local.set $0
+   i32.const 0
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -29017,7 +28868,7 @@
      local.get $4
      i32.eqz
      if
-      block $__inlined_func$~lib/util/number/itoa64$2 (result i32)
+      block $__inlined_func$~lib/util/number/itoa64$4 (result i32)
        local.get $1
        i64.load
        i64.extend32_s
@@ -29041,7 +28892,7 @@
         i32.add
         global.set $~lib/memory/__stack_pointer
         i32.const 7712
-        br $__inlined_func$~lib/util/number/itoa64$2
+        br $__inlined_func$~lib/util/number/itoa64$4
        end
        i64.const 0
        local.get $5
@@ -29315,15 +29166,12 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14704
-   i32.store offset=8
    local.get $2
    i32.const 14704
    call $~lib/string/String.__eq
@@ -29343,19 +29191,16 @@
    i32.const 14864
    call $~lib/rt/__newArray
    local.tee $0
-   i32.store offset=368
+   i32.store offset=364
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    local.get $0
    call $~lib/array/Array<~lib/string/String|null>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14912
-   i32.store offset=8
    local.get $0
    i32.const 14912
    call $~lib/string/String.__eq
@@ -29376,16 +29221,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=8
    local.get $0
    call $~lib/array/Array<~lib/string/String|null>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15072
-   i32.store offset=8
    local.get $0
    i32.const 15072
    call $~lib/string/String.__eq
@@ -29406,7 +29248,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=372
+   i32.store offset=368
    local.get $1
    i32.const 0
    i32.const 2
@@ -29424,12 +29266,12 @@
    call $~lib/rt/__newArray
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=376
+   i32.store offset=372
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -29437,14 +29279,11 @@
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -29636,15 +29475,12 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15168
-   i32.store offset=8
    local.get $2
    i32.const 15168
    call $~lib/string/String.__eq
@@ -29665,7 +29501,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=380
+   i32.store offset=376
    local.get $1
    i32.const 0
    i32.const 2
@@ -29683,12 +29519,12 @@
    call $~lib/rt/__newArray
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=384
+   i32.store offset=380
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -29696,14 +29532,11 @@
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -29895,15 +29728,12 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15168
-   i32.store offset=8
    local.get $2
    i32.const 15168
    call $~lib/string/String.__eq
@@ -29924,7 +29754,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=388
+   i32.store offset=384
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 2
@@ -29932,7 +29762,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $2
-   i32.store offset=392
+   i32.store offset=388
    local.get $2
    i32.const 0
    i32.const 1
@@ -29946,12 +29776,12 @@
    local.get $2
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=396
+   i32.store offset=392
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -29959,14 +29789,11 @@
    i32.lt_s
    br_if $folding-inner2
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11856
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -30158,15 +29985,12 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13568
-   i32.store offset=8
    local.get $2
    i32.const 13568
    call $~lib/string/String.__eq
@@ -30187,7 +30011,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=400
+   i32.store offset=396
    local.get $1
    i32.const 0
    i32.const 1
@@ -30221,7 +30045,7 @@
    call $~lib/rt/__newArray
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=404
+   i32.store offset=400
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -30229,7 +30053,7 @@
    local.get $1
    call $~lib/array/Array<~lib/array/Array<i32>>#flat
    local.tee $1
-   i32.store offset=408
+   i32.store offset=404
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -30283,7 +30107,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=412
+   i32.store offset=408
    local.get $1
    i32.const 0
    i32.const 1
@@ -30317,7 +30141,7 @@
    call $~lib/rt/__newArray
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=416
+   i32.store offset=412
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -30479,7 +30303,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $10
-   i32.store offset=420
+   i32.store offset=416
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.const 2
@@ -30487,7 +30311,7 @@
    i32.const 15792
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=424
+   i32.store offset=420
    global.get $~lib/memory/__stack_pointer
    local.get $10
    i32.store
@@ -30561,7 +30385,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=428
+   i32.store offset=424
    local.get $1
    i32.const 0
    i32.const 0
@@ -30579,7 +30403,7 @@
    call $~lib/rt/__newArray
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=432
+   i32.store offset=428
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
@@ -30607,7 +30431,7 @@
    i32.const 0
    call $~lib/rt/__newArray
    local.tee $1
-   i32.store offset=436
+   i32.store offset=432
    local.get $1
    i32.const 0
    i32.const 1
@@ -30625,7 +30449,7 @@
    call $~lib/rt/__newArray
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $1
-   i32.store offset=440
+   i32.store offset=436
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -30735,7 +30559,7 @@
    local.get $3
    call $~lib/array/Array<~lib/array/Array<i32>>#flat
    local.tee $0
-   i32.store offset=444
+   i32.store offset=440
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -30857,7 +30681,7 @@
    i32.add
    global.set $~lib/rt/itcms/threshold
    global.get $~lib/memory/__stack_pointer
-   i32.const 448
+   i32.const 444
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/console.debug.wat
+++ b/tests/compiler/std/console.debug.wat
@@ -35,6 +35,46 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
+ (func $start:std/console
+  i32.const 0
+  i32.const 32
+  call $~lib/console/console.assert<bool>
+  i32.const 1
+  i32.const 64
+  call $~lib/console/console.assert<bool>
+  i32.const 96
+  call $~lib/console/console.log
+  i32.const 144
+  call $~lib/console/console.debug
+  i32.const 192
+  call $~lib/console/console.info
+  i32.const 240
+  call $~lib/console/console.warn
+  i32.const 288
+  call $~lib/console/console.error
+  i32.const 336
+  call $~lib/console/console.time
+  i32.const 336
+  call $~lib/console/console.timeLog
+  i32.const 336
+  call $~lib/console/console.timeEnd
+  i32.const 384
+  call $~lib/console/console.timeLog
+  i32.const 384
+  call $~lib/console/console.timeEnd
+  i32.const 432
+  call $~lib/console/console.time
+  i32.const 432
+  call $~lib/console/console.time
+  i32.const 480
+  call $~lib/console/console.log
+  i32.const 512
+  call $~lib/console/console.log
+  i32.const 544
+  call $~lib/console/console.log
+  i32.const 576
+  call $~lib/console/console.log
+ )
  (func $~start
   call $start:std/console
  )
@@ -247,149 +287,6 @@
   i32.store
   local.get $1
   call $~lib/bindings/dom/console.timeEnd
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
- (func $start:std/console
-  (local $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  i32.const 0
-  i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.assert<bool>
-  i32.const 1
-  i32.const 64
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.assert<bool>
-  i32.const 96
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.log
-  i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.debug
-  i32.const 192
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.info
-  i32.const 240
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.warn
-  i32.const 288
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.error
-  i32.const 336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.time
-  i32.const 336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.timeLog
-  i32.const 336
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.timeEnd
-  i32.const 384
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.timeLog
-  i32.const 384
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.timeEnd
-  i32.const 432
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.time
-  i32.const 432
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.time
-  i32.const 480
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.log
-  i32.const 512
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.log
-  i32.const 544
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.log
-  i32.const 576
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/console/console.log
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add

--- a/tests/compiler/std/console.release.wat
+++ b/tests/compiler/std/console.release.wat
@@ -46,42 +46,19 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~start
+  i32.const 0
+  i32.const 1056
+  call $~lib/console/console.assert<bool>
+  i32.const 1
+  i32.const 1088
+  call $~lib/console/console.assert<bool>
+  i32.const 1120
+  call $~lib/console/console.log
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1612
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
-   i32.const 0
-   i32.const 1056
-   call $~lib/console/console.assert<bool>
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1088
-   i32.store
-   i32.const 1
-   i32.const 1088
-   call $~lib/console/console.assert<bool>
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1120
-   i32.store
-   i32.const 1120
-   call $~lib/console/console.log
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    i32.const 1612
    i32.lt_s
@@ -98,9 +75,6 @@
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1216
-   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -122,9 +96,6 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1264
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -145,9 +116,6 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 1312
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -167,65 +135,28 @@
    i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1360
-   i32.store
    i32.const 1360
    call $~lib/console/console.time
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1360
-   i32.store
    i32.const 1360
    call $~lib/console/console.timeLog
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1360
-   i32.store
    i32.const 1360
    call $~lib/console/console.timeEnd
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1408
-   i32.store
    i32.const 1408
    call $~lib/console/console.timeLog
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1408
-   i32.store
    i32.const 1408
    call $~lib/console/console.timeEnd
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1456
-   i32.store
    i32.const 1456
    call $~lib/console/console.time
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1456
-   i32.store
    i32.const 1456
    call $~lib/console/console.time
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1504
-   i32.store
    i32.const 1504
    call $~lib/console/console.log
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1536
-   i32.store
    i32.const 1536
    call $~lib/console/console.log
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store
    i32.const 1568
    call $~lib/console/console.log
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1600
-   i32.store
    i32.const 1600
    call $~lib/console/console.log
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    return
   end
   i32.const 34400

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -4711,13 +4711,13 @@
  (func $~lib/date/stringify (param $value i32) (param $padding i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $value
   i32.const 10
   call $~lib/number/I32#toString
@@ -4728,15 +4728,10 @@
   local.get $2
   local.get $padding
   i32.const 848
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   call $~lib/string/String#padStart
   local.set $2
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $2
@@ -5415,11 +5410,6 @@
   i32.store
   local.get $19
   i32.const 2432
-  local.set $19
-  global.get $~lib/memory/__stack_pointer
-  local.get $19
-  i32.store offset=4
-  local.get $19
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $19
   global.get $~lib/memory/__stack_pointer
@@ -5746,11 +5736,6 @@
   i32.store offset=8
   local.get $20
   i32.const 2432
-  local.set $20
-  global.get $~lib/memory/__stack_pointer
-  local.get $20
-  i32.store offset=48
-  local.get $20
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $20
   global.get $~lib/memory/__stack_pointer
@@ -5874,11 +5859,6 @@
   i32.store
   local.get $7
   i32.const 2432
-  local.set $7
-  global.get $~lib/memory/__stack_pointer
-  local.get $7
-  i32.store offset=28
-  local.get $7
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $7
   global.get $~lib/memory/__stack_pointer
@@ -6205,11 +6185,6 @@
   i32.store offset=8
   local.get $26
   i32.const 2432
-  local.set $26
-  global.get $~lib/memory/__stack_pointer
-  local.get $26
-  i32.store offset=72
-  local.get $26
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $26
   global.get $~lib/memory/__stack_pointer
@@ -7479,11 +7454,6 @@
      i32.store offset=4
      local.get $21
      i32.const 2432
-     local.set $21
-     global.get $~lib/memory/__stack_pointer
-     local.get $21
-     i32.store offset=24
-     local.get $21
      call $~lib/array/Array<~lib/string/String>#push
      drop
     end
@@ -7584,11 +7554,6 @@
    i32.store offset=4
    local.get $21
    i32.const 2432
-   local.set $21
-   global.get $~lib/memory/__stack_pointer
-   local.get $21
-   i32.store offset=24
-   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
   end
@@ -8017,13 +7982,13 @@
   (local $radix|45 i32)
   (local $46 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 76
+  i32.const 72
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 76
+  i32.const 72
   memory.fill
   local.get $dateTimeString
   local.set $46
@@ -8062,11 +8027,6 @@
   i32.store
   local.get $46
   i32.const 2464
-  local.set $46
-  global.get $~lib/memory/__stack_pointer
-  local.get $46
-  i32.store offset=8
-  local.get $46
   i32.const 0
   call $~lib/string/String#indexOf
   local.set $posT
@@ -8101,7 +8061,7 @@
    i32.const 0
    call $~lib/string/String#substring@varargs
    local.tee $timeString
-   i32.store offset=12
+   i32.store offset=8
    local.get $timeString
    local.set $46
    global.get $~lib/memory/__stack_pointer
@@ -8142,7 +8102,7 @@
        local.get $i
        call $~lib/string/String#substring
        local.tee $timeString
-       i32.store offset=12
+       i32.store offset=8
        br $for-break0
       else
        local.get $c
@@ -8182,11 +8142,6 @@
         i32.store
         local.get $46
         i32.const 2496
-        local.set $46
-        global.get $~lib/memory/__stack_pointer
-        local.get $46
-        i32.store offset=8
-        local.get $46
         local.get $i
         i32.const 1
         i32.add
@@ -8210,7 +8165,7 @@
           local.get $posColon
           call $~lib/string/String#substring
           local.tee $value
-          i32.store offset=16
+          i32.store offset=12
           i32.const 0
           local.set $radix
           local.get $value
@@ -8240,7 +8195,7 @@
           i32.const 0
           call $~lib/string/String#substring@varargs
           local.tee $value|15
-          i32.store offset=20
+          i32.store offset=16
           i32.const 0
           local.set $radix|16
           local.get $value|15
@@ -8279,7 +8234,7 @@
           i32.const 0
           call $~lib/string/String#substring@varargs
           local.tee $value|18
-          i32.store offset=24
+          i32.store offset=20
           i32.const 0
           local.set $radix|19
           local.get $value|18
@@ -8318,7 +8273,7 @@
         local.get $i
         call $~lib/string/String#substring
         local.tee $timeString
-        i32.store offset=12
+        i32.store offset=8
         br $for-break0
        end
       end
@@ -8338,17 +8293,12 @@
    i32.store
    local.get $46
    i32.const 2496
-   local.set $46
-   global.get $~lib/memory/__stack_pointer
-   local.get $46
-   i32.store offset=8
-   local.get $46
    i32.const 1
    global.set $~argumentsLength
    i32.const 0
    call $~lib/string/String#split@varargs
    local.tee $timeParts
-   i32.store offset=28
+   i32.store offset=24
    local.get $timeParts
    local.set $46
    global.get $~lib/memory/__stack_pointer
@@ -8379,7 +8329,7 @@
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $value|23
-    i32.store offset=32
+    i32.store offset=28
     i32.const 0
     local.set $radix|24
     local.get $value|23
@@ -8404,7 +8354,7 @@
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $value|25
-    i32.store offset=36
+    i32.store offset=32
     i32.const 0
     local.set $radix|26
     local.get $value|25
@@ -8432,7 +8382,7 @@
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $secAndFrac
-    i32.store offset=40
+    i32.store offset=36
     local.get $secAndFrac
     local.set $46
     global.get $~lib/memory/__stack_pointer
@@ -8440,11 +8390,6 @@
     i32.store
     local.get $46
     i32.const 2528
-    local.set $46
-    global.get $~lib/memory/__stack_pointer
-    local.get $46
-    i32.store offset=8
-    local.get $46
     i32.const 0
     call $~lib/string/String#indexOf
     local.set $posDot
@@ -8464,7 +8409,7 @@
       local.get $posDot
       call $~lib/string/String#substring
       local.tee $value|29
-      i32.store offset=44
+      i32.store offset=40
       i32.const 0
       local.set $radix|30
       local.get $value|29
@@ -8484,7 +8429,7 @@
       local.set $46
       global.get $~lib/memory/__stack_pointer
       local.get $46
-      i32.store offset=48
+      i32.store offset=44
       local.get $46
       local.get $posDot
       i32.const 1
@@ -8498,14 +8443,9 @@
       local.get $46
       i32.const 3
       i32.const 848
-      local.set $46
-      global.get $~lib/memory/__stack_pointer
-      local.get $46
-      i32.store offset=8
-      local.get $46
       call $~lib/string/String#padEnd
       local.tee $value|31
-      i32.store offset=52
+      i32.store offset=48
       i32.const 0
       local.set $radix|32
       local.get $value|31
@@ -8524,7 +8464,7 @@
       global.get $~lib/memory/__stack_pointer
       local.get $secAndFrac
       local.tee $value|33
-      i32.store offset=56
+      i32.store offset=52
       i32.const 0
       local.set $radix|34
       local.get $value|33
@@ -8549,17 +8489,12 @@
   i32.store
   local.get $46
   i32.const 592
-  local.set $46
-  global.get $~lib/memory/__stack_pointer
-  local.get $46
-  i32.store offset=8
-  local.get $46
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $parts
-  i32.store offset=60
+  i32.store offset=56
   block $~lib/builtins/i32.parse|inlined.8 (result i32)
    global.get $~lib/memory/__stack_pointer
    local.get $parts
@@ -8571,7 +8506,7 @@
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $value|36
-   i32.store offset=64
+   i32.store offset=60
    i32.const 0
    local.set $radix|37
    local.get $value|36
@@ -8612,7 +8547,7 @@
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $value|42
-    i32.store offset=68
+    i32.store offset=64
     i32.const 0
     local.set $radix|43
     local.get $value|42
@@ -8641,7 +8576,7 @@
      i32.const 2
      call $~lib/array/Array<~lib/string/String>#__get
      local.tee $value|44
-     i32.store offset=72
+     i32.store offset=68
      i32.const 0
      local.set $radix|45
      local.get $value|44
@@ -8672,7 +8607,7 @@
   call $~lib/date/Date#constructor
   local.set $46
   global.get $~lib/memory/__stack_pointer
-  i32.const 76
+  i32.const 72
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $46
@@ -8845,13 +8780,13 @@
   (local $163 i32)
   (local $164 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 440
+  i32.const 436
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 440
+  i32.const 436
   memory.fill
   block $~lib/date/Date.UTC|inlined.0 (result i64)
    i32.const 1970
@@ -11876,7 +11811,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -11885,11 +11820,6 @@
   i32.store offset=8
   local.get $164
   i32.const 2672
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11912,7 +11842,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -11921,11 +11851,6 @@
   i32.store offset=8
   local.get $164
   i32.const 2752
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11946,7 +11871,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -11955,11 +11880,6 @@
   i32.store offset=8
   local.get $164
   i32.const 2832
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11980,7 +11900,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -11989,11 +11909,6 @@
   i32.store offset=8
   local.get $164
   i32.const 2912
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12014,7 +11929,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -12023,11 +11938,6 @@
   i32.store offset=8
   local.get $164
   i32.const 2992
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12048,7 +11958,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -12057,11 +11967,6 @@
   i32.store offset=8
   local.get $164
   i32.const 3072
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12082,7 +11987,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -12091,11 +11996,6 @@
   i32.store offset=8
   local.get $164
   i32.const 3152
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12116,7 +12016,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -12125,11 +12025,6 @@
   i32.store offset=8
   local.get $164
   i32.const 3232
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12150,7 +12045,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -12159,11 +12054,6 @@
   i32.store offset=8
   local.get $164
   i32.const 3312
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12179,12 +12069,12 @@
   i64.const -61536067200000
   call $~lib/date/Date#constructor
   local.tee $124
-  i32.store offset=280
+  i32.store offset=276
   local.get $124
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toDateString
   local.set $164
@@ -12193,11 +12083,6 @@
   i32.store offset=8
   local.get $164
   i32.const 4240
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12213,12 +12098,12 @@
   i64.const 1580601600000
   call $~lib/date/Date#constructor
   local.tee $124
-  i32.store offset=280
+  i32.store offset=276
   local.get $124
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toDateString
   local.set $164
@@ -12227,11 +12112,6 @@
   i32.store offset=8
   local.get $164
   i32.const 4304
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12247,12 +12127,12 @@
   i64.const -62183116800000
   call $~lib/date/Date#constructor
   local.tee $124
-  i32.store offset=280
+  i32.store offset=276
   local.get $124
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toDateString
   local.set $164
@@ -12261,11 +12141,6 @@
   i32.store offset=8
   local.get $164
   i32.const 4368
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12281,12 +12156,12 @@
   i64.const -61536067200000
   call $~lib/date/Date#constructor
   local.tee $125
-  i32.store offset=284
+  i32.store offset=280
   local.get $125
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toTimeString
   local.set $164
@@ -12295,11 +12170,6 @@
   i32.store offset=8
   local.get $164
   i32.const 4480
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12315,12 +12185,12 @@
   i64.const 253402300799999
   call $~lib/date/Date#constructor
   local.tee $125
-  i32.store offset=284
+  i32.store offset=280
   local.get $125
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toTimeString
   local.set $164
@@ -12329,11 +12199,6 @@
   i32.store offset=8
   local.get $164
   i32.const 4528
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12349,12 +12214,12 @@
   i64.const -61536067200000
   call $~lib/date/Date#constructor
   local.tee $126
-  i32.store offset=288
+  i32.store offset=284
   local.get $126
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toUTCString
   local.set $164
@@ -12363,11 +12228,6 @@
   i32.store offset=8
   local.get $164
   i32.const 5424
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12383,12 +12243,12 @@
   i64.const 1580741613467
   call $~lib/date/Date#constructor
   local.tee $126
-  i32.store offset=288
+  i32.store offset=284
   local.get $126
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toUTCString
   local.set $164
@@ -12397,11 +12257,6 @@
   i32.store offset=8
   local.get $164
   i32.const 5504
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12417,12 +12272,12 @@
   i64.const -62183116800000
   call $~lib/date/Date#constructor
   local.tee $126
-  i32.store offset=288
+  i32.store offset=284
   local.get $126
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toUTCString
   local.set $164
@@ -12431,11 +12286,6 @@
   i32.store offset=8
   local.get $164
   i32.const 5584
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12448,19 +12298,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 5664
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.26 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $128
-   i32.store offset=296
+   i32.store offset=292
    local.get $128
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12483,19 +12328,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 5936
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.27 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $129
-   i32.store offset=300
+   i32.store offset=296
    local.get $129
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12518,19 +12358,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 5984
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.28 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $130
-   i32.store offset=304
+   i32.store offset=300
    local.get $130
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12553,19 +12388,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6032
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.29 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $131
-   i32.store offset=308
+   i32.store offset=304
    local.get $131
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12588,19 +12418,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6096
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.30 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $132
-   i32.store offset=312
+   i32.store offset=308
    local.get $132
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12623,19 +12448,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6176
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.31 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $133
-   i32.store offset=316
+   i32.store offset=312
    local.get $133
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12658,19 +12478,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6256
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.32 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $134
-   i32.store offset=320
+   i32.store offset=316
    local.get $134
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12693,19 +12508,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6336
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.33 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $135
-   i32.store offset=324
+   i32.store offset=320
    local.get $135
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12728,19 +12538,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6416
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.34 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $136
-   i32.store offset=328
+   i32.store offset=324
    local.get $136
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12763,19 +12568,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6480
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.35 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $137
-   i32.store offset=332
+   i32.store offset=328
    local.get $137
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12798,19 +12598,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6560
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.36 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $138
-   i32.store offset=336
+   i32.store offset=332
    local.get $138
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12833,19 +12628,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6640
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.37 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $139
-   i32.store offset=340
+   i32.store offset=336
    local.get $139
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12868,19 +12658,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6720
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.38 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $140
-   i32.store offset=344
+   i32.store offset=340
    local.get $140
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12903,19 +12688,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6800
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.39 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $141
-   i32.store offset=348
+   i32.store offset=344
    local.get $141
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12938,19 +12718,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6896
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.40 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $142
-   i32.store offset=352
+   i32.store offset=348
    local.get $142
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -12973,19 +12748,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6928
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.41 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $143
-   i32.store offset=356
+   i32.store offset=352
    local.get $143
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13008,19 +12778,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6960
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.42 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $144
-   i32.store offset=360
+   i32.store offset=356
    local.get $144
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13043,19 +12808,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6992
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.43 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $145
-   i32.store offset=364
+   i32.store offset=360
    local.get $145
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13078,19 +12838,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 5664
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.44 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $146
-   i32.store offset=368
+   i32.store offset=364
    local.get $146
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13113,19 +12868,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 7040
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.45 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $147
-   i32.store offset=372
+   i32.store offset=368
    local.get $147
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13148,19 +12898,14 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 6032
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
   call $~lib/date/Date.fromString
   local.tee $127
-  i32.store offset=292
+  i32.store offset=288
   block $~lib/date/Date#getTime|inlined.46 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $127
    local.tee $148
-   i32.store offset=376
+   i32.store offset=372
    local.get $148
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13186,18 +12931,18 @@
   i64.const -8640000000000000
   call $~lib/date/Date#constructor
   local.tee $149
-  i32.store offset=380
+  i32.store offset=376
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 8640000000000000
   call $~lib/date/Date#constructor
   local.tee $150
-  i32.store offset=384
+  i32.store offset=380
   block $~lib/date/Date#getTime|inlined.47 (result i64)
    global.get $~lib/memory/__stack_pointer
    local.get $149
    local.tee $151
-   i32.store offset=388
+   i32.store offset=384
    local.get $151
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13222,7 +12967,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $150
    local.tee $152
-   i32.store offset=392
+   i32.store offset=388
    local.get $152
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13247,7 +12992,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $149
    local.tee $153
-   i32.store offset=396
+   i32.store offset=392
    local.get $153
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13272,7 +13017,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $150
    local.tee $154
-   i32.store offset=400
+   i32.store offset=396
    local.get $154
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13297,7 +13042,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $149
    local.tee $155
-   i32.store offset=404
+   i32.store offset=400
    local.get $155
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13324,7 +13069,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $150
    local.tee $156
-   i32.store offset=408
+   i32.store offset=404
    local.get $156
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13351,7 +13096,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $149
    local.tee $157
-   i32.store offset=412
+   i32.store offset=408
    local.get $157
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13376,7 +13121,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $150
    local.tee $158
-   i32.store offset=416
+   i32.store offset=412
    local.get $158
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13401,7 +13146,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -13410,11 +13155,6 @@
   i32.store offset=8
   local.get $164
   i32.const 7104
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13429,7 +13169,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -13438,11 +13178,6 @@
   i32.store offset=8
   local.get $164
   i32.const 7184
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13460,7 +13195,7 @@
   i64.sub
   call $~lib/date/Date#constructor
   local.tee $159
-  i32.store offset=420
+  i32.store offset=416
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const -8640000000000000
@@ -13468,12 +13203,12 @@
   i64.add
   call $~lib/date/Date#constructor
   local.tee $160
-  i32.store offset=424
+  i32.store offset=420
   block $~lib/date/Date#getUTCFullYear|inlined.9 (result i32)
    global.get $~lib/memory/__stack_pointer
    local.get $160
    local.tee $161
-   i32.store offset=428
+   i32.store offset=424
    local.get $161
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13498,7 +13233,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $160
    local.tee $162
-   i32.store offset=432
+   i32.store offset=428
    local.get $162
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13525,7 +13260,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $160
    local.tee $163
-   i32.store offset=436
+   i32.store offset=432
    local.get $163
    local.set $164
    global.get $~lib/memory/__stack_pointer
@@ -13622,7 +13357,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -13631,11 +13366,6 @@
   i32.store offset=8
   local.get $164
   i32.const 7264
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13650,7 +13380,7 @@
   local.set $164
   global.get $~lib/memory/__stack_pointer
   local.get $164
-  i32.store offset=276
+  i32.store offset=272
   local.get $164
   call $~lib/date/Date#toISOString
   local.set $164
@@ -13659,11 +13389,6 @@
   i32.store offset=8
   local.get $164
   i32.const 7344
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13675,7 +13400,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 440
+  i32.const 436
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -3269,7 +3269,7 @@
   (local $6 i32)
   (local $7 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -3278,17 +3278,14 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    local.get $0
    call $~lib/number/I32#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1872
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -3402,7 +3399,7 @@
     local.set $0
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
@@ -3998,9 +3995,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 3616
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    i32.const 3616
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
    global.get $~lib/memory/__stack_pointer
@@ -4351,9 +4345,6 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 5152
   i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3456
-  i32.store offset=48
   i32.const 5152
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   global.get $~lib/memory/__stack_pointer
@@ -4464,9 +4455,6 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 5456
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3456
-  i32.store offset=28
   i32.const 5456
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   global.get $~lib/memory/__stack_pointer
@@ -4804,9 +4792,6 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6368
   i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3456
-  i32.store offset=72
   i32.const 6368
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   global.get $~lib/memory/__stack_pointer
@@ -5829,9 +5814,6 @@
          global.get $~lib/memory/__stack_pointer
          local.get $2
          i32.store offset=4
-         global.get $~lib/memory/__stack_pointer
-         i32.const 3456
-         i32.store offset=24
          local.get $2
          i32.const 3456
          call $~lib/array/Array<~lib/string/String>#push
@@ -5901,9 +5883,6 @@
        global.get $~lib/memory/__stack_pointer
        local.get $2
        i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 3456
-       i32.store offset=24
        local.get $2
        i32.const 3456
        call $~lib/array/Array<~lib/string/String>#push
@@ -6091,7 +6070,7 @@
   (local $11 i32)
   (local $12 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 76
+  i32.const 72
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -6101,7 +6080,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 76
+   i32.const 72
    memory.fill
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -6121,17 +6100,15 @@
     call $~lib/builtins/abort
     unreachable
    end
+   local.get $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3488
-   i32.store offset=8
    local.get $0
-   local.tee $1
    i32.const 3488
    i32.const 0
    call $~lib/string/String#indexOf
@@ -6160,12 +6137,12 @@
     i32.const 1
     i32.add
     call $~lib/string/String#substring@varargs
-    local.tee $0
-    i32.store offset=12
+    local.tee $2
+    i32.store offset=8
     global.get $~lib/memory/__stack_pointer
-    local.get $0
+    local.get $2
     i32.store
-    local.get $0
+    local.get $2
     i32.const 20
     i32.sub
     i32.load offset=16
@@ -6180,7 +6157,7 @@
      i32.ge_s
      if
       global.get $~lib/memory/__stack_pointer
-      local.get $0
+      local.get $2
       i32.store
       global.get $~lib/memory/__stack_pointer
       i32.const 4
@@ -6194,11 +6171,11 @@
       i32.const 0
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $0
+      local.get $2
       i32.store
       block $__inlined_func$~lib/string/String#charCodeAt$386
        local.get $3
-       local.get $0
+       local.get $2
        i32.const 20
        i32.sub
        i32.load offset=16
@@ -6211,39 +6188,39 @@
         i32.add
         global.set $~lib/memory/__stack_pointer
         i32.const -1
-        local.set $2
+        local.set $0
         br $__inlined_func$~lib/string/String#charCodeAt$386
        end
-       local.get $0
+       local.get $2
        local.get $3
        i32.const 1
        i32.shl
        i32.add
        i32.load16_u
-       local.set $2
+       local.set $0
        global.get $~lib/memory/__stack_pointer
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
       end
       block $for-break0
-       local.get $2
+       local.get $0
        i32.const 90
        i32.eq
        br_if $for-break0
-       local.get $2
+       local.get $0
        i32.const 45
        i32.eq
-       local.get $2
+       local.get $0
        i32.const 43
        i32.eq
        i32.or
        if
         global.get $~lib/memory/__stack_pointer
-        local.get $0
+        local.get $2
         i32.store
         local.get $3
-        local.get $0
+        local.get $2
         i32.const 20
         i32.sub
         i32.load offset=16
@@ -6261,13 +6238,10 @@
          unreachable
         end
         global.get $~lib/memory/__stack_pointer
-        local.get $0
+        local.get $2
         i32.store
-        global.get $~lib/memory/__stack_pointer
-        i32.const 3520
-        i32.store offset=8
         i32.const 0
-        local.get $0
+        local.get $2
         i32.const 3520
         local.get $3
         i32.const 1
@@ -6279,15 +6253,15 @@
         i32.xor
         if (result i32)
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $2
          i32.store
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $2
          local.get $5
          local.get $7
          call $~lib/string/String#substring
          local.tee $5
-         i32.store offset=16
+         i32.store offset=12
          global.get $~lib/memory/__stack_pointer
          local.get $5
          i32.store
@@ -6295,18 +6269,18 @@
          call $~lib/util/string/strtol<i32>
          local.set $5
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $2
          i32.store
          i32.const 1
          global.set $~argumentsLength
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $2
          local.get $7
          i32.const 1
          i32.add
          call $~lib/string/String#substring@varargs
          local.tee $7
-         i32.store offset=20
+         i32.store offset=16
          global.get $~lib/memory/__stack_pointer
          local.get $7
          i32.store
@@ -6320,18 +6294,18 @@
          i32.mul
         else
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $2
          i32.store
          i32.const 1
          global.set $~argumentsLength
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $2
          local.get $3
          i32.const 1
          i32.add
          call $~lib/string/String#substring@varargs
          local.tee $5
-         i32.store offset=24
+         i32.store offset=20
          global.get $~lib/memory/__stack_pointer
          local.get $5
          i32.store
@@ -6343,7 +6317,7 @@
         local.tee $5
         i32.sub
         local.get $5
-        local.get $2
+        local.get $0
         i32.const 45
         i32.eq
         select
@@ -6357,31 +6331,28 @@
        br $for-loop|0
       end
       global.get $~lib/memory/__stack_pointer
-      local.get $0
+      local.get $2
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $0
+      local.get $2
       i32.const 0
       local.get $3
       call $~lib/string/String#substring
-      local.tee $0
-      i32.store offset=12
+      local.tee $2
+      i32.store offset=8
      end
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $0
+    local.get $2
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 3520
-    i32.store offset=8
     i32.const 1
     global.set $~argumentsLength
     global.get $~lib/memory/__stack_pointer
-    local.get $0
+    local.get $2
     i32.const 3520
     call $~lib/string/String#split@varargs
     local.tee $0
-    i32.store offset=28
+    i32.store offset=24
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
@@ -6406,7 +6377,7 @@
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $3
-    i32.store offset=32
+    i32.store offset=28
     global.get $~lib/memory/__stack_pointer
     local.get $3
     i32.store
@@ -6421,7 +6392,7 @@
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $7
-    i32.store offset=36
+    i32.store offset=32
     global.get $~lib/memory/__stack_pointer
     local.get $7
     i32.store
@@ -6440,13 +6411,10 @@
      i32.const 2
      call $~lib/array/Array<~lib/string/String>#__get
      local.tee $2
-     i32.store offset=40
+     i32.store offset=36
      global.get $~lib/memory/__stack_pointer
      local.get $2
      i32.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 3552
-     i32.store offset=8
      local.get $2
      i32.const 3552
      i32.const 0
@@ -6464,7 +6432,7 @@
       local.get $0
       call $~lib/string/String#substring
       local.tee $6
-      i32.store offset=44
+      i32.store offset=40
       global.get $~lib/memory/__stack_pointer
       local.get $6
       i32.store
@@ -6475,7 +6443,7 @@
       block $__inlined_func$~lib/string/String#substr$387 (result i32)
        global.get $~lib/memory/__stack_pointer
        local.get $2
-       i32.store offset=48
+       i32.store offset=44
        local.get $0
        i32.const 1
        i32.add
@@ -6561,9 +6529,6 @@
       global.get $~lib/memory/__stack_pointer
       local.get $0
       i32.store
-      global.get $~lib/memory/__stack_pointer
-      i32.const 1872
-      i32.store offset=8
       global.get $~lib/memory/__stack_pointer
       i32.const 8
       i32.sub
@@ -6680,7 +6645,7 @@
        local.set $0
       end
       local.get $0
-      i32.store offset=52
+      i32.store offset=48
       global.get $~lib/memory/__stack_pointer
       local.get $0
       i32.store
@@ -6690,7 +6655,7 @@
      else
       global.get $~lib/memory/__stack_pointer
       local.get $2
-      i32.store offset=56
+      i32.store offset=52
       global.get $~lib/memory/__stack_pointer
       local.get $2
       i32.store
@@ -6703,9 +6668,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1616
-   i32.store offset=8
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -6713,7 +6675,7 @@
    i32.const 1616
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=60
+   i32.store offset=56
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -6722,7 +6684,7 @@
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
    local.tee $1
-   i32.store offset=64
+   i32.store offset=60
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -6747,7 +6709,7 @@
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
     local.tee $1
-    i32.store offset=68
+    i32.store offset=64
     global.get $~lib/memory/__stack_pointer
     local.get $1
     i32.store
@@ -6766,7 +6728,7 @@
      i32.const 2
      call $~lib/array/Array<~lib/string/String>#__get
      local.tee $0
-     i32.store offset=72
+     i32.store offset=68
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
@@ -6791,7 +6753,7 @@
    i64.sub
    call $~lib/date/Date#constructor
    global.get $~lib/memory/__stack_pointer
-   i32.const 76
+   i32.const 72
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
@@ -6809,7 +6771,7 @@
   (local $2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 440
+  i32.const 436
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -6825,7 +6787,7 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 440
+  i32.const 436
   memory.fill
   block $folding-inner0
    i32.const 1970
@@ -9332,16 +9294,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3696
-   i32.store offset=272
    local.get $0
    i32.const 3696
    call $~lib/string/String.__eq
@@ -9361,16 +9320,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3776
-   i32.store offset=272
    local.get $0
    i32.const 3776
    call $~lib/string/String.__eq
@@ -9390,16 +9346,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3856
-   i32.store offset=272
    local.get $0
    i32.const 3856
    call $~lib/string/String.__eq
@@ -9419,16 +9372,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3936
-   i32.store offset=272
    local.get $0
    i32.const 3936
    call $~lib/string/String.__eq
@@ -9448,16 +9398,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4016
-   i32.store offset=272
    local.get $0
    i32.const 4016
    call $~lib/string/String.__eq
@@ -9477,16 +9424,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4096
-   i32.store offset=272
    local.get $0
    i32.const 4096
    call $~lib/string/String.__eq
@@ -9506,16 +9450,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4176
-   i32.store offset=272
    local.get $0
    i32.const 4176
    call $~lib/string/String.__eq
@@ -9535,16 +9476,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4256
-   i32.store offset=272
    local.get $0
    i32.const 4256
    call $~lib/string/String.__eq
@@ -9564,16 +9502,13 @@
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4336
-   i32.store offset=272
    local.get $0
    i32.const 4336
    call $~lib/string/String.__eq
@@ -9590,19 +9525,16 @@
    i64.const -61536067200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=280
+   i32.store offset=276
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toDateString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5264
-   i32.store offset=272
    local.get $0
    i32.const 5264
    call $~lib/string/String.__eq
@@ -9619,19 +9551,16 @@
    i64.const 1580601600000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=280
+   i32.store offset=276
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toDateString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5328
-   i32.store offset=272
    local.get $0
    i32.const 5328
    call $~lib/string/String.__eq
@@ -9648,19 +9577,16 @@
    i64.const -62183116800000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=280
+   i32.store offset=276
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toDateString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5392
-   i32.store offset=272
    local.get $0
    i32.const 5392
    call $~lib/string/String.__eq
@@ -9677,19 +9603,16 @@
    i64.const -61536067200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=284
+   i32.store offset=280
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toTimeString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5504
-   i32.store offset=272
    local.get $0
    i32.const 5504
    call $~lib/string/String.__eq
@@ -9706,19 +9629,16 @@
    i64.const 253402300799999
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=284
+   i32.store offset=280
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toTimeString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5552
-   i32.store offset=272
    local.get $0
    i32.const 5552
    call $~lib/string/String.__eq
@@ -9735,19 +9655,16 @@
    i64.const -61536067200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=288
+   i32.store offset=284
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toUTCString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6448
-   i32.store offset=272
    local.get $0
    i32.const 6448
    call $~lib/string/String.__eq
@@ -9764,19 +9681,16 @@
    i64.const 1580741613467
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=288
+   i32.store offset=284
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toUTCString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6528
-   i32.store offset=272
    local.get $0
    i32.const 6528
    call $~lib/string/String.__eq
@@ -9793,19 +9707,16 @@
    i64.const -62183116800000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=288
+   i32.store offset=284
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toUTCString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6608
-   i32.store offset=272
    local.get $0
    i32.const 6608
    call $~lib/string/String.__eq
@@ -9820,15 +9731,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 6688
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6688
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=296
+   i32.store offset=292
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9846,15 +9754,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 6960
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6960
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=300
+   i32.store offset=296
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9872,15 +9777,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7008
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7008
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=304
+   i32.store offset=300
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9898,15 +9800,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7056
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7056
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=308
+   i32.store offset=304
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9924,15 +9823,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7120
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7120
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=312
+   i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9950,15 +9846,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7200
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7200
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=316
+   i32.store offset=312
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9976,15 +9869,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7280
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7280
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=320
+   i32.store offset=316
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10002,15 +9892,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7360
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7360
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=324
+   i32.store offset=320
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10028,15 +9915,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7440
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7440
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=328
+   i32.store offset=324
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10054,15 +9938,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7504
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7504
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=332
+   i32.store offset=328
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10080,15 +9961,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7584
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7584
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=336
+   i32.store offset=332
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10106,15 +9984,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7664
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7664
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=340
+   i32.store offset=336
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10132,15 +10007,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7744
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7744
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=344
+   i32.store offset=340
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10158,15 +10030,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7824
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7824
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=348
+   i32.store offset=344
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10184,15 +10053,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7920
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7920
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=352
+   i32.store offset=348
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10210,15 +10076,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7952
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7952
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=356
+   i32.store offset=352
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10236,15 +10099,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7984
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7984
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=360
+   i32.store offset=356
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10262,15 +10122,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8016
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8016
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=364
+   i32.store offset=360
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10288,15 +10145,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 6688
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6688
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=368
+   i32.store offset=364
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10314,15 +10168,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8064
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8064
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=372
+   i32.store offset=368
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10340,15 +10191,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 7056
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7056
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=292
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=376
+   i32.store offset=372
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10368,15 +10216,15 @@
    i64.const -8640000000000000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=380
+   i32.store offset=376
    global.get $~lib/memory/__stack_pointer
    i64.const 8640000000000000
    call $~lib/date/Date#constructor
    local.tee $2
-   i32.store offset=384
+   i32.store offset=380
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=388
+   i32.store offset=384
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10394,7 +10242,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=392
+   i32.store offset=388
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10412,7 +10260,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=396
+   i32.store offset=392
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10430,7 +10278,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=400
+   i32.store offset=396
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10448,7 +10296,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=404
+   i32.store offset=400
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10466,7 +10314,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=408
+   i32.store offset=404
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10484,7 +10332,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=412
+   i32.store offset=408
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10502,7 +10350,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=416
+   i32.store offset=412
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10520,16 +10368,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8128
-   i32.store offset=272
    local.get $0
    i32.const 8128
    call $~lib/string/String.__eq
@@ -10544,16 +10389,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=276
+   i32.store offset=272
    local.get $2
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8208
-   i32.store offset=272
    local.get $0
    i32.const 8208
    call $~lib/string/String.__eq
@@ -10570,15 +10412,15 @@
    i64.const 8639999999999999
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=420
+   i32.store offset=416
    global.get $~lib/memory/__stack_pointer
    i64.const -8639999999999999
    call $~lib/date/Date#constructor
    local.tee $2
-   i32.store offset=424
+   i32.store offset=420
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=428
+   i32.store offset=424
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10596,7 +10438,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=432
+   i32.store offset=428
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10614,7 +10456,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=436
+   i32.store offset=432
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10686,16 +10528,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=276
+   i32.store offset=272
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8288
-   i32.store offset=272
    local.get $0
    i32.const 8288
    call $~lib/string/String.__eq
@@ -10710,16 +10549,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=276
+   i32.store offset=272
    local.get $2
    call $~lib/date/Date#toISOString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8368
-   i32.store offset=272
    local.get $0
    i32.const 8368
    call $~lib/string/String.__eq
@@ -10733,7 +10569,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 440
+   i32.const 436
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/hash.debug.wat
+++ b/tests/compiler/std/hash.debug.wat
@@ -198,6 +198,100 @@
   end
   return
  )
+ (func $start:std/hash
+  i32.const 0
+  call $~lib/util/hash/HASH<~lib/string/String|null>
+  call $std/hash/check
+  drop
+  i32.const 32
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 64
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 96
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 128
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 160
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 192
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 224
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 256
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 304
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  i32.const 352
+  call $~lib/util/hash/HASH<~lib/string/String>
+  call $std/hash/check
+  drop
+  f32.const 0
+  call $~lib/util/hash/HASH<f32>
+  call $std/hash/check
+  drop
+  f32.const 1
+  call $~lib/util/hash/HASH<f32>
+  call $std/hash/check
+  drop
+  f32.const 1.100000023841858
+  call $~lib/util/hash/HASH<f32>
+  call $std/hash/check
+  drop
+  f32.const -0
+  call $~lib/util/hash/HASH<f32>
+  call $std/hash/check
+  drop
+  f32.const inf
+  call $~lib/util/hash/HASH<f32>
+  call $std/hash/check
+  drop
+  f32.const nan:0x400000
+  call $~lib/util/hash/HASH<f32>
+  call $std/hash/check
+  drop
+  f64.const 0
+  call $~lib/util/hash/HASH<f64>
+  call $std/hash/check
+  drop
+  f64.const 1
+  call $~lib/util/hash/HASH<f64>
+  call $std/hash/check
+  drop
+  f64.const 1.1
+  call $~lib/util/hash/HASH<f64>
+  call $std/hash/check
+  drop
+  f64.const -0
+  call $~lib/util/hash/HASH<f64>
+  call $std/hash/check
+  drop
+  f64.const inf
+  call $~lib/util/hash/HASH<f64>
+  call $std/hash/check
+  drop
+  f64.const nan:0x8000000000000
+  call $~lib/util/hash/HASH<f64>
+  call $std/hash/check
+  drop
+ )
  (func $~start
   call $start:std/hash
  )
@@ -791,162 +885,5 @@
   global.set $~lib/memory/__stack_pointer
   local.get $19
   return
- )
- (func $start:std/hash
-  (local $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  i32.const 0
-  call $~lib/util/hash/HASH<~lib/string/String|null>
-  call $std/hash/check
-  drop
-  i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 64
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 96
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 160
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 192
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 224
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 256
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 304
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  i32.const 352
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $~lib/util/hash/HASH<~lib/string/String>
-  call $std/hash/check
-  drop
-  f32.const 0
-  call $~lib/util/hash/HASH<f32>
-  call $std/hash/check
-  drop
-  f32.const 1
-  call $~lib/util/hash/HASH<f32>
-  call $std/hash/check
-  drop
-  f32.const 1.100000023841858
-  call $~lib/util/hash/HASH<f32>
-  call $std/hash/check
-  drop
-  f32.const -0
-  call $~lib/util/hash/HASH<f32>
-  call $std/hash/check
-  drop
-  f32.const inf
-  call $~lib/util/hash/HASH<f32>
-  call $std/hash/check
-  drop
-  f32.const nan:0x400000
-  call $~lib/util/hash/HASH<f32>
-  call $std/hash/check
-  drop
-  f64.const 0
-  call $~lib/util/hash/HASH<f64>
-  call $std/hash/check
-  drop
-  f64.const 1
-  call $~lib/util/hash/HASH<f64>
-  call $std/hash/check
-  drop
-  f64.const 1.1
-  call $~lib/util/hash/HASH<f64>
-  call $std/hash/check
-  drop
-  f64.const -0
-  call $~lib/util/hash/HASH<f64>
-  call $std/hash/check
-  drop
-  f64.const inf
-  call $~lib/util/hash/HASH<f64>
-  call $std/hash/check
-  drop
-  f64.const nan:0x8000000000000
-  call $~lib/util/hash/HASH<f64>
-  call $std/hash/check
-  drop
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
 )

--- a/tests/compiler/std/hash.release.wat
+++ b/tests/compiler/std/hash.release.wat
@@ -28,80 +28,28 @@
  (export "memory" (memory $0))
  (start $~start)
  (func $~start
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1404
-  i32.lt_s
-  if
-   i32.const 34192
-   i32.const 34240
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
   i32.const 0
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store
   i32.const 1056
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1088
-  i32.store
   i32.const 1088
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1120
-  i32.store
   i32.const 1120
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1152
-  i32.store
   i32.const 1152
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1184
-  i32.store
   i32.const 1184
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1216
-  i32.store
   i32.const 1216
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1248
-  i32.store
   i32.const 1248
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1280
-  i32.store
   i32.const 1280
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1328
-  i32.store
   i32.const 1328
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1376
-  i32.store
   i32.const 1376
   call $~lib/util/hash/HASH<~lib/string/String|null>
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/util/hash/HASH<~lib/string/String|null> (param $0 i32)
   (local $1 i32)

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -4693,13 +4693,13 @@
  (func $std/operator-overloading/TesterElementAccess#__set (param $this i32) (param $key i32) (param $value i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $key
   local.set $3
   global.get $~lib/memory/__stack_pointer
@@ -4707,11 +4707,6 @@
   i32.store
   local.get $3
   i32.const 512
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=4
-  local.get $3
   call $~lib/string/String.__eq
   if
    local.get $this
@@ -4733,20 +4728,20 @@
    call $std/operator-overloading/TesterElementAccess#set:y
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/operator-overloading/TesterElementAccess#__get (param $this i32) (param $key i32) (result i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $key
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -4754,11 +4749,6 @@
   i32.store
   local.get $2
   i32.const 512
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   call $~lib/string/String.__eq
   if (result i32)
    local.get $this
@@ -4779,7 +4769,7 @@
   end
   local.set $2
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $2
@@ -4797,13 +4787,13 @@
   (local $8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 48
+  i32.const 40
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 48
+  i32.const 40
   memory.fill
   memory.size
   i32.const 16
@@ -6435,11 +6425,6 @@
   i32.store
   local.get $9
   i32.const 512
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=4
-  local.get $9
   i32.const -1
   call $std/operator-overloading/TesterElementAccess#__set
   global.get $std/operator-overloading/tea
@@ -6449,11 +6434,6 @@
   i32.store
   local.get $9
   i32.const 544
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=4
-  local.get $9
   i32.const -2
   call $std/operator-overloading/TesterElementAccess#__set
   global.get $std/operator-overloading/tea
@@ -6481,11 +6461,6 @@
   i32.store
   local.get $9
   i32.const 512
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=4
-  local.get $9
   call $std/operator-overloading/TesterElementAccess#__get
   i32.const -1
   i32.eq
@@ -6523,11 +6498,6 @@
   i32.store
   local.get $9
   i32.const 544
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=4
-  local.get $9
   call $std/operator-overloading/TesterElementAccess#__get
   i32.const -2
   i32.eq
@@ -6547,23 +6517,13 @@
   i32.store
   local.get $9
   i32.const 512
+  global.get $std/operator-overloading/tea
   local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $9
   i32.store offset=4
   local.get $9
-  global.get $std/operator-overloading/tea
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=40
-  local.get $9
   i32.const 512
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=44
-  local.get $9
   call $std/operator-overloading/TesterElementAccess#__get
   i32.const 1
   i32.add
@@ -6575,23 +6535,13 @@
   i32.store
   local.get $9
   i32.const 544
+  global.get $std/operator-overloading/tea
   local.set $9
   global.get $~lib/memory/__stack_pointer
   local.get $9
   i32.store offset=4
   local.get $9
-  global.get $std/operator-overloading/tea
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=40
-  local.get $9
   i32.const 544
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=44
-  local.get $9
   call $std/operator-overloading/TesterElementAccess#__get
   i32.const 1
   i32.sub
@@ -6603,11 +6553,6 @@
   i32.store
   local.get $9
   i32.const 512
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=4
-  local.get $9
   call $std/operator-overloading/TesterElementAccess#__get
   i32.const 0
   i32.eq
@@ -6627,11 +6572,6 @@
   i32.store
   local.get $9
   i32.const 544
-  local.set $9
-  global.get $~lib/memory/__stack_pointer
-  local.get $9
-  i32.store offset=4
-  local.get $9
   call $std/operator-overloading/TesterElementAccess#__get
   i32.const -3
   i32.eq
@@ -6645,7 +6585,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 48
+  i32.const 40
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -2414,7 +2414,7 @@
  )
  (func $std/operator-overloading/TesterElementAccess#__set (param $0 i32) (param $1 i32) (param $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2429,14 +2429,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1536
-  i32.store offset=4
   local.get $1
   call $~lib/string/String.__eq
   if
@@ -2455,13 +2452,13 @@
    i32.store offset=4
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
  (func $std/operator-overloading/TesterElementAccess#__get (param $0 i32) (param $1 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2476,14 +2473,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1536
-  i32.store offset=4
   local.get $1
   call $~lib/string/String.__eq
   if (result i32)
@@ -2500,7 +2494,7 @@
    i32.load offset=4
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -2509,7 +2503,7 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 48
+  i32.const 40
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -2519,7 +2513,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 48
+   i32.const 40
    memory.fill
    memory.size
    i32.const 16
@@ -4768,9 +4762,6 @@
    global.get $std/operator-overloading/tea
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1536
-   i32.store offset=4
    local.get $0
    i32.const 1536
    i32.const -1
@@ -4779,9 +4770,6 @@
    global.get $std/operator-overloading/tea
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=4
    local.get $0
    i32.const 1568
    i32.const -2
@@ -4806,9 +4794,6 @@
    global.get $std/operator-overloading/tea
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1536
-   i32.store offset=4
    local.get $0
    i32.const 1536
    call $std/operator-overloading/TesterElementAccess#__get
@@ -4842,9 +4827,6 @@
    global.get $std/operator-overloading/tea
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=4
    local.get $0
    i32.const 1568
    call $std/operator-overloading/TesterElementAccess#__get
@@ -4863,15 +4845,9 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 1536
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
    global.get $std/operator-overloading/tea
    local.tee $1
-   i32.store offset=40
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1536
-   i32.store offset=44
+   i32.store offset=4
    local.get $0
    i32.const 1536
    local.get $1
@@ -4885,15 +4861,9 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
    global.get $std/operator-overloading/tea
    local.tee $1
-   i32.store offset=40
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=44
+   i32.store offset=4
    local.get $0
    i32.const 1568
    local.get $1
@@ -4906,9 +4876,6 @@
    global.get $std/operator-overloading/tea
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1536
-   i32.store offset=4
    local.get $0
    i32.const 1536
    call $std/operator-overloading/TesterElementAccess#__get
@@ -4924,9 +4891,6 @@
    global.get $std/operator-overloading/tea
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1568
-   i32.store offset=4
    local.get $0
    i32.const 1568
    call $std/operator-overloading/TesterElementAccess#__get
@@ -4941,7 +4905,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 48
+   i32.const 40
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -5785,13 +5785,13 @@
  (func $~lib/staticarray/StaticArray<~lib/string/String>#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -5799,15 +5799,10 @@
   i32.store
   local.get $1
   i32.const 1936
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -7564,13 +7559,13 @@
   (local $51 i32)
   (local $52 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 108
+  i32.const 104
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 108
+  i32.const 104
   memory.fill
   global.get $std/staticarray/arr1
   local.set $52
@@ -8332,7 +8327,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -8342,11 +8337,6 @@
   i32.store
   local.get $52
   i32.const 1120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8361,7 +8351,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 1
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -8371,11 +8361,6 @@
   i32.store
   local.get $52
   i32.const 1152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8530,7 +8515,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -8540,11 +8525,6 @@
   i32.store
   local.get $52
   i32.const 1216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8619,7 +8599,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -8629,11 +8609,6 @@
   i32.store
   local.get $52
   i32.const 1152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -8759,11 +8734,6 @@
   i32.store
   local.get $52
   i32.const 1120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 1
@@ -8784,11 +8754,6 @@
   i32.store
   local.get $52
   i32.const 1520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   i32.const 0
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 0
@@ -8809,11 +8774,6 @@
   i32.store
   local.get $52
   i32.const 1216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   i32.const 5
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 0
@@ -8834,11 +8794,6 @@
   i32.store
   local.get $52
   i32.const 1216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   i32.const -1
   call $~lib/staticarray/StaticArray<~lib/string/String>#includes
   i32.const 1
@@ -9147,14 +9102,9 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 1936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=76
-  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9162,11 +9112,6 @@
   i32.store
   local.get $52
   i32.const 1968
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9181,14 +9126,9 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 1904
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=76
-  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9196,11 +9136,6 @@
   i32.store
   local.get $52
   i32.const 2016
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9215,14 +9150,9 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 2064
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=76
-  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9230,11 +9160,6 @@
   i32.store
   local.get $52
   i32.const 2096
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9249,14 +9174,9 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=48
+  i32.store offset=24
   local.get $52
   i32.const 2144
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=76
-  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9264,11 +9184,6 @@
   i32.store
   local.get $52
   i32.const 2176
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=24
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -9286,11 +9201,6 @@
   i32.store offset=48
   local.get $52
   i32.const 1936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=76
-  local.get $52
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9325,7 +9235,7 @@
   i32.const 2240
   call $~lib/rt/__newBuffer
   local.tee $39
-  i32.store offset=80
+  i32.store offset=76
   local.get $39
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9383,7 +9293,7 @@
   i32.const 2272
   call $~lib/rt/__newBuffer
   local.tee $41
-  i32.store offset=84
+  i32.store offset=80
   local.get $41
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9455,7 +9365,7 @@
   i32.const 2304
   call $~lib/rt/__newBuffer
   local.tee $43
-  i32.store offset=88
+  i32.store offset=84
   local.get $43
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9570,7 +9480,7 @@
   i32.const 2352
   call $~lib/rt/__newBuffer
   local.tee $45
-  i32.store offset=92
+  i32.store offset=88
   global.get $~lib/memory/__stack_pointer
   local.get $45
   local.set $52
@@ -9586,7 +9496,7 @@
   local.get $52
   call $~lib/staticarray/StaticArray<i32>#map<i32>
   local.tee $46
-  i32.store offset=96
+  i32.store offset=92
   local.get $46
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9684,7 +9594,7 @@
   local.get $52
   call $~lib/staticarray/StaticArray<i32>#filter
   local.tee $47
-  i32.store offset=100
+  i32.store offset=96
   local.get $47
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -9987,7 +9897,7 @@
   i32.const 2800
   call $~lib/rt/__newBuffer
   local.tee $51
-  i32.store offset=104
+  i32.store offset=100
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -10079,7 +9989,7 @@
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 108
+  i32.const 104
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -4952,7 +4952,7 @@
   (local $8 i32)
   (local $9 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 108
+  i32.const 104
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -4962,7 +4962,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 108
+   i32.const 104
    memory.fill
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
@@ -5857,7 +5857,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=24
    local.get $0
    i32.const 0
    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -5865,9 +5865,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2144
-   i32.store offset=24
    local.get $1
    i32.const 2144
    call $~lib/string/String.__eq
@@ -5882,7 +5879,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=24
    local.get $0
    i32.const 1
    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -5890,9 +5887,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2176
-   i32.store offset=24
    local.get $0
    i32.const 2176
    call $~lib/string/String.__eq
@@ -6042,7 +6036,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=24
    local.get $0
    i32.const 0
    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -6050,9 +6044,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2240
-   i32.store offset=24
    local.get $0
    i32.const 2240
    call $~lib/string/String.__eq
@@ -6123,7 +6114,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=48
+   i32.store offset=24
    local.get $0
    i32.const 0
    call $~lib/staticarray/StaticArray<~lib/string/String>#__get
@@ -6131,9 +6122,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2176
-   i32.store offset=24
    local.get $0
    i32.const 2176
    call $~lib/string/String.__eq
@@ -6251,9 +6239,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2144
-   i32.store offset=24
    local.get $1
    i32.const 2144
    i32.const 0
@@ -6271,9 +6256,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2544
-   i32.store offset=24
    local.get $1
    i32.const 2544
    i32.const 0
@@ -6289,9 +6271,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2240
-   i32.store offset=24
    local.get $1
    i32.const 2240
    i32.const 5
@@ -6307,9 +6286,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2240
-   i32.store offset=24
    local.get $1
    i32.const 2240
    i32.const -1
@@ -6711,10 +6687,7 @@
    i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2960
-   i32.store offset=76
+   i32.store offset=24
    local.get $1
    i32.const 2960
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
@@ -6722,9 +6695,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2992
-   i32.store offset=24
    local.get $0
    i32.const 2992
    call $~lib/string/String.__eq
@@ -6739,10 +6709,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2928
-   i32.store offset=76
+   i32.store offset=24
    local.get $1
    i32.const 2928
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
@@ -6750,9 +6717,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3040
-   i32.store offset=24
    local.get $0
    i32.const 3040
    call $~lib/string/String.__eq
@@ -6767,10 +6731,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3088
-   i32.store offset=76
+   i32.store offset=24
    local.get $1
    i32.const 3088
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
@@ -6778,9 +6739,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3120
-   i32.store offset=24
    local.get $0
    i32.const 3120
    call $~lib/string/String.__eq
@@ -6795,10 +6753,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3168
-   i32.store offset=76
+   i32.store offset=24
    local.get $1
    i32.const 3168
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
@@ -6806,9 +6761,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3200
-   i32.store offset=24
    local.get $0
    i32.const 3200
    call $~lib/string/String.__eq
@@ -6824,9 +6776,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2960
-   i32.store offset=76
    local.get $1
    i32.const 2960
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
@@ -6838,7 +6787,7 @@
    local.get $1
    i32.store offset=48
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -6846,20 +6795,17 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2960
-   i32.store offset=4
    local.get $1
    i32.const 2960
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
    local.set $1
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -6886,7 +6832,7 @@
    i64.load align=1
    i64.store align=1
    local.get $1
-   i32.store offset=80
+   i32.store offset=76
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -6999,7 +6945,7 @@
    i32.const 12
    memory.copy
    local.get $1
-   i32.store offset=84
+   i32.store offset=80
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -7133,7 +7079,7 @@
    i32.const 20
    memory.copy
    local.get $1
-   i32.store offset=88
+   i32.store offset=84
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -7309,7 +7255,7 @@
    i32.const 12
    memory.copy
    local.get $2
-   i32.store offset=92
+   i32.store offset=88
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $2
@@ -7392,7 +7338,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $6
-   i32.store offset=96
+   i32.store offset=92
    global.get $~lib/memory/__stack_pointer
    local.get $6
    i32.store
@@ -7523,7 +7469,7 @@
    local.get $2
    call $~lib/staticarray/StaticArray<i32>#filter
    local.tee $0
-   i32.store offset=100
+   i32.store offset=96
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -7882,7 +7828,7 @@
    i32.const 16
    memory.copy
    local.get $1
-   i32.store offset=104
+   i32.store offset=100
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
@@ -8044,7 +7990,7 @@
    i32.add
    global.set $~lib/rt/itcms/threshold
    global.get $~lib/memory/__stack_pointer
-   i32.const 108
+   i32.const 104
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -4820,13 +4820,13 @@
   (local $9 i64)
   (local $10 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 28
+  i32.const 20
   memory.fill
   memory.size
   i32.const 16
@@ -4846,11 +4846,6 @@
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
   i32.const 32
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -4858,11 +4853,6 @@
   i32.store
   local.get $10
   i32.const 32
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4874,11 +4864,6 @@
    unreachable
   end
   i32.const 32
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -4886,11 +4871,6 @@
   i32.store
   local.get $10
   i32.const 32
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4902,11 +4882,6 @@
    unreachable
   end
   i32.const 10784
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -4914,11 +4889,6 @@
   i32.store
   local.get $10
   i32.const 10832
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4930,11 +4900,6 @@
    unreachable
   end
   i32.const 10880
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -4942,11 +4907,6 @@
   i32.store
   local.get $10
   i32.const 10928
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4958,11 +4918,6 @@
    unreachable
   end
   i32.const 10976
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -4970,11 +4925,6 @@
   i32.store
   local.get $10
   i32.const 11072
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4986,11 +4936,6 @@
    unreachable
   end
   i32.const 11072
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -4998,11 +4943,6 @@
   i32.store
   local.get $10
   i32.const 11168
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5014,11 +4954,6 @@
    unreachable
   end
   i32.const 11264
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5026,11 +4961,6 @@
   i32.store
   local.get $10
   i32.const 11328
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5042,11 +4972,6 @@
    unreachable
   end
   i32.const 11328
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5054,11 +4979,6 @@
   i32.store
   local.get $10
   i32.const 11392
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5070,11 +4990,6 @@
    unreachable
   end
   i32.const 11456
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5082,11 +4997,6 @@
   i32.store
   local.get $10
   i32.const 11552
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5098,11 +5008,6 @@
    unreachable
   end
   i32.const 11552
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5110,11 +5015,6 @@
   i32.store
   local.get $10
   i32.const 11648
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5126,11 +5026,6 @@
    unreachable
   end
   i32.const 11744
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5138,11 +5033,6 @@
   i32.store
   local.get $10
   i32.const 11840
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5154,11 +5044,6 @@
    unreachable
   end
   i32.const 11840
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5166,11 +5051,6 @@
   i32.store
   local.get $10
   i32.const 11936
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5182,11 +5062,6 @@
    unreachable
   end
   i32.const 12032
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5194,11 +5069,6 @@
   i32.store
   local.get $10
   i32.const 12112
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5210,11 +5080,6 @@
    unreachable
   end
   i32.const 12192
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5222,11 +5087,6 @@
   i32.store
   local.get $10
   i32.const 12272
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5238,11 +5098,6 @@
    unreachable
   end
   i32.const 12352
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5250,11 +5105,6 @@
   i32.store
   local.get $10
   i32.const 12416
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5266,11 +5116,6 @@
    unreachable
   end
   i32.const 12480
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5278,11 +5123,6 @@
   i32.store
   local.get $10
   i32.const 12560
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5294,11 +5134,6 @@
    unreachable
   end
   i32.const 12640
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5306,11 +5141,6 @@
   i32.store
   local.get $10
   i32.const 12720
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5322,11 +5152,6 @@
    unreachable
   end
   i32.const 12800
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5334,11 +5159,6 @@
   i32.store
   local.get $10
   i32.const 12864
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5350,11 +5170,6 @@
    unreachable
   end
   i32.const 12928
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5362,11 +5177,6 @@
   i32.store
   local.get $10
   i32.const 13008
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5378,11 +5188,6 @@
    unreachable
   end
   i32.const 13088
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5390,11 +5195,6 @@
   i32.store
   local.get $10
   i32.const 13168
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5406,11 +5206,6 @@
    unreachable
   end
   i32.const 13248
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5418,11 +5213,6 @@
   i32.store
   local.get $10
   i32.const 13408
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5434,11 +5224,6 @@
    unreachable
   end
   i32.const 13248
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5446,11 +5231,6 @@
   i32.store
   local.get $10
   i32.const 13568
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5462,11 +5242,6 @@
    unreachable
   end
   i32.const 13728
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5474,11 +5249,6 @@
   i32.store
   local.get $10
   i32.const 13760
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5490,11 +5260,6 @@
    unreachable
   end
   i32.const 13792
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5502,11 +5267,6 @@
   i32.store
   local.get $10
   i32.const 13824
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5518,11 +5278,6 @@
    unreachable
   end
   i32.const 13856
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5530,11 +5285,6 @@
   i32.store
   local.get $10
   i32.const 14064
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5546,16 +5296,11 @@
    unreachable
   end
   i32.const 13728
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=12
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $10
-  i32.store offset=8
+  i32.store offset=4
   local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
@@ -5564,11 +5309,6 @@
   i32.store
   local.get $10
   i32.const 14272
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5580,16 +5320,11 @@
    unreachable
   end
   i32.const 14304
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=12
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $10
-  i32.store offset=8
+  i32.store offset=4
   local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
@@ -5598,11 +5333,6 @@
   i32.store
   local.get $10
   i32.const 14336
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5614,16 +5344,11 @@
    unreachable
   end
   i32.const 14368
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=12
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $10
-  i32.store offset=8
+  i32.store offset=4
   local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
@@ -5632,11 +5357,6 @@
   i32.store
   local.get $10
   i32.const 14368
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5652,7 +5372,7 @@
   local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $10
-  i32.store offset=8
+  i32.store offset=4
   local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
@@ -5661,11 +5381,6 @@
   i32.store
   local.get $10
   i32.const 14624
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5681,7 +5396,7 @@
   local.set $10
   global.get $~lib/memory/__stack_pointer
   local.get $10
-  i32.store offset=8
+  i32.store offset=4
   local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
@@ -5690,11 +5405,6 @@
   i32.store
   local.get $10
   i32.const 14624
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5706,11 +5416,6 @@
    unreachable
   end
   i32.const 14656
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5718,11 +5423,6 @@
   i32.store
   local.get $10
   i32.const 14688
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5734,11 +5434,6 @@
    unreachable
   end
   i32.const 14720
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5746,11 +5441,6 @@
   i32.store
   local.get $10
   i32.const 14752
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5762,11 +5452,6 @@
    unreachable
   end
   i32.const 14784
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5774,11 +5459,6 @@
   i32.store
   local.get $10
   i32.const 14816
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5790,11 +5470,6 @@
    unreachable
   end
   i32.const 14848
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5802,11 +5477,6 @@
   i32.store
   local.get $10
   i32.const 14880
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5818,11 +5488,6 @@
    unreachable
   end
   i32.const 14912
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5830,11 +5495,6 @@
   i32.store
   local.get $10
   i32.const 14944
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5846,11 +5506,6 @@
    unreachable
   end
   i32.const 14976
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5858,11 +5513,6 @@
   i32.store
   local.get $10
   i32.const 15008
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5874,11 +5524,6 @@
    unreachable
   end
   i32.const 15040
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5886,11 +5531,6 @@
   i32.store
   local.get $10
   i32.const 15072
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5902,11 +5542,6 @@
    unreachable
   end
   i32.const 15104
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5914,11 +5549,6 @@
   i32.store
   local.get $10
   i32.const 15136
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5930,11 +5560,6 @@
    unreachable
   end
   i32.const 15168
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5942,11 +5567,6 @@
   i32.store
   local.get $10
   i32.const 15200
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5958,11 +5578,6 @@
    unreachable
   end
   i32.const 15232
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5970,11 +5585,6 @@
   i32.store
   local.get $10
   i32.const 15264
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5986,11 +5596,6 @@
    unreachable
   end
   i32.const 15296
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -5998,11 +5603,6 @@
   i32.store
   local.get $10
   i32.const 15328
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6014,11 +5614,6 @@
    unreachable
   end
   i32.const 15360
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6026,11 +5621,6 @@
   i32.store
   local.get $10
   i32.const 15392
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6042,11 +5632,6 @@
    unreachable
   end
   i32.const 15424
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6054,11 +5639,6 @@
   i32.store
   local.get $10
   i32.const 15456
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6070,11 +5650,6 @@
    unreachable
   end
   i32.const 15488
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6082,11 +5657,6 @@
   i32.store
   local.get $10
   i32.const 15520
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6098,11 +5668,6 @@
    unreachable
   end
   i32.const 15552
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6110,11 +5675,6 @@
   i32.store
   local.get $10
   i32.const 15584
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6126,11 +5686,6 @@
    unreachable
   end
   i32.const 15616
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6138,11 +5693,6 @@
   i32.store
   local.get $10
   i32.const 15648
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6154,11 +5704,6 @@
    unreachable
   end
   i32.const 15680
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6166,11 +5711,6 @@
   i32.store
   local.get $10
   i32.const 15712
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6182,11 +5722,6 @@
    unreachable
   end
   i32.const 15744
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6194,11 +5729,6 @@
   i32.store
   local.get $10
   i32.const 15776
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6210,11 +5740,6 @@
    unreachable
   end
   i32.const 15808
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6222,11 +5747,6 @@
   i32.store
   local.get $10
   i32.const 15840
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6238,11 +5758,6 @@
    unreachable
   end
   i32.const 15872
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6250,11 +5765,6 @@
   i32.store
   local.get $10
   i32.const 15904
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6266,11 +5776,6 @@
    unreachable
   end
   i32.const 15936
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6278,11 +5783,6 @@
   i32.store
   local.get $10
   i32.const 15968
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6294,11 +5794,6 @@
    unreachable
   end
   i32.const 16000
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6306,11 +5801,6 @@
   i32.store
   local.get $10
   i32.const 16032
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6322,11 +5812,6 @@
    unreachable
   end
   i32.const 16064
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6334,11 +5819,6 @@
   i32.store
   local.get $10
   i32.const 16096
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6350,11 +5830,6 @@
    unreachable
   end
   i32.const 16128
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6362,11 +5837,6 @@
   i32.store
   local.get $10
   i32.const 16160
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6378,11 +5848,6 @@
    unreachable
   end
   i32.const 16192
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6390,11 +5855,6 @@
   i32.store
   local.get $10
   i32.const 16224
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6406,11 +5866,6 @@
    unreachable
   end
   i32.const 16256
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6418,11 +5873,6 @@
   i32.store
   local.get $10
   i32.const 15328
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6434,11 +5884,6 @@
    unreachable
   end
   i32.const 16288
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6446,11 +5891,6 @@
   i32.store
   local.get $10
   i32.const 16320
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6462,11 +5902,6 @@
    unreachable
   end
   i32.const 16352
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6474,11 +5909,6 @@
   i32.store
   local.get $10
   i32.const 16384
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6490,11 +5920,6 @@
    unreachable
   end
   i32.const 16416
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6502,11 +5927,6 @@
   i32.store
   local.get $10
   i32.const 16448
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6518,11 +5938,6 @@
    unreachable
   end
   i32.const 16480
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6530,11 +5945,6 @@
   i32.store
   local.get $10
   i32.const 16512
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6546,11 +5956,6 @@
    unreachable
   end
   i32.const 16544
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6558,11 +5963,6 @@
   i32.store
   local.get $10
   i32.const 16576
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6574,11 +5974,6 @@
    unreachable
   end
   i32.const 16608
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6586,11 +5981,6 @@
   i32.store
   local.get $10
   i32.const 16640
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6602,11 +5992,6 @@
    unreachable
   end
   i32.const 16672
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6614,11 +5999,6 @@
   i32.store
   local.get $10
   i32.const 16704
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6630,11 +6010,6 @@
    unreachable
   end
   i32.const 16736
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6642,11 +6017,6 @@
   i32.store
   local.get $10
   i32.const 16768
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6658,11 +6028,6 @@
    unreachable
   end
   i32.const 16800
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6670,11 +6035,6 @@
   i32.store
   local.get $10
   i32.const 16832
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6686,11 +6046,6 @@
    unreachable
   end
   i32.const 16864
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6698,11 +6053,6 @@
   i32.store
   local.get $10
   i32.const 16896
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6714,11 +6064,6 @@
    unreachable
   end
   i32.const 16928
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6726,11 +6071,6 @@
   i32.store
   local.get $10
   i32.const 16960
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6742,11 +6082,6 @@
    unreachable
   end
   i32.const 16992
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toLowerCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6754,11 +6089,6 @@
   i32.store
   local.get $10
   i32.const 17024
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6770,11 +6100,6 @@
    unreachable
   end
   i32.const 17056
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6782,11 +6107,6 @@
   i32.store
   local.get $10
   i32.const 17088
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6798,11 +6118,6 @@
    unreachable
   end
   i32.const 14304
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6810,11 +6125,6 @@
   i32.store
   local.get $10
   i32.const 17120
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6826,11 +6136,6 @@
    unreachable
   end
   i32.const 17152
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6838,11 +6143,6 @@
   i32.store
   local.get $10
   i32.const 17184
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6854,11 +6154,6 @@
    unreachable
   end
   i32.const 17216
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6866,11 +6161,6 @@
   i32.store
   local.get $10
   i32.const 17248
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6882,11 +6172,6 @@
    unreachable
   end
   i32.const 17280
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6894,11 +6179,6 @@
   i32.store
   local.get $10
   i32.const 17312
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6910,11 +6190,6 @@
    unreachable
   end
   i32.const 17344
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6922,11 +6197,6 @@
   i32.store
   local.get $10
   i32.const 17376
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6938,11 +6208,6 @@
    unreachable
   end
   i32.const 17408
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6950,11 +6215,6 @@
   i32.store
   local.get $10
   i32.const 17376
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6966,11 +6226,6 @@
    unreachable
   end
   i32.const 17440
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -6978,11 +6233,6 @@
   i32.store
   local.get $10
   i32.const 17472
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6994,11 +6244,6 @@
    unreachable
   end
   i32.const 17504
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -7006,11 +6251,6 @@
   i32.store
   local.get $10
   i32.const 17536
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7022,11 +6262,6 @@
    unreachable
   end
   i32.const 17568
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -7034,11 +6269,6 @@
   i32.store
   local.get $10
   i32.const 17600
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7050,11 +6280,6 @@
    unreachable
   end
   i32.const 17632
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -7062,11 +6287,6 @@
   i32.store
   local.get $10
   i32.const 17664
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7078,11 +6298,6 @@
    unreachable
   end
   i32.const 17696
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -7090,11 +6305,6 @@
   i32.store
   local.get $10
   i32.const 17728
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7106,11 +6316,6 @@
    unreachable
   end
   i32.const 17760
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=8
-  local.get $10
   call $~lib/string/String#toUpperCase
   local.set $10
   global.get $~lib/memory/__stack_pointer
@@ -7118,11 +6323,6 @@
   i32.store
   local.get $10
   i32.const 17792
-  local.set $10
-  global.get $~lib/memory/__stack_pointer
-  local.get $10
-  i32.store offset=4
-  local.get $10
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -7144,7 +6344,7 @@
     local.get $0
     call $~lib/string/String.fromCodePoint
     local.tee $1
-    i32.store offset=16
+    i32.store offset=8
     global.get $~lib/memory/__stack_pointer
     local.get $1
     local.set $10
@@ -7154,7 +6354,7 @@
     local.get $10
     call $~lib/string/String#toLowerCase
     local.tee $2
-    i32.store offset=20
+    i32.store offset=12
     global.get $~lib/memory/__stack_pointer
     local.get $1
     local.set $10
@@ -7164,7 +6364,7 @@
     local.get $10
     call $~lib/string/String#toUpperCase
     local.tee $3
-    i32.store offset=24
+    i32.store offset=16
     local.get $2
     local.set $10
     global.get $~lib/memory/__stack_pointer
@@ -7340,11 +6540,6 @@
     i64.ne
     if
      i32.const 17824
-     local.set $10
-     global.get $~lib/memory/__stack_pointer
-     local.get $10
-     i32.store
-     local.get $10
      i32.const 1
      local.get $0
      f64.convert_i32_s
@@ -7354,18 +6549,13 @@
      f64.const 0
      call $~lib/builtins/trace
      i32.const 17920
-     local.set $10
-     global.get $~lib/memory/__stack_pointer
-     local.get $10
-     i32.store offset=4
-     local.get $10
      local.get $6
      i32.const 10
      call $~lib/number/I64#toString
      local.set $10
      global.get $~lib/memory/__stack_pointer
      local.get $10
-     i32.store offset=8
+     i32.store offset=4
      local.get $10
      call $~lib/string/String.__concat
      local.set $10
@@ -7381,18 +6571,13 @@
      f64.const 0
      call $~lib/builtins/trace
      i32.const 19760
-     local.set $10
-     global.get $~lib/memory/__stack_pointer
-     local.get $10
-     i32.store offset=4
-     local.get $10
      local.get $8
      i32.const 10
      call $~lib/number/I64#toString
      local.set $10
      global.get $~lib/memory/__stack_pointer
      local.get $10
-     i32.store offset=8
+     i32.store offset=4
      local.get $10
      call $~lib/string/String.__concat
      local.set $10
@@ -7413,11 +6598,6 @@
     i64.ne
     if
      i32.const 19824
-     local.set $10
-     global.get $~lib/memory/__stack_pointer
-     local.get $10
-     i32.store
-     local.get $10
      i32.const 1
      local.get $0
      f64.convert_i32_s
@@ -7427,18 +6607,13 @@
      f64.const 0
      call $~lib/builtins/trace
      i32.const 19920
-     local.set $10
-     global.get $~lib/memory/__stack_pointer
-     local.get $10
-     i32.store offset=4
-     local.get $10
      local.get $7
      i32.const 10
      call $~lib/number/I64#toString
      local.set $10
      global.get $~lib/memory/__stack_pointer
      local.get $10
-     i32.store offset=8
+     i32.store offset=4
      local.get $10
      call $~lib/string/String.__concat
      local.set $10
@@ -7454,18 +6629,13 @@
      f64.const 0
      call $~lib/builtins/trace
      i32.const 19984
-     local.set $10
-     global.get $~lib/memory/__stack_pointer
-     local.get $10
-     i32.store offset=4
-     local.get $10
      local.get $9
      i32.const 10
      call $~lib/number/I64#toString
      local.set $10
      global.get $~lib/memory/__stack_pointer
      local.get $10
-     i32.store offset=8
+     i32.store offset=4
      local.get $10
      call $~lib/string/String.__concat
      local.set $10
@@ -7489,7 +6659,7 @@
    end
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 20
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -3553,7 +3553,7 @@
   (local $6 i32)
   (local $7 i64)
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -3569,7 +3569,7 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 28
+  i32.const 20
   memory.fill
   memory.size
   i32.const 16
@@ -3603,18 +3603,12 @@
   i32.store
   i32.const 1376
   global.set $~lib/rt/itcms/fromSpace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=8
   i32.const 1056
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   local.get $5
   i32.const 1056
   call $~lib/string/String.__eq
@@ -3627,18 +3621,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=8
   i32.const 1056
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   local.get $5
   i32.const 1056
   call $~lib/string/String.__eq
@@ -3651,18 +3639,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11808
-  i32.store offset=8
   i32.const 11808
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11856
-  i32.store offset=4
   local.get $5
   i32.const 11856
   call $~lib/string/String.__eq
@@ -3675,18 +3657,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11904
-  i32.store offset=8
   i32.const 11904
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 11952
-  i32.store offset=4
   local.get $5
   i32.const 11952
   call $~lib/string/String.__eq
@@ -3699,18 +3675,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12000
-  i32.store offset=8
   i32.const 12000
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12096
-  i32.store offset=4
   local.get $5
   i32.const 12096
   call $~lib/string/String.__eq
@@ -3723,18 +3693,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12096
-  i32.store offset=8
   i32.const 12096
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12192
-  i32.store offset=4
   local.get $5
   i32.const 12192
   call $~lib/string/String.__eq
@@ -3747,18 +3711,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12288
-  i32.store offset=8
   i32.const 12288
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12352
-  i32.store offset=4
   local.get $5
   i32.const 12352
   call $~lib/string/String.__eq
@@ -3771,18 +3729,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12352
-  i32.store offset=8
   i32.const 12352
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12416
-  i32.store offset=4
   local.get $5
   i32.const 12416
   call $~lib/string/String.__eq
@@ -3795,18 +3747,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12480
-  i32.store offset=8
   i32.const 12480
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12576
-  i32.store offset=4
   local.get $5
   i32.const 12576
   call $~lib/string/String.__eq
@@ -3819,18 +3765,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12576
-  i32.store offset=8
   i32.const 12576
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12672
-  i32.store offset=4
   local.get $5
   i32.const 12672
   call $~lib/string/String.__eq
@@ -3843,18 +3783,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12768
-  i32.store offset=8
   i32.const 12768
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12864
-  i32.store offset=4
   local.get $5
   i32.const 12864
   call $~lib/string/String.__eq
@@ -3867,18 +3801,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12864
-  i32.store offset=8
   i32.const 12864
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12960
-  i32.store offset=4
   local.get $5
   i32.const 12960
   call $~lib/string/String.__eq
@@ -3891,18 +3819,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13056
-  i32.store offset=8
   i32.const 13056
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13136
-  i32.store offset=4
   local.get $5
   i32.const 13136
   call $~lib/string/String.__eq
@@ -3915,18 +3837,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13216
-  i32.store offset=8
   i32.const 13216
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13296
-  i32.store offset=4
   local.get $5
   i32.const 13296
   call $~lib/string/String.__eq
@@ -3939,18 +3855,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13376
-  i32.store offset=8
   i32.const 13376
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13440
-  i32.store offset=4
   local.get $5
   i32.const 13440
   call $~lib/string/String.__eq
@@ -3963,18 +3873,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13504
-  i32.store offset=8
   i32.const 13504
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13584
-  i32.store offset=4
   local.get $5
   i32.const 13584
   call $~lib/string/String.__eq
@@ -3987,18 +3891,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13664
-  i32.store offset=8
   i32.const 13664
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13744
-  i32.store offset=4
   local.get $5
   i32.const 13744
   call $~lib/string/String.__eq
@@ -4011,18 +3909,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13824
-  i32.store offset=8
   i32.const 13824
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13888
-  i32.store offset=4
   local.get $5
   i32.const 13888
   call $~lib/string/String.__eq
@@ -4035,18 +3927,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 13952
-  i32.store offset=8
   i32.const 13952
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14032
-  i32.store offset=4
   local.get $5
   i32.const 14032
   call $~lib/string/String.__eq
@@ -4059,18 +3945,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14112
-  i32.store offset=8
   i32.const 14112
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14192
-  i32.store offset=4
   local.get $5
   i32.const 14192
   call $~lib/string/String.__eq
@@ -4083,18 +3963,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14272
-  i32.store offset=8
   i32.const 14272
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14432
-  i32.store offset=4
   local.get $5
   i32.const 14432
   call $~lib/string/String.__eq
@@ -4107,18 +3981,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14272
-  i32.store offset=8
   i32.const 14272
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14592
-  i32.store offset=4
   local.get $5
   i32.const 14592
   call $~lib/string/String.__eq
@@ -4131,18 +3999,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14752
-  i32.store offset=8
   i32.const 14752
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14784
-  i32.store offset=4
   local.get $5
   i32.const 14784
   call $~lib/string/String.__eq
@@ -4155,18 +4017,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14816
-  i32.store offset=8
   i32.const 14816
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14848
-  i32.store offset=4
   local.get $5
   i32.const 14848
   call $~lib/string/String.__eq
@@ -4179,18 +4035,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14880
-  i32.store offset=8
   i32.const 14880
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15088
-  i32.store offset=4
   local.get $5
   i32.const 15088
   call $~lib/string/String.__eq
@@ -4203,24 +4053,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 14752
-  i32.store offset=12
   i32.const 14752
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=8
+  i32.store offset=4
   local.get $5
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15296
-  i32.store offset=4
   local.get $5
   i32.const 15296
   call $~lib/string/String.__eq
@@ -4233,24 +4077,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15328
-  i32.store offset=12
   i32.const 15328
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=8
+  i32.store offset=4
   local.get $5
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15360
-  i32.store offset=4
   local.get $5
   i32.const 15360
   call $~lib/string/String.__eq
@@ -4263,24 +4101,18 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15392
-  i32.store offset=12
   i32.const 15392
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=8
+  i32.store offset=4
   local.get $5
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15392
-  i32.store offset=4
   local.get $5
   i32.const 15392
   call $~lib/string/String.__eq
@@ -4298,16 +4130,13 @@
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=8
+  i32.store offset=4
   local.get $5
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15648
-  i32.store offset=4
   local.get $5
   i32.const 15648
   call $~lib/string/String.__eq
@@ -4325,16 +4154,13 @@
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=8
+  i32.store offset=4
   local.get $5
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15648
-  i32.store offset=4
   local.get $5
   i32.const 15648
   call $~lib/string/String.__eq
@@ -4347,18 +4173,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15680
-  i32.store offset=8
   i32.const 15680
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15712
-  i32.store offset=4
   local.get $5
   i32.const 15712
   call $~lib/string/String.__eq
@@ -4371,18 +4191,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15744
-  i32.store offset=8
   i32.const 15744
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15776
-  i32.store offset=4
   local.get $5
   i32.const 15776
   call $~lib/string/String.__eq
@@ -4395,18 +4209,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15808
-  i32.store offset=8
   i32.const 15808
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15840
-  i32.store offset=4
   local.get $5
   i32.const 15840
   call $~lib/string/String.__eq
@@ -4419,18 +4227,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15872
-  i32.store offset=8
   i32.const 15872
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15904
-  i32.store offset=4
   local.get $5
   i32.const 15904
   call $~lib/string/String.__eq
@@ -4443,18 +4245,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15936
-  i32.store offset=8
   i32.const 15936
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15968
-  i32.store offset=4
   local.get $5
   i32.const 15968
   call $~lib/string/String.__eq
@@ -4467,18 +4263,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16000
-  i32.store offset=8
   i32.const 16000
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16032
-  i32.store offset=4
   local.get $5
   i32.const 16032
   call $~lib/string/String.__eq
@@ -4491,18 +4281,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16064
-  i32.store offset=8
   i32.const 16064
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16096
-  i32.store offset=4
   local.get $5
   i32.const 16096
   call $~lib/string/String.__eq
@@ -4515,18 +4299,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16128
-  i32.store offset=8
   i32.const 16128
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16160
-  i32.store offset=4
   local.get $5
   i32.const 16160
   call $~lib/string/String.__eq
@@ -4539,18 +4317,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16192
-  i32.store offset=8
   i32.const 16192
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16224
-  i32.store offset=4
   local.get $5
   i32.const 16224
   call $~lib/string/String.__eq
@@ -4563,18 +4335,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16256
-  i32.store offset=8
   i32.const 16256
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16288
-  i32.store offset=4
   local.get $5
   i32.const 16288
   call $~lib/string/String.__eq
@@ -4587,18 +4353,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16320
-  i32.store offset=8
   i32.const 16320
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16352
-  i32.store offset=4
   local.get $5
   i32.const 16352
   call $~lib/string/String.__eq
@@ -4611,18 +4371,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16384
-  i32.store offset=8
   i32.const 16384
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16416
-  i32.store offset=4
   local.get $5
   i32.const 16416
   call $~lib/string/String.__eq
@@ -4635,18 +4389,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16448
-  i32.store offset=8
   i32.const 16448
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16480
-  i32.store offset=4
   local.get $5
   i32.const 16480
   call $~lib/string/String.__eq
@@ -4659,18 +4407,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16512
-  i32.store offset=8
   i32.const 16512
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16544
-  i32.store offset=4
   local.get $5
   i32.const 16544
   call $~lib/string/String.__eq
@@ -4683,18 +4425,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16576
-  i32.store offset=8
   i32.const 16576
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16608
-  i32.store offset=4
   local.get $5
   i32.const 16608
   call $~lib/string/String.__eq
@@ -4707,18 +4443,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16640
-  i32.store offset=8
   i32.const 16640
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16672
-  i32.store offset=4
   local.get $5
   i32.const 16672
   call $~lib/string/String.__eq
@@ -4731,18 +4461,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16704
-  i32.store offset=8
   i32.const 16704
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16736
-  i32.store offset=4
   local.get $5
   i32.const 16736
   call $~lib/string/String.__eq
@@ -4755,18 +4479,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16768
-  i32.store offset=8
   i32.const 16768
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16800
-  i32.store offset=4
   local.get $5
   i32.const 16800
   call $~lib/string/String.__eq
@@ -4779,18 +4497,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16832
-  i32.store offset=8
   i32.const 16832
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16864
-  i32.store offset=4
   local.get $5
   i32.const 16864
   call $~lib/string/String.__eq
@@ -4803,18 +4515,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16896
-  i32.store offset=8
   i32.const 16896
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16928
-  i32.store offset=4
   local.get $5
   i32.const 16928
   call $~lib/string/String.__eq
@@ -4827,18 +4533,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16960
-  i32.store offset=8
   i32.const 16960
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16992
-  i32.store offset=4
   local.get $5
   i32.const 16992
   call $~lib/string/String.__eq
@@ -4851,18 +4551,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17024
-  i32.store offset=8
   i32.const 17024
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17056
-  i32.store offset=4
   local.get $5
   i32.const 17056
   call $~lib/string/String.__eq
@@ -4875,18 +4569,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17088
-  i32.store offset=8
   i32.const 17088
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17120
-  i32.store offset=4
   local.get $5
   i32.const 17120
   call $~lib/string/String.__eq
@@ -4899,18 +4587,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17152
-  i32.store offset=8
   i32.const 17152
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17184
-  i32.store offset=4
   local.get $5
   i32.const 17184
   call $~lib/string/String.__eq
@@ -4923,18 +4605,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17216
-  i32.store offset=8
   i32.const 17216
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17248
-  i32.store offset=4
   local.get $5
   i32.const 17248
   call $~lib/string/String.__eq
@@ -4947,18 +4623,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17280
-  i32.store offset=8
   i32.const 17280
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 16352
-  i32.store offset=4
   local.get $5
   i32.const 16352
   call $~lib/string/String.__eq
@@ -4971,18 +4641,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17312
-  i32.store offset=8
   i32.const 17312
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17344
-  i32.store offset=4
   local.get $5
   i32.const 17344
   call $~lib/string/String.__eq
@@ -4995,18 +4659,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17376
-  i32.store offset=8
   i32.const 17376
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17408
-  i32.store offset=4
   local.get $5
   i32.const 17408
   call $~lib/string/String.__eq
@@ -5019,18 +4677,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17440
-  i32.store offset=8
   i32.const 17440
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17472
-  i32.store offset=4
   local.get $5
   i32.const 17472
   call $~lib/string/String.__eq
@@ -5043,18 +4695,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17504
-  i32.store offset=8
   i32.const 17504
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17536
-  i32.store offset=4
   local.get $5
   i32.const 17536
   call $~lib/string/String.__eq
@@ -5067,18 +4713,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17568
-  i32.store offset=8
   i32.const 17568
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17600
-  i32.store offset=4
   local.get $5
   i32.const 17600
   call $~lib/string/String.__eq
@@ -5091,18 +4731,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17632
-  i32.store offset=8
   i32.const 17632
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17664
-  i32.store offset=4
   local.get $5
   i32.const 17664
   call $~lib/string/String.__eq
@@ -5115,18 +4749,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17696
-  i32.store offset=8
   i32.const 17696
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17728
-  i32.store offset=4
   local.get $5
   i32.const 17728
   call $~lib/string/String.__eq
@@ -5139,18 +4767,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17760
-  i32.store offset=8
   i32.const 17760
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17792
-  i32.store offset=4
   local.get $5
   i32.const 17792
   call $~lib/string/String.__eq
@@ -5163,18 +4785,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17824
-  i32.store offset=8
   i32.const 17824
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17856
-  i32.store offset=4
   local.get $5
   i32.const 17856
   call $~lib/string/String.__eq
@@ -5187,18 +4803,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17888
-  i32.store offset=8
   i32.const 17888
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17920
-  i32.store offset=4
   local.get $5
   i32.const 17920
   call $~lib/string/String.__eq
@@ -5211,18 +4821,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17952
-  i32.store offset=8
   i32.const 17952
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 17984
-  i32.store offset=4
   local.get $5
   i32.const 17984
   call $~lib/string/String.__eq
@@ -5235,18 +4839,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18016
-  i32.store offset=8
   i32.const 18016
   call $~lib/string/String#toLowerCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18048
-  i32.store offset=4
   local.get $5
   i32.const 18048
   call $~lib/string/String.__eq
@@ -5259,18 +4857,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18080
-  i32.store offset=8
   i32.const 18080
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18112
-  i32.store offset=4
   local.get $5
   i32.const 18112
   call $~lib/string/String.__eq
@@ -5283,18 +4875,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 15328
-  i32.store offset=8
   i32.const 15328
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18144
-  i32.store offset=4
   local.get $5
   i32.const 18144
   call $~lib/string/String.__eq
@@ -5307,18 +4893,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18176
-  i32.store offset=8
   i32.const 18176
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18208
-  i32.store offset=4
   local.get $5
   i32.const 18208
   call $~lib/string/String.__eq
@@ -5331,18 +4911,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18240
-  i32.store offset=8
   i32.const 18240
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18272
-  i32.store offset=4
   local.get $5
   i32.const 18272
   call $~lib/string/String.__eq
@@ -5355,18 +4929,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18304
-  i32.store offset=8
   i32.const 18304
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18336
-  i32.store offset=4
   local.get $5
   i32.const 18336
   call $~lib/string/String.__eq
@@ -5379,18 +4947,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18368
-  i32.store offset=8
   i32.const 18368
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18400
-  i32.store offset=4
   local.get $5
   i32.const 18400
   call $~lib/string/String.__eq
@@ -5403,18 +4965,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18432
-  i32.store offset=8
   i32.const 18432
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18400
-  i32.store offset=4
   local.get $5
   i32.const 18400
   call $~lib/string/String.__eq
@@ -5427,18 +4983,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18464
-  i32.store offset=8
   i32.const 18464
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18496
-  i32.store offset=4
   local.get $5
   i32.const 18496
   call $~lib/string/String.__eq
@@ -5451,18 +5001,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18528
-  i32.store offset=8
   i32.const 18528
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18560
-  i32.store offset=4
   local.get $5
   i32.const 18560
   call $~lib/string/String.__eq
@@ -5475,18 +5019,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18592
-  i32.store offset=8
   i32.const 18592
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18624
-  i32.store offset=4
   local.get $5
   i32.const 18624
   call $~lib/string/String.__eq
@@ -5499,18 +5037,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18656
-  i32.store offset=8
   i32.const 18656
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18688
-  i32.store offset=4
   local.get $5
   i32.const 18688
   call $~lib/string/String.__eq
@@ -5523,18 +5055,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18720
-  i32.store offset=8
   i32.const 18720
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18752
-  i32.store offset=4
   local.get $5
   i32.const 18752
   call $~lib/string/String.__eq
@@ -5547,18 +5073,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18784
-  i32.store offset=8
   i32.const 18784
   call $~lib/string/String#toUpperCase
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 18816
-  i32.store offset=4
   local.get $5
   i32.const 18816
   call $~lib/string/String.__eq
@@ -5580,7 +5100,7 @@
     local.get $4
     call $~lib/string/String.fromCodePoint
     local.tee $5
-    i32.store offset=16
+    i32.store offset=8
     global.get $~lib/memory/__stack_pointer
     local.get $5
     i32.store
@@ -5588,7 +5108,7 @@
     local.get $5
     call $~lib/string/String#toLowerCase
     local.tee $6
-    i32.store offset=20
+    i32.store offset=12
     global.get $~lib/memory/__stack_pointer
     local.get $5
     i32.store
@@ -5596,7 +5116,7 @@
     local.get $5
     call $~lib/string/String#toUpperCase
     local.tee $5
-    i32.store offset=24
+    i32.store offset=16
     global.get $~lib/memory/__stack_pointer
     local.get $6
     i32.store
@@ -5765,9 +5285,6 @@
     local.get $3
     i64.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 18848
-     i32.store
      i32.const 18848
      i32.const 1
      local.get $4
@@ -5777,15 +5294,12 @@
      f64.const 0
      f64.const 0
      call $~lib/builtins/trace
-     global.get $~lib/memory/__stack_pointer
-     i32.const 18944
-     i32.store offset=4
      local.get $1
      call $~lib/util/number/itoa64
      local.set $5
      global.get $~lib/memory/__stack_pointer
      local.get $5
-     i32.store offset=8
+     i32.store offset=4
      i32.const 18944
      local.get $5
      call $~lib/string/String.__concat
@@ -5801,15 +5315,12 @@
      f64.const 0
      f64.const 0
      call $~lib/builtins/trace
-     global.get $~lib/memory/__stack_pointer
-     i32.const 20784
-     i32.store offset=4
      local.get $3
      call $~lib/util/number/itoa64
      local.set $5
      global.get $~lib/memory/__stack_pointer
      local.get $5
-     i32.store offset=8
+     i32.store offset=4
      i32.const 20784
      local.get $5
      call $~lib/string/String.__concat
@@ -5830,9 +5341,6 @@
     local.get $2
     i64.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 20848
-     i32.store
      i32.const 20848
      i32.const 1
      local.get $4
@@ -5842,15 +5350,12 @@
      f64.const 0
      f64.const 0
      call $~lib/builtins/trace
-     global.get $~lib/memory/__stack_pointer
-     i32.const 20944
-     i32.store offset=4
      local.get $2
      call $~lib/util/number/itoa64
      local.set $5
      global.get $~lib/memory/__stack_pointer
      local.get $5
-     i32.store offset=8
+     i32.store offset=4
      i32.const 20944
      local.get $5
      call $~lib/string/String.__concat
@@ -5866,15 +5371,12 @@
      f64.const 0
      f64.const 0
      call $~lib/builtins/trace
-     global.get $~lib/memory/__stack_pointer
-     i32.const 21008
-     i32.store offset=4
      local.get $0
      call $~lib/util/number/itoa64
      local.set $5
      global.get $~lib/memory/__stack_pointer
      local.get $5
-     i32.store offset=8
+     i32.store offset=4
      i32.const 21008
      local.get $5
      call $~lib/string/String.__concat
@@ -5899,7 +5401,7 @@
    end
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 28
+  i32.const 20
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -2859,6 +2859,41 @@
   i32.const 0
   drop
  )
+ (func $start:std/string-encoding
+  call $std/string-encoding/testUTF16Length
+  memory.size
+  i32.const 16
+  i32.shl
+  global.get $~lib/memory/__heap_base
+  i32.sub
+  i32.const 1
+  i32.shr_u
+  global.set $~lib/rt/itcms/threshold
+  i32.const 240
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/pinSpace
+  i32.const 272
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/toSpace
+  i32.const 416
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/fromSpace
+  call $std/string-encoding/testUTF16Encode
+  call $std/string-encoding/testUTF16Decode
+  call $std/string-encoding/testUTF16DecodeUnsafe
+  call $std/string-encoding/testUTF8Length
+  call $std/string-encoding/testUTF8Encode
+  call $std/string-encoding/testUTF8EncodeNullTerminated
+  call $std/string-encoding/testUTF8ErrorMode
+  call $std/string-encoding/testUTF8Decode
+  call $std/string-encoding/testUTF8DecodeNullTerminated
+  call $std/string-encoding/testUTF8DecodeUnsafe
+  i32.const 1088
+  call $std/string-encoding/testRoundtrip
+  i32.const 14208
+  call $std/string-encoding/testRoundtrip
+  call $~lib/rt/itcms/__collect
+ )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   global.get $std/string-encoding/str
@@ -3435,11 +3470,6 @@
   i32.store
   local.get $3
   i32.const 528
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3483,11 +3513,6 @@
   i32.store
   local.get $3
   i32.const 560
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3509,11 +3534,6 @@
   i32.store
   local.get $3
   i32.const 592
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3535,11 +3555,6 @@
   i32.store
   local.get $3
   i32.const 624
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3561,11 +3576,6 @@
   i32.store
   local.get $3
   i32.const 656
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3587,11 +3597,6 @@
   i32.store
   local.get $3
   i32.const 528
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4204,7 +4209,7 @@
   (local $str i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
@@ -4212,15 +4217,7 @@
   i64.const 0
   i64.store
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
   i32.const 880
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/string/String.UTF8.encode
@@ -4232,7 +4229,7 @@
   i32.const 0
   call $~lib/string/String.UTF8.decode
   local.tee $str
-  i32.store offset=8
+  i32.store offset=4
   local.get $str
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4240,11 +4237,6 @@
   i32.store
   local.get $1
   i32.const 880
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4257,11 +4249,6 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 880
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/string/String.UTF8.encode
@@ -4273,7 +4260,7 @@
   i32.const 0
   call $~lib/string/String.UTF8.decode
   local.tee $str
-  i32.store offset=8
+  i32.store offset=4
   local.get $str
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4281,11 +4268,6 @@
   i32.store
   local.get $1
   i32.const 912
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4298,11 +4280,6 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 944
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   i32.const 0
   i32.const 0
   call $~lib/string/String.UTF8.encode
@@ -4314,7 +4291,7 @@
   i32.const 0
   call $~lib/string/String.UTF8.decode
   local.tee $str
-  i32.store offset=8
+  i32.store offset=4
   local.get $str
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4322,11 +4299,6 @@
   i32.store
   local.get $1
   i32.const 944
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4339,11 +4311,6 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 944
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   i32.const 0
   i32.const 1
   call $~lib/string/String.UTF8.encode
@@ -4355,7 +4322,7 @@
   i32.const 0
   call $~lib/string/String.UTF8.decode
   local.tee $str
-  i32.store offset=8
+  i32.store offset=4
   local.get $str
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4363,11 +4330,6 @@
   i32.store
   local.get $1
   i32.const 912
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4379,7 +4341,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -4710,11 +4672,6 @@
   i32.store
   local.get $3
   i32.const 528
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4760,11 +4717,6 @@
   i32.store
   local.get $3
   i32.const 560
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4787,11 +4739,6 @@
   i32.store
   local.get $3
   i32.const 624
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4814,11 +4761,6 @@
   i32.store
   local.get $3
   i32.const 656
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4841,11 +4783,6 @@
   i32.store
   local.get $3
   i32.const 528
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4868,11 +4805,6 @@
   i32.store
   local.get $3
   i32.const 1056
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4895,11 +4827,6 @@
   i32.store
   local.get $3
   i32.const 656
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4922,11 +4849,6 @@
   i32.store
   local.get $3
   i32.const 528
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5038,64 +4960,6 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 20
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
- (func $start:std/string-encoding
-  (local $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  call $std/string-encoding/testUTF16Length
-  memory.size
-  i32.const 16
-  i32.shl
-  global.get $~lib/memory/__heap_base
-  i32.sub
-  i32.const 1
-  i32.shr_u
-  global.set $~lib/rt/itcms/threshold
-  i32.const 240
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/pinSpace
-  i32.const 272
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/toSpace
-  i32.const 416
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/fromSpace
-  call $std/string-encoding/testUTF16Encode
-  call $std/string-encoding/testUTF16Decode
-  call $std/string-encoding/testUTF16DecodeUnsafe
-  call $std/string-encoding/testUTF8Length
-  call $std/string-encoding/testUTF8Encode
-  call $std/string-encoding/testUTF8EncodeNullTerminated
-  call $std/string-encoding/testUTF8ErrorMode
-  call $std/string-encoding/testUTF8Decode
-  call $std/string-encoding/testUTF8DecodeNullTerminated
-  call $std/string-encoding/testUTF8DecodeUnsafe
-  i32.const 1088
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $std/string-encoding/testRoundtrip
-  i32.const 14208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  call $std/string-encoding/testRoundtrip
-  call $~lib/rt/itcms/__collect
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -158,7 +158,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$156
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$158
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -182,7 +182,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$156
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$158
     end
     local.get $1
     i32.load offset=8
@@ -1653,50 +1653,15 @@
   end
   local.get $2
  )
- (func $~lib/rt/__visit_members (param $0 i32)
-  block $invalid
-   block $~lib/arraybuffer/ArrayBufferView
-    block $~lib/string/String
-     block $~lib/arraybuffer/ArrayBuffer
-      block $~lib/object/Object
-       local.get $0
-       i32.const 8
-       i32.sub
-       i32.load
-       br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $invalid
-      end
-      return
-     end
-     return
-    end
-    return
-   end
-   local.get $0
-   i32.load
-   call $~lib/rt/itcms/__visit
-   return
-  end
-  unreachable
- )
- (func $~start
+ (func $start:std/string-encoding
   (local $0 i32)
   (local $1 i32)
+  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22804
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    i32.const 22804
    i32.lt_s
@@ -1985,7 +1950,182 @@
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   call $std/string-encoding/testUTF16DecodeUnsafe
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 22804
+   i32.lt_s
+   br_if $folding-inner1
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1056
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1056
+   call $~lib/string/String.UTF16.encode
+   local.tee $1
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1056
+   i32.store
+   i32.const 1052
+   i32.load
+   local.set $2
+   local.get $1
+   i32.const 0
+   call $~lib/string/String.UTF16.decodeUnsafe
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 1552
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1088
+    i32.const 42
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   local.get $2
+   call $~lib/string/String.UTF16.decodeUnsafe
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1056
+   i32.store offset=8
+   local.get $0
+   i32.const 1056
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1088
+    i32.const 43
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 4
+   call $~lib/string/String.UTF16.decodeUnsafe
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 1584
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1088
+    i32.const 44
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 4
+   i32.add
+   i32.const 2
+   call $~lib/string/String.UTF16.decodeUnsafe
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 1616
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1088
+    i32.const 45
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 4
+   i32.add
+   i32.const 4
+   call $~lib/string/String.UTF16.decodeUnsafe
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 1648
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1088
+    i32.const 46
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 8
+   i32.add
+   i32.const 4
+   call $~lib/string/String.UTF16.decodeUnsafe
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 1680
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1088
+    i32.const 47
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 12
+   i32.add
+   i32.const 0
+   call $~lib/string/String.UTF16.decodeUnsafe
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.const 1552
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1088
+    i32.const 48
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -2198,7 +2338,7 @@
    global.set $~lib/memory/__stack_pointer
    call $std/string-encoding/testUTF8EncodeNullTerminated
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2209,12 +2349,6 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1904
-   i32.store offset=4
    i32.const 1904
    i32.const 0
    i32.const 0
@@ -2227,13 +2361,10 @@
    i32.const 0
    call $~lib/string/String.UTF8.decode
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1904
-   i32.store offset=4
    local.get $0
    i32.const 1904
    call $~lib/string/String.__eq
@@ -2247,9 +2378,6 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1904
-   i32.store offset=4
    i32.const 1904
    i32.const 0
    i32.const 1
@@ -2262,13 +2390,10 @@
    i32.const 0
    call $~lib/string/String.UTF8.decode
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1936
-   i32.store offset=4
    local.get $0
    i32.const 1936
    call $~lib/string/String.__eq
@@ -2282,9 +2407,6 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1968
-   i32.store offset=4
    i32.const 1968
    i32.const 0
    i32.const 0
@@ -2297,13 +2419,10 @@
    i32.const 0
    call $~lib/string/String.UTF8.decode
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1968
-   i32.store offset=4
    local.get $0
    i32.const 1968
    call $~lib/string/String.__eq
@@ -2317,9 +2436,6 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1968
-   i32.store offset=4
    i32.const 1968
    i32.const 0
    i32.const 1
@@ -2332,13 +2448,10 @@
    i32.const 0
    call $~lib/string/String.UTF8.decode
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1936
-   i32.store offset=4
    local.get $0
    i32.const 1936
    call $~lib/string/String.__eq
@@ -2352,7 +2465,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2589,14 +2702,8 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    call $std/string-encoding/testUTF8DecodeUnsafe
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2112
-   i32.store
    i32.const 2112
    call $std/string-encoding/testRoundtrip
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15232
-   i32.store
    i32.const 15232
    call $std/string-encoding/testRoundtrip
    global.get $~lib/rt/itcms/state
@@ -2632,10 +2739,6 @@
    i32.const 1024
    i32.add
    global.set $~lib/rt/itcms/threshold
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    return
   end
   i32.const 55600
@@ -2644,6 +2747,34 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
+ )
+ (func $~lib/rt/__visit_members (param $0 i32)
+  block $invalid
+   block $~lib/arraybuffer/ArrayBufferView
+    block $~lib/string/String
+     block $~lib/arraybuffer/ArrayBuffer
+      block $~lib/object/Object
+       local.get $0
+       i32.const 8
+       i32.sub
+       i32.load
+       br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $invalid
+      end
+      return
+     end
+     return
+    end
+    return
+   end
+   local.get $0
+   i32.load
+   call $~lib/rt/itcms/__visit
+   return
+  end
+  unreachable
+ )
+ (func $~start
+  call $start:std/string-encoding
  )
  (func $~lib/string/String.UTF16.encode (param $0 i32) (result i32)
   (local $1 i32)
@@ -2841,7 +2972,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$88
+   block $__inlined_func$~lib/util/string/compareImpl$94
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2861,7 +2992,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$88
+      br_if $__inlined_func$~lib/util/string/compareImpl$94
       local.get $2
       i32.const 2
       i32.add
@@ -2889,212 +3020,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   i32.const 0
- )
- (func $std/string-encoding/testUTF16DecodeUnsafe
-  (local $0 i32)
-  (local $1 i32)
-  (local $2 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 22804
-  i32.lt_s
-  if
-   i32.const 55600
-   i32.const 55648
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  call $~lib/string/String.UTF16.encode
-  local.tee $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store
-  i32.const 1052
-  i32.load
-  local.set $2
-  local.get $0
-  i32.const 0
-  call $~lib/string/String.UTF16.decodeUnsafe
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1552
-  i32.store offset=8
-  local.get $1
-  i32.const 1552
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 42
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.get $2
-  call $~lib/string/String.UTF16.decodeUnsafe
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=8
-  local.get $1
-  i32.const 1056
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 43
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 4
-  call $~lib/string/String.UTF16.decodeUnsafe
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1584
-  i32.store offset=8
-  local.get $1
-  i32.const 1584
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 44
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 4
-  i32.add
-  i32.const 2
-  call $~lib/string/String.UTF16.decodeUnsafe
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1616
-  i32.store offset=8
-  local.get $1
-  i32.const 1616
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 45
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 4
-  i32.add
-  i32.const 4
-  call $~lib/string/String.UTF16.decodeUnsafe
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1648
-  i32.store offset=8
-  local.get $1
-  i32.const 1648
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 46
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 8
-  i32.add
-  i32.const 4
-  call $~lib/string/String.UTF16.decodeUnsafe
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1680
-  i32.store offset=8
-  local.get $1
-  i32.const 1680
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 47
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  i32.const 12
-  i32.add
-  i32.const 0
-  call $~lib/string/String.UTF16.decodeUnsafe
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1552
-  i32.store offset=8
-  local.get $0
-  i32.const 1552
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 48
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/string/String.UTF8.encode (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
@@ -3694,9 +3619,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1552
-  i32.store offset=8
   local.get $1
   i32.const 1552
   call $~lib/string/String.__eq
@@ -3740,9 +3662,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1584
-  i32.store offset=8
   local.get $1
   i32.const 1584
   call $~lib/string/String.__eq
@@ -3765,9 +3684,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1648
-  i32.store offset=8
   local.get $1
   i32.const 1648
   call $~lib/string/String.__eq
@@ -3790,9 +3706,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1680
-  i32.store offset=8
   local.get $1
   i32.const 1680
   call $~lib/string/String.__eq
@@ -3815,9 +3728,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1552
-  i32.store offset=8
   local.get $1
   i32.const 1552
   call $~lib/string/String.__eq
@@ -3840,9 +3750,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2080
-  i32.store offset=8
   local.get $1
   i32.const 2080
   call $~lib/string/String.__eq
@@ -3865,9 +3772,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1680
-  i32.store offset=8
   local.get $1
   i32.const 1680
   call $~lib/string/String.__eq
@@ -3890,9 +3794,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1552
-  i32.store offset=8
   local.get $0
   i32.const 1552
   call $~lib/string/String.__eq
@@ -4249,7 +4150,7 @@
     end
    end
   end
-  block $__inlined_func$~lib/rt/itcms/__renew$155
+  block $__inlined_func$~lib/rt/itcms/__renew$157
    local.get $1
    local.get $0
    i32.sub
@@ -4268,7 +4169,7 @@
     local.get $3
     local.get $2
     i32.store offset=16
-    br $__inlined_func$~lib/rt/itcms/__renew$155
+    br $__inlined_func$~lib/rt/itcms/__renew$157
    end
    local.get $2
    local.get $3

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -11876,11 +11876,6 @@
      i32.store offset=4
      local.get $21
      i32.const 688
-     local.set $21
-     global.get $~lib/memory/__stack_pointer
-     local.get $21
-     i32.store offset=24
-     local.get $21
      call $~lib/array/Array<~lib/string/String>#push
      drop
     end
@@ -11981,11 +11976,6 @@
    i32.store offset=4
    local.get $21
    i32.const 688
-   local.set $21
-   global.get $~lib/memory/__stack_pointer
-   local.get $21
-   i32.store offset=24
-   local.get $21
    call $~lib/array/Array<~lib/string/String>#push
    drop
   end
@@ -12191,13 +12181,13 @@
   (local $51 i32)
   (local $52 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 96
+  i32.const 76
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 96
+  i32.const 76
   memory.fill
   global.get $std/string/str
   i32.const 32
@@ -12212,17 +12202,7 @@
    unreachable
   end
   i32.const 144
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 144
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12234,17 +12214,7 @@
    unreachable
   end
   i32.const 176
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 176
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12256,17 +12226,7 @@
    unreachable
   end
   i32.const 208
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 208
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12434,14 +12394,14 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   global.get $std/string/str
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=12
+  i32.store offset=8
   local.get $52
   call $~lib/string/String#get:length
   i32.sub
@@ -12452,11 +12412,6 @@
   i32.store
   local.get $52
   i32.const 720
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12468,11 +12423,6 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/String.__not
   i32.eqz
   i32.const 0
@@ -12487,11 +12437,6 @@
    unreachable
   end
   i32.const 752
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/String.__not
   i32.eqz
   i32.const 1
@@ -12506,11 +12451,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/String.__not
   i32.eqz
   i32.const 1
@@ -12535,11 +12475,6 @@
   i32.store
   local.get $52
   i32.const 752
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12561,11 +12496,6 @@
   i32.store
   local.get $52
   i32.const 816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12587,11 +12517,6 @@
   i32.store
   local.get $52
   i32.const 848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12615,11 +12540,6 @@
   i32.store
   local.get $52
   i32.const 848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12639,11 +12559,6 @@
   i32.store
   local.get $52
   i32.const 880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12662,7 +12577,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   call $~lib/string/String.fromCharCodes
   local.set $52
@@ -12671,11 +12586,6 @@
   i32.store
   local.get $52
   i32.const 944
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12694,7 +12604,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   call $~lib/string/String.fromCharCodes
   local.set $52
@@ -12703,11 +12613,6 @@
   i32.store
   local.get $52
   i32.const 1008
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12726,7 +12631,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   call $~lib/string/String.fromCharCodes
   local.set $52
@@ -12735,11 +12640,6 @@
   i32.store
   local.get $52
   i32.const 1088
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12758,11 +12658,6 @@
   i32.store
   local.get $52
   i32.const 752
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12781,11 +12676,6 @@
   i32.store
   local.get $52
   i32.const 848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12804,11 +12694,6 @@
   i32.store
   local.get $52
   i32.const 1120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12826,11 +12711,6 @@
   i32.store
   local.get $52
   i32.const 1152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#startsWith
   i32.eqz
@@ -12849,11 +12729,6 @@
   i32.store
   local.get $52
   i32.const 1184
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -12874,11 +12749,6 @@
   i32.store
   local.get $52
   i32.const 1216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#includes
   i32.eqz
@@ -12898,11 +12768,6 @@
   local.get $52
   i32.const 0
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -12933,11 +12798,6 @@
   local.get $52
   i32.const 15
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -12961,18 +12821,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -12980,11 +12830,6 @@
   i32.store
   local.get $52
   i32.const 1280
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12996,18 +12841,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 10
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13015,11 +12850,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13031,18 +12861,8 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 100
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13050,11 +12870,6 @@
   i32.store
   local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13066,18 +12881,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 5
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13085,11 +12890,6 @@
   i32.store
   local.get $52
   i32.const 1344
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13101,18 +12901,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 6
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13120,11 +12910,6 @@
   i32.store
   local.get $52
   i32.const 1408
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13136,18 +12921,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 8
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13155,11 +12930,6 @@
   i32.store
   local.get $52
   i32.const 1440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13178,11 +12948,6 @@
   local.get $52
   i32.const 0
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13213,11 +12978,6 @@
   local.get $52
   i32.const 15
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13241,18 +13001,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13260,11 +13010,6 @@
   i32.store
   local.get $52
   i32.const 1280
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13276,18 +13021,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 10
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13295,11 +13030,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13311,18 +13041,8 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 100
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13330,11 +13050,6 @@
   i32.store
   local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13346,18 +13061,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 5
   i32.const 1248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13365,11 +13070,6 @@
   i32.store
   local.get $52
   i32.const 1488
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13381,18 +13081,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 6
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13400,11 +13090,6 @@
   i32.store
   local.get $52
   i32.const 1520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13416,18 +13101,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 8
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#padEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -13435,11 +13110,6 @@
   i32.store
   local.get $52
   i32.const 1552
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -13451,17 +13121,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 0
@@ -13476,17 +13136,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const -1
@@ -13501,17 +13151,7 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 0
@@ -13557,11 +13197,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 0
@@ -13582,11 +13217,6 @@
   i32.store
   local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const 2
@@ -13607,11 +13237,6 @@
   i32.store
   local.get $52
   i32.const 1632
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#indexOf
   i32.const -1
@@ -13632,11 +13257,6 @@
   i32.store
   local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 2
   call $~lib/string/String#indexOf
   i32.const 2
@@ -13657,11 +13277,6 @@
   i32.store
   local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 3
   call $~lib/string/String#indexOf
   i32.const -1
@@ -13682,11 +13297,6 @@
   i32.store
   local.get $52
   i32.const 1664
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const -1
   call $~lib/string/String#indexOf
   i32.const 2
@@ -13701,17 +13311,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13728,17 +13328,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13761,11 +13351,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13794,11 +13379,6 @@
   i32.store
   local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13821,11 +13401,6 @@
   i32.store
   local.get $52
   i32.const 1632
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13848,11 +13423,6 @@
   i32.store
   local.get $52
   i32.const 1696
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
@@ -13875,11 +13445,6 @@
   i32.store
   local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 2
   call $~lib/string/String#lastIndexOf
   i32.const 2
@@ -13900,11 +13465,6 @@
   i32.store
   local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 3
   call $~lib/string/String#lastIndexOf
   i32.const 2
@@ -13925,11 +13485,6 @@
   i32.store
   local.get $52
   i32.const 1664
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const -1
   call $~lib/string/String#lastIndexOf
   i32.const -1
@@ -13950,11 +13505,6 @@
   i32.store
   local.get $52
   i32.const 1728
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#lastIndexOf
   i32.const -1
@@ -13975,11 +13525,6 @@
   i32.store
   local.get $52
   i32.const 1152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#lastIndexOf
   i32.const 0
@@ -13994,17 +13539,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 0
   i32.eq
@@ -14018,17 +13553,7 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14042,17 +13567,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14066,17 +13581,7 @@
    unreachable
   end
   i32.const 1760
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1760
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 0
   i32.eq
@@ -14090,17 +13595,7 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1792
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14114,17 +13609,7 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1824
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14138,17 +13623,7 @@
    unreachable
   end
   i32.const 1792
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14162,17 +13637,7 @@
    unreachable
   end
   i32.const 1856
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14186,17 +13651,7 @@
    unreachable
   end
   i32.const 1888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14210,17 +13665,7 @@
    unreachable
   end
   i32.const 1856
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1920
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14234,17 +13679,7 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14258,17 +13693,7 @@
    unreachable
   end
   i32.const 1920
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1856
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14282,17 +13707,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1280
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const -1
   i32.eq
@@ -14306,17 +13721,7 @@
    unreachable
   end
   i32.const 752
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String#localeCompare
   i32.const 1
   i32.eq
@@ -14330,11 +13735,6 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trimStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14342,11 +13742,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14358,11 +13753,6 @@
    unreachable
   end
   i32.const 1952
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trimStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14370,11 +13760,6 @@
   i32.store
   local.get $52
   i32.const 1952
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14386,11 +13771,6 @@
    unreachable
   end
   i32.const 1984
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trimStart
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14398,11 +13778,6 @@
   i32.store
   local.get $52
   i32.const 2032
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14414,11 +13789,6 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trimEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14426,11 +13796,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14442,11 +13807,6 @@
    unreachable
   end
   i32.const 1952
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trimEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14454,11 +13814,6 @@
   i32.store
   local.get $52
   i32.const 1952
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14470,11 +13825,6 @@
    unreachable
   end
   i32.const 1984
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trimEnd
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14482,11 +13832,6 @@
   i32.store
   local.get $52
   i32.const 2080
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14498,11 +13843,6 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trim
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14510,11 +13850,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14526,11 +13861,6 @@
    unreachable
   end
   i32.const 1952
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trim
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14538,11 +13868,6 @@
   i32.store
   local.get $52
   i32.const 1952
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14554,11 +13879,6 @@
    unreachable
   end
   i32.const 1984
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String#trim
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -14566,11 +13886,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -14771,11 +14086,6 @@
    unreachable
   end
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -14790,11 +14100,6 @@
    unreachable
   end
   i32.const 2400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -14809,11 +14114,6 @@
    unreachable
   end
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -14828,11 +14128,6 @@
    unreachable
   end
   i32.const 2464
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -14847,11 +14142,6 @@
    unreachable
   end
   i32.const 2496
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 5
@@ -14866,11 +14156,6 @@
    unreachable
   end
   i32.const 2528
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 455
@@ -14885,11 +14170,6 @@
    unreachable
   end
   i32.const 2560
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 3855
@@ -14904,11 +14184,6 @@
    unreachable
   end
   i32.const 2592
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 3855
@@ -14923,11 +14198,6 @@
    unreachable
   end
   i32.const 2624
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 11
@@ -14942,11 +14212,6 @@
    unreachable
   end
   i32.const 2656
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -14961,11 +14226,6 @@
    unreachable
   end
   i32.const 2688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const -123
@@ -14980,11 +14240,6 @@
    unreachable
   end
   i32.const 2720
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 123
@@ -14999,11 +14254,6 @@
    unreachable
   end
   i32.const 2752
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const -12
@@ -15018,11 +14268,6 @@
    unreachable
   end
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15037,11 +14282,6 @@
    unreachable
   end
   i32.const 2784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15056,11 +14296,6 @@
    unreachable
   end
   i32.const 2816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 16
   call $~lib/string/parseInt
   f64.const 2833
@@ -15075,11 +14310,6 @@
    unreachable
   end
   i32.const 2848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15094,11 +14324,6 @@
    unreachable
   end
   i32.const 2880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15113,11 +14338,6 @@
    unreachable
   end
   i32.const 2912
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15133,11 +14353,6 @@
   end
   block $~lib/math/NativeMath.signbit|inlined.0 (result i32)
    i32.const 2944
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store
-   local.get $52
    i32.const 0
    call $~lib/string/parseInt
    local.set $10
@@ -15161,19 +14376,9 @@
    unreachable
   end
   i32.const 2976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   i32.const 3024
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 16
   call $~lib/string/parseInt
   f64.eq
@@ -15187,11 +14392,6 @@
    unreachable
   end
   i32.const 3056
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 36893488147419103232
@@ -15206,11 +14406,6 @@
    unreachable
   end
   i32.const 3056
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 13
   call $~lib/string/parseInt
   f64.const 5135857308667095285760
@@ -15225,11 +14420,6 @@
    unreachable
   end
   i32.const 3120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 10
   call $~lib/string/parseInt
   f64.const -1.e+24
@@ -15244,11 +14434,6 @@
    unreachable
   end
   i32.const 3200
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 16
   call $~lib/string/parseInt
   f64.const 75557863725914323419136
@@ -15263,11 +14448,6 @@
    unreachable
   end
   i32.const 3264
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15282,11 +14462,6 @@
    unreachable
   end
   i32.const 3296
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 2
@@ -15301,11 +14476,6 @@
    unreachable
   end
   i32.const 3344
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15320,11 +14490,6 @@
    unreachable
   end
   i32.const 3376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 2
@@ -15339,11 +14504,6 @@
    unreachable
   end
   i32.const 3424
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15358,11 +14518,6 @@
    unreachable
   end
   i32.const 3456
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 1
@@ -15377,11 +14532,6 @@
    unreachable
   end
   i32.const 3488
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   f64.const 0
@@ -15396,11 +14546,6 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   local.tee $11
@@ -15416,11 +14561,6 @@
    unreachable
   end
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   local.tee $12
@@ -15436,11 +14576,6 @@
    unreachable
   end
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   local.tee $13
@@ -15456,11 +14591,6 @@
    unreachable
   end
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 37
   call $~lib/string/parseInt
   local.tee $14
@@ -15476,11 +14606,6 @@
    unreachable
   end
   i32.const 3600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   local.tee $15
@@ -15496,11 +14621,6 @@
    unreachable
   end
   i32.const 3632
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/string/parseInt
   local.tee $16
@@ -15516,11 +14636,6 @@
    unreachable
   end
   i32.const 3632
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/number/F32.parseFloat
   local.tee $17
   local.get $17
@@ -15535,11 +14650,6 @@
    unreachable
   end
   i32.const 3632
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/number/F64.parseFloat
   local.tee $18
   local.get $18
@@ -15607,11 +14717,6 @@
    unreachable
   end
   i32.const 3856
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/number/I32.parseInt
   global.get $~lib/number/I32.MAX_VALUE
@@ -15654,11 +14759,6 @@
    unreachable
   end
   i32.const 3904
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   call $~lib/number/I64.parseInt
   global.get $~lib/number/I64.MAX_VALUE
@@ -15701,11 +14801,6 @@
    unreachable
   end
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -15719,11 +14814,6 @@
    unreachable
   end
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -15737,11 +14827,6 @@
    unreachable
   end
   i32.const 3968
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -15755,11 +14840,6 @@
    unreachable
   end
   i32.const 4000
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -15773,11 +14853,6 @@
    unreachable
   end
   i32.const 4032
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-05
   f64.eq
@@ -15791,11 +14866,6 @@
    unreachable
   end
   i32.const 4064
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -1e-05
   f64.eq
@@ -15809,11 +14879,6 @@
    unreachable
   end
   i32.const 4096
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -3e-23
   f64.eq
@@ -15827,11 +14892,6 @@
    unreachable
   end
   i32.const 4144
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 3e21
   f64.eq
@@ -15845,11 +14905,6 @@
    unreachable
   end
   i32.const 4192
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -15863,11 +14918,6 @@
    unreachable
   end
   i32.const 4224
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -15881,11 +14931,6 @@
    unreachable
   end
   i32.const 4256
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -15899,11 +14944,6 @@
    unreachable
   end
   i32.const 4288
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.25
   f64.eq
@@ -15917,11 +14957,6 @@
    unreachable
   end
   i32.const 4320
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e3
   f64.eq
@@ -15935,11 +14970,6 @@
    unreachable
   end
   i32.const 4352
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-10
   f64.eq
@@ -15953,11 +14983,6 @@
    unreachable
   end
   i32.const 4400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-30
   f64.eq
@@ -15971,11 +14996,6 @@
    unreachable
   end
   i32.const 4448
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-323
   f64.eq
@@ -15989,11 +15009,6 @@
    unreachable
   end
   i32.const 4496
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16007,11 +15022,6 @@
    unreachable
   end
   i32.const 4544
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+308
   f64.eq
@@ -16025,11 +15035,6 @@
    unreachable
   end
   i32.const 4576
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -16043,11 +15048,6 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $27
   local.get $27
@@ -16062,11 +15062,6 @@
    unreachable
   end
   i32.const 4608
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16080,11 +15075,6 @@
    unreachable
   end
   i32.const 4656
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-10
   f64.eq
@@ -16098,11 +15088,6 @@
    unreachable
   end
   i32.const 4704
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16116,11 +15101,6 @@
    unreachable
   end
   i32.const 4752
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16134,11 +15114,6 @@
    unreachable
   end
   i32.const 4784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16152,11 +15127,6 @@
    unreachable
   end
   i32.const 4816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16170,11 +15140,6 @@
    unreachable
   end
   i32.const 4864
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 123456789
   f64.eq
@@ -16188,11 +15153,6 @@
    unreachable
   end
   i32.const 4912
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16206,11 +15166,6 @@
    unreachable
   end
   i32.const 4960
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-60
   f64.eq
@@ -16224,11 +15179,6 @@
    unreachable
   end
   i32.const 4992
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+60
   f64.eq
@@ -16242,11 +15192,6 @@
    unreachable
   end
   i32.const 5024
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 123.4
   f64.eq
@@ -16260,11 +15205,6 @@
    unreachable
   end
   i32.const 5056
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16278,11 +15218,6 @@
    unreachable
   end
   i32.const 5088
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16296,11 +15231,6 @@
    unreachable
   end
   i32.const 5136
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16314,11 +15244,6 @@
    unreachable
   end
   i32.const 5184
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16332,11 +15257,6 @@
    unreachable
   end
   i32.const 5232
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.022
   f64.eq
@@ -16350,11 +15270,6 @@
    unreachable
   end
   i32.const 5280
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 11
   f64.eq
@@ -16368,11 +15283,6 @@
    unreachable
   end
   i32.const 2784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16386,11 +15296,6 @@
    unreachable
   end
   i32.const 5312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16404,11 +15309,6 @@
    unreachable
   end
   i32.const 5344
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16422,11 +15322,6 @@
    unreachable
   end
   i32.const 5376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.1
   f64.eq
@@ -16440,11 +15335,6 @@
    unreachable
   end
   i32.const 5408
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16458,11 +15348,6 @@
    unreachable
   end
   i32.const 5440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16476,11 +15361,6 @@
    unreachable
   end
   i32.const 5472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16494,11 +15374,6 @@
    unreachable
   end
   i32.const 5504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -1.1
   f64.eq
@@ -16512,11 +15387,6 @@
    unreachable
   end
   i32.const 5536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16530,11 +15400,6 @@
    unreachable
   end
   i32.const 5568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16548,11 +15413,6 @@
    unreachable
   end
   i32.const 5600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16566,11 +15426,6 @@
    unreachable
   end
   i32.const 5632
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16584,11 +15439,6 @@
    unreachable
   end
   i32.const 5664
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16602,11 +15452,6 @@
    unreachable
   end
   i32.const 5696
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16620,11 +15465,6 @@
    unreachable
   end
   i32.const 5728
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16638,11 +15478,6 @@
    unreachable
   end
   i32.const 5776
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16656,11 +15491,6 @@
    unreachable
   end
   i32.const 5808
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16674,11 +15504,6 @@
    unreachable
   end
   i32.const 5840
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16692,11 +15517,6 @@
    unreachable
   end
   i32.const 5872
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16710,11 +15530,6 @@
    unreachable
   end
   i32.const 5904
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 10
   f64.eq
@@ -16728,11 +15543,6 @@
    unreachable
   end
   i32.const 5936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16746,11 +15556,6 @@
    unreachable
   end
   i32.const 5968
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16764,11 +15569,6 @@
    unreachable
   end
   i32.const 6000
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.01
   f64.eq
@@ -16782,11 +15582,6 @@
    unreachable
   end
   i32.const 6048
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16800,11 +15595,6 @@
    unreachable
   end
   i32.const 6080
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16818,11 +15608,6 @@
    unreachable
   end
   i32.const 6112
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16836,11 +15621,6 @@
    unreachable
   end
   i32.const 6144
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16854,11 +15634,6 @@
    unreachable
   end
   i32.const 6176
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16872,11 +15647,6 @@
    unreachable
   end
   i32.const 6208
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16890,11 +15660,6 @@
    unreachable
   end
   i32.const 6240
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -16908,11 +15673,6 @@
    unreachable
   end
   i32.const 6272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -16926,11 +15686,6 @@
    unreachable
   end
   i32.const 6304
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -16944,11 +15699,6 @@
    unreachable
   end
   i32.const 6336
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -16964,11 +15714,6 @@
    unreachable
   end
   i32.const 6368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -0
   call $~lib/object/Object.is<f64>
@@ -16984,11 +15729,6 @@
    unreachable
   end
   i32.const 6400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   call $~lib/object/Object.is<f64>
@@ -17004,11 +15744,6 @@
    unreachable
   end
   i32.const 2944
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -0
   call $~lib/object/Object.is<f64>
@@ -17024,11 +15759,6 @@
    unreachable
   end
   i32.const 6432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const -0
   call $~lib/object/Object.is<f64>
@@ -17044,11 +15774,6 @@
    unreachable
   end
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $28
   local.get $28
@@ -17063,11 +15788,6 @@
    unreachable
   end
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $29
   local.get $29
@@ -17082,11 +15802,6 @@
    unreachable
   end
   i32.const 6480
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $30
   local.get $30
@@ -17101,11 +15816,6 @@
    unreachable
   end
   i32.const 6512
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $31
   local.get $31
@@ -17120,11 +15830,6 @@
    unreachable
   end
   i32.const 6544
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $32
   local.get $32
@@ -17139,11 +15844,6 @@
    unreachable
   end
   i32.const 6576
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $33
   local.get $33
@@ -17158,11 +15858,6 @@
    unreachable
   end
   i32.const 6608
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $34
   local.get $34
@@ -17177,11 +15872,6 @@
    unreachable
   end
   i32.const 6640
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $35
   local.get $35
@@ -17196,11 +15886,6 @@
    unreachable
   end
   i32.const 6672
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $36
   local.get $36
@@ -17215,11 +15900,6 @@
    unreachable
   end
   i32.const 6704
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $37
   local.get $37
@@ -17234,11 +15914,6 @@
    unreachable
   end
   i32.const 6736
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $38
   local.get $38
@@ -17253,11 +15928,6 @@
    unreachable
   end
   i32.const 6768
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $39
   local.get $39
@@ -17272,11 +15942,6 @@
    unreachable
   end
   i32.const 6800
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $40
   local.get $40
@@ -17291,11 +15956,6 @@
    unreachable
   end
   i32.const 6832
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $41
   local.get $41
@@ -17310,11 +15970,6 @@
    unreachable
   end
   i32.const 6864
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $42
   local.get $42
@@ -17329,11 +15984,6 @@
    unreachable
   end
   i32.const 2336
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $43
   local.get $43
@@ -17348,11 +15998,6 @@
    unreachable
   end
   i32.const 6896
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e22
   f64.eq
@@ -17366,11 +16011,6 @@
    unreachable
   end
   i32.const 6928
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-22
   f64.eq
@@ -17384,11 +16024,6 @@
    unreachable
   end
   i32.const 6960
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+23
   f64.eq
@@ -17402,11 +16037,6 @@
    unreachable
   end
   i32.const 6992
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-23
   f64.eq
@@ -17420,11 +16050,6 @@
    unreachable
   end
   i32.const 7024
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+37
   f64.eq
@@ -17438,11 +16063,6 @@
    unreachable
   end
   i32.const 7056
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-37
   f64.eq
@@ -17456,11 +16076,6 @@
    unreachable
   end
   i32.const 7088
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+38
   f64.eq
@@ -17474,11 +16089,6 @@
    unreachable
   end
   i32.const 7120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1e-38
   f64.eq
@@ -17492,11 +16102,6 @@
    unreachable
   end
   i32.const 7152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.EPSILON
   f64.eq
@@ -17510,11 +16115,6 @@
    unreachable
   end
   i32.const 7216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.MAX_VALUE
   f64.eq
@@ -17528,11 +16128,6 @@
    unreachable
   end
   i32.const 7296
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   global.get $~lib/builtins/f64.MIN_VALUE
   f64.eq
@@ -17546,11 +16141,6 @@
    unreachable
   end
   i32.const 7328
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1.e+308
   f64.eq
@@ -17564,11 +16154,6 @@
    unreachable
   end
   i32.const 7376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1
   f64.eq
@@ -17582,11 +16167,6 @@
    unreachable
   end
   i32.const 7520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17600,11 +16180,6 @@
    unreachable
   end
   i32.const 7568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17618,11 +16193,6 @@
    unreachable
   end
   i32.const 7616
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17636,11 +16206,6 @@
    unreachable
   end
   i32.const 7664
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.neg
@@ -17655,11 +16220,6 @@
    unreachable
   end
   i32.const 7712
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17673,11 +16233,6 @@
    unreachable
   end
   i32.const 7760
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17691,11 +16246,6 @@
    unreachable
   end
   i32.const 7808
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17709,11 +16259,6 @@
    unreachable
   end
   i32.const 7840
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17727,11 +16272,6 @@
    unreachable
   end
   i32.const 7888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17745,11 +16285,6 @@
    unreachable
   end
   i32.const 7936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.neg
@@ -17764,11 +16299,6 @@
    unreachable
   end
   i32.const 7984
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17782,11 +16312,6 @@
    unreachable
   end
   i32.const 8032
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const inf
   f64.eq
@@ -17800,11 +16325,6 @@
    unreachable
   end
   i32.const 8080
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $44
   local.get $44
@@ -17819,11 +16339,6 @@
    unreachable
   end
   i32.const 8112
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $45
   local.get $45
@@ -17838,11 +16353,6 @@
    unreachable
   end
   i32.const 8160
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $46
   local.get $46
@@ -17857,11 +16367,6 @@
    unreachable
   end
   i32.const 8208
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0
   f64.eq
@@ -17875,11 +16380,6 @@
    unreachable
   end
   i32.const 8400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   global.get $std/string/Ox1p_1073
   f64.eq
@@ -17893,11 +16393,6 @@
    unreachable
   end
   i32.const 8592
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   global.get $std/string/Ox1_0000000000001p_1022
   f64.eq
@@ -17911,41 +16406,21 @@
    unreachable
   end
   i32.const 8784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=72
-  local.get $52
   i32.const 8944
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=76
-  local.get $52
-  call $~lib/string/String.__concat
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=64
-  local.get $52
-  i32.const 9104
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=68
-  local.get $52
   call $~lib/string/String.__concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
   i32.store offset=12
   local.get $52
-  i32.const 9264
+  i32.const 9104
+  call $~lib/string/String.__concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=60
+  i32.store offset=8
   local.get $52
+  i32.const 9264
   call $~lib/string/String.__concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -17953,11 +16428,6 @@
   i32.store offset=4
   local.get $52
   i32.const 9424
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   call $~lib/string/String.__concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -17977,11 +16447,6 @@
    unreachable
   end
   i32.const 9584
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 9.753531888799502e-104
   f64.eq
@@ -17995,11 +16460,6 @@
    unreachable
   end
   i32.const 9696
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.5961860348131807
   f64.eq
@@ -18013,11 +16473,6 @@
    unreachable
   end
   i32.const 9808
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.18150131692180388
   f64.eq
@@ -18031,11 +16486,6 @@
    unreachable
   end
   i32.const 9920
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.42070823575344535
   f64.eq
@@ -18049,11 +16499,6 @@
    unreachable
   end
   i32.const 10032
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.6654686306516261
   f64.eq
@@ -18067,11 +16512,6 @@
    unreachable
   end
   i32.const 10144
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.6101852922970868
   f64.eq
@@ -18085,11 +16525,6 @@
    unreachable
   end
   i32.const 10256
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.7696695208236968
   f64.eq
@@ -18103,11 +16538,6 @@
    unreachable
   end
   i32.const 10368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.25050653222286823
   f64.eq
@@ -18121,11 +16551,6 @@
    unreachable
   end
   i32.const 10480
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.2740037230228005
   f64.eq
@@ -18139,11 +16564,6 @@
    unreachable
   end
   i32.const 10592
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.20723093500497428
   f64.eq
@@ -18157,11 +16577,6 @@
    unreachable
   end
   i32.const 10704
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 7.900280238081605
   f64.eq
@@ -18175,11 +16590,6 @@
    unreachable
   end
   i32.const 10816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 98.22860653737297
   f64.eq
@@ -18193,11 +16603,6 @@
    unreachable
   end
   i32.const 10928
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 746.894972319037
   f64.eq
@@ -18211,11 +16616,6 @@
    unreachable
   end
   i32.const 11040
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 1630.2683202827284
   f64.eq
@@ -18229,11 +16629,6 @@
    unreachable
   end
   i32.const 11152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 46371.68629719171
   f64.eq
@@ -18247,11 +16642,6 @@
    unreachable
   end
   i32.const 11264
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 653780.5944497711
   f64.eq
@@ -18265,11 +16655,6 @@
    unreachable
   end
   i32.const 11376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 234632.43565024371
   f64.eq
@@ -18283,11 +16668,6 @@
    unreachable
   end
   i32.const 11488
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 97094817.16420048
   f64.eq
@@ -18301,11 +16681,6 @@
    unreachable
   end
   i32.const 11600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 499690852.20518744
   f64.eq
@@ -18319,11 +16694,6 @@
    unreachable
   end
   i32.const 11712
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 7925201200557245595648
   f64.eq
@@ -18337,11 +16707,6 @@
    unreachable
   end
   i32.const 11824
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 6096564585983177528398588e5
   f64.eq
@@ -18355,11 +16720,6 @@
    unreachable
   end
   i32.const 11936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 4800416117477028695992383e42
   f64.eq
@@ -18373,11 +16733,6 @@
    unreachable
   end
   i32.const 12048
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 8524829079817968137287277e80
   f64.eq
@@ -18391,11 +16746,6 @@
    unreachable
   end
   i32.const 12160
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 3271239291709782092398754e243
   f64.eq
@@ -18409,11 +16759,6 @@
    unreachable
   end
   i32.const 12272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   local.tee $47
   local.get $47
@@ -18428,11 +16773,6 @@
    unreachable
   end
   i32.const 12304
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/parseFloat
   f64.const 0.1
   f64.eq
@@ -18447,20 +16787,10 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12336
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__concat
   local.tee $48
-  i32.store offset=80
+  i32.store offset=60
   local.get $48
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -18468,11 +16798,6 @@
   i32.store
   local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18490,11 +16815,6 @@
   i32.store
   local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18506,17 +16826,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18545,16 +16855,11 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   global.get $std/string/nullStr
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=4
+  i32.store
   local.get $52
   call $~lib/string/String.__ne
   i32.eqz
@@ -18573,11 +16878,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18589,17 +16889,7 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12336
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18611,17 +16901,7 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18633,17 +16913,7 @@
    unreachable
   end
   i32.const 12400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18655,17 +16925,7 @@
    unreachable
   end
   i32.const 12400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18677,17 +16937,7 @@
    unreachable
   end
   i32.const 12464
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12496
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18699,17 +16949,7 @@
    unreachable
   end
   i32.const 12528
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12560
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18721,17 +16961,7 @@
    unreachable
   end
   i32.const 12592
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12592
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -18743,17 +16973,7 @@
    unreachable
   end
   i32.const 12592
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12640
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18765,17 +16985,7 @@
    unreachable
   end
   i32.const 12688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12736
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -18787,17 +16997,7 @@
    unreachable
   end
   i32.const 12336
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18809,17 +17009,7 @@
    unreachable
   end
   i32.const 12784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18831,17 +17021,7 @@
    unreachable
   end
   i32.const 12784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -18853,17 +17033,7 @@
    unreachable
   end
   i32.const 12784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18875,17 +17045,7 @@
    unreachable
   end
   i32.const 12784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -18898,17 +17058,7 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -18920,17 +17070,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   if
@@ -18942,17 +17082,7 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -18964,17 +17094,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -18986,17 +17106,7 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19009,17 +17119,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19032,17 +17132,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19055,17 +17145,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19078,17 +17158,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -19100,17 +17170,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -19122,17 +17182,7 @@
    unreachable
   end
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   if
@@ -19144,17 +17194,7 @@
    unreachable
   end
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -19166,17 +17206,7 @@
    unreachable
   end
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19189,17 +17219,7 @@
    unreachable
   end
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19212,17 +17232,7 @@
    unreachable
   end
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   if
@@ -19234,17 +17244,7 @@
    unreachable
   end
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   if
@@ -19256,17 +17256,7 @@
    unreachable
   end
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lt
   i32.eqz
   i32.eqz
@@ -19279,17 +17269,7 @@
    unreachable
   end
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gt
   i32.eqz
   i32.eqz
@@ -19302,17 +17282,7 @@
    unreachable
   end
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -19324,17 +17294,7 @@
    unreachable
   end
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -19346,17 +17306,7 @@
    unreachable
   end
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12912
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   i32.eqz
@@ -19369,17 +17319,7 @@
    unreachable
   end
   i32.const 12912
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__gte
   i32.eqz
   if
@@ -19391,17 +17331,7 @@
    unreachable
   end
   i32.const 12848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12912
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__lte
   i32.eqz
   if
@@ -19413,17 +17343,7 @@
    unreachable
   end
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19435,17 +17355,7 @@
    unreachable
   end
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19457,17 +17367,7 @@
    unreachable
   end
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19479,17 +17379,7 @@
    unreachable
   end
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12944
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -19501,17 +17391,7 @@
    unreachable
   end
   i32.const 12976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19523,17 +17403,7 @@
    unreachable
   end
   i32.const 13008
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 12976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__ne
   i32.eqz
   if
@@ -19548,7 +17418,7 @@
   i32.const 65377
   call $~lib/string/String.fromCodePoint
   local.tee $49
-  i32.store offset=84
+  i32.store offset=64
   global.get $~lib/memory/__stack_pointer
   i32.const 55296
   call $~lib/string/String.fromCodePoint
@@ -19566,7 +17436,7 @@
   local.get $52
   call $~lib/string/String.__concat
   local.tee $50
-  i32.store offset=88
+  i32.store offset=68
   local.get $49
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -19590,11 +17460,6 @@
    unreachable
   end
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   call $~lib/string/String#get:length
   i32.const 3
   i32.eq
@@ -19608,11 +17473,6 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 100
   call $~lib/string/String#repeat
   local.set $52
@@ -19621,11 +17481,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19637,11 +17492,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 0
   call $~lib/string/String#repeat
   local.set $52
@@ -19650,11 +17500,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19666,11 +17511,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1
   call $~lib/string/String#repeat
   local.set $52
@@ -19679,11 +17519,6 @@
   i32.store
   local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19695,11 +17530,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 2
   call $~lib/string/String#repeat
   local.set $52
@@ -19708,11 +17538,6 @@
   i32.store
   local.get $52
   i32.const 12816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19724,11 +17549,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3
   call $~lib/string/String#repeat
   local.set $52
@@ -19737,11 +17557,6 @@
   i32.store
   local.get $52
   i32.const 13088
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19753,11 +17568,6 @@
    unreachable
   end
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 4
   call $~lib/string/String#repeat
   local.set $52
@@ -19766,11 +17576,6 @@
   i32.store
   local.get $52
   i32.const 13120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19782,11 +17587,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 5
   call $~lib/string/String#repeat
   local.set $52
@@ -19795,11 +17595,6 @@
   i32.store
   local.get $52
   i32.const 13168
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19811,11 +17606,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 6
   call $~lib/string/String#repeat
   local.set $52
@@ -19824,11 +17614,6 @@
   i32.store
   local.get $52
   i32.const 13200
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19840,11 +17625,6 @@
    unreachable
   end
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 7
   call $~lib/string/String#repeat
   local.set $52
@@ -19853,11 +17633,6 @@
   i32.store
   local.get $52
   i32.const 13232
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19869,23 +17644,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -19893,11 +17653,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19909,23 +17664,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -19933,11 +17673,6 @@
   i32.store
   local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19949,23 +17684,8 @@
    unreachable
   end
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -19973,11 +17693,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -19989,23 +17704,8 @@
    unreachable
   end
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20013,11 +17713,6 @@
   i32.store
   local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20029,23 +17724,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20053,11 +17733,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20069,23 +17744,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20093,11 +17753,6 @@
   i32.store
   local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20109,23 +17764,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20133,11 +17773,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20149,23 +17784,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20173,11 +17793,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20189,23 +17804,8 @@
    unreachable
   end
   i32.const 13280
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20213,11 +17813,6 @@
   i32.store
   local.get $52
   i32.const 13312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20229,23 +17824,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20253,11 +17833,6 @@
   i32.store
   local.get $52
   i32.const 13344
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20269,23 +17844,8 @@
    unreachable
   end
   i32.const 13376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 13408
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20293,11 +17853,6 @@
   i32.store
   local.get $52
   i32.const 13344
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20309,23 +17864,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 13440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 13472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20333,11 +17873,6 @@
   i32.store
   local.get $52
   i32.const 13504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20349,23 +17884,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 13440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replace
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20373,11 +17893,6 @@
   i32.store
   local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20389,23 +17904,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20413,11 +17913,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20429,23 +17924,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20453,11 +17933,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20469,23 +17944,8 @@
    unreachable
   end
   i32.const 1520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20493,11 +17953,6 @@
   i32.store
   local.get $52
   i32.const 13472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20509,23 +17964,8 @@
    unreachable
   end
   i32.const 13536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20533,11 +17973,6 @@
   i32.store
   local.get $52
   i32.const 13584
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20549,23 +17984,8 @@
    unreachable
   end
   i32.const 1520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20573,11 +17993,6 @@
   i32.store
   local.get $52
   i32.const 1520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20589,23 +18004,8 @@
    unreachable
   end
   i32.const 13616
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 13584
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20613,11 +18013,6 @@
   i32.store
   local.get $52
   i32.const 13664
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20629,23 +18024,8 @@
    unreachable
   end
   i32.const 1520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 13472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20653,11 +18033,6 @@
   i32.store
   local.get $52
   i32.const 13712
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20669,23 +18044,8 @@
    unreachable
   end
   i32.const 13744
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 13776
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 13472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20693,11 +18053,6 @@
   i32.store
   local.get $52
   i32.const 13808
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20709,23 +18064,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20733,11 +18073,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20749,23 +18084,8 @@
    unreachable
   end
   i32.const 1888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 13840
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 13472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20773,11 +18093,6 @@
   i32.store
   local.get $52
   i32.const 1888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20789,23 +18104,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 13872
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20813,11 +18113,6 @@
   i32.store
   local.get $52
   i32.const 13904
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20829,23 +18124,8 @@
    unreachable
   end
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20853,11 +18133,6 @@
   i32.store
   local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20869,23 +18144,8 @@
    unreachable
   end
   i32.const 13280
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20893,11 +18153,6 @@
   i32.store
   local.get $52
   i32.const 13936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20909,23 +18164,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20933,11 +18173,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20949,23 +18184,8 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -20973,11 +18193,6 @@
   i32.store
   local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -20989,23 +18204,8 @@
    unreachable
   end
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21013,11 +18213,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21029,23 +18224,8 @@
    unreachable
   end
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21053,11 +18233,6 @@
   i32.store
   local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21069,23 +18244,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21093,11 +18253,6 @@
   i32.store
   local.get $52
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21109,23 +18264,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 1792
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21133,11 +18273,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21149,23 +18284,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 3568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21173,11 +18293,6 @@
   i32.store
   local.get $52
   i32.const 13968
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21189,23 +18304,8 @@
    unreachable
   end
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21213,11 +18313,6 @@
   i32.store
   local.get $52
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21229,23 +18324,8 @@
    unreachable
   end
   i32.const 14016
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 14048
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21253,11 +18333,6 @@
   i32.store
   local.get $52
   i32.const 14080
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21269,23 +18344,8 @@
    unreachable
   end
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 12368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 14128
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21293,11 +18353,6 @@
   i32.store
   local.get $52
   i32.const 14128
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21309,23 +18364,8 @@
    unreachable
   end
   i32.const 13088
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 14160
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21333,11 +18373,6 @@
   i32.store
   local.get $52
   i32.const 14192
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21349,23 +18384,8 @@
    unreachable
   end
   i32.const 13088
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 12816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   i32.const 14048
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=60
-  local.get $52
   call $~lib/string/String#replaceAll
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -21373,11 +18393,6 @@
   i32.store
   local.get $52
   i32.const 14240
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21394,7 +18409,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const 1
@@ -21407,11 +18422,6 @@
   i32.store
   local.get $52
   i32.const 14272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21426,7 +18436,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -1
   i32.const 1
@@ -21439,11 +18449,6 @@
   i32.store
   local.get $52
   i32.const 14320
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21458,7 +18463,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -5
   i32.const 1
@@ -21471,11 +18476,6 @@
   i32.store
   local.get $52
   i32.const 14352
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21490,7 +18490,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 2
   i32.const 7
@@ -21501,11 +18501,6 @@
   i32.store
   local.get $52
   i32.const 14384
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21520,7 +18515,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -11
   i32.const -6
@@ -21531,11 +18526,6 @@
   i32.store
   local.get $52
   i32.const 14416
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21550,7 +18540,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 4
   i32.const 3
@@ -21561,11 +18551,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21580,7 +18565,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const -1
@@ -21591,11 +18576,6 @@
   i32.store
   local.get $52
   i32.const 14448
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21610,7 +18590,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const 1
@@ -21623,11 +18603,6 @@
   i32.store
   local.get $52
   i32.const 14272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21642,7 +18617,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -1
   i32.const 1
@@ -21655,11 +18630,6 @@
   i32.store
   local.get $52
   i32.const 14320
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21674,7 +18644,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -5
   i32.const 1
@@ -21687,11 +18657,6 @@
   i32.store
   local.get $52
   i32.const 14352
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21706,7 +18671,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 2
   i32.const 7
@@ -21717,11 +18682,6 @@
   i32.store
   local.get $52
   i32.const 14496
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21736,7 +18696,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -11
   i32.const -6
@@ -21747,11 +18707,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21766,7 +18721,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 4
   i32.const 3
@@ -21777,11 +18732,6 @@
   i32.store
   local.get $52
   i32.const 14544
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21796,7 +18746,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const -1
@@ -21807,11 +18757,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21826,7 +18771,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const 100
@@ -21837,11 +18782,6 @@
   i32.store
   local.get $52
   i32.const 14272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21856,7 +18796,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 4
   i32.const 4
@@ -21867,11 +18807,6 @@
   i32.store
   local.get $52
   i32.const 14576
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21886,7 +18821,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 4
   i32.const -3
@@ -21897,11 +18832,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21916,7 +18846,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const 1
@@ -21929,11 +18859,6 @@
   i32.store
   local.get $52
   i32.const 14272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21948,7 +18873,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -1
   i32.const 1
@@ -21961,11 +18886,6 @@
   i32.store
   local.get $52
   i32.const 14272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -21980,7 +18900,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -5
   i32.const 1
@@ -21993,11 +18913,6 @@
   i32.store
   local.get $52
   i32.const 14272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22012,7 +18927,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 2
   i32.const 7
@@ -22023,11 +18938,6 @@
   i32.store
   local.get $52
   i32.const 14384
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22042,7 +18952,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const -11
   i32.const -6
@@ -22053,11 +18963,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22072,7 +18977,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 4
   i32.const 3
@@ -22083,11 +18988,6 @@
   i32.store
   local.get $52
   i32.const 14608
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22102,7 +19002,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const -1
@@ -22113,11 +19013,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22132,7 +19027,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 0
   i32.const 100
@@ -22143,11 +19038,6 @@
   i32.store
   local.get $52
   i32.const 14272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22162,7 +19052,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 4
   i32.const 4
@@ -22173,11 +19063,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22192,7 +19077,7 @@
   local.set $52
   global.get $~lib/memory/__stack_pointer
   local.get $52
-  i32.store offset=8
+  i32.store offset=4
   local.get $52
   i32.const 4
   i32.const -3
@@ -22203,11 +19088,6 @@
   i32.store
   local.get $52
   i32.const 1888
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -22220,18 +19100,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 0
   i32.const 0
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22246,7 +19121,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22256,11 +19131,6 @@
    i32.store
    local.get $52
    i32.const 688
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22276,23 +19146,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22313,23 +19173,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22344,7 +19194,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22354,11 +19204,6 @@
    i32.store
    local.get $52
    i32.const 688
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22374,23 +19219,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 6608
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22405,7 +19240,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22415,11 +19250,6 @@
    i32.store
    local.get $52
    i32.const 14816
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22435,23 +19265,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22466,7 +19286,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22476,11 +19296,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22490,7 +19305,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22500,11 +19315,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22514,7 +19324,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22524,11 +19334,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22544,23 +19349,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 14896
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22575,7 +19370,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22585,11 +19380,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22599,7 +19389,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22609,11 +19399,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22623,7 +19408,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22633,11 +19418,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22653,23 +19433,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14928
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22684,7 +19454,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22694,11 +19464,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22708,7 +19473,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22718,11 +19483,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22732,7 +19492,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22742,11 +19502,6 @@
    i32.store
    local.get $52
    i32.const 688
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22756,7 +19511,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22766,11 +19521,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22786,23 +19536,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14960
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22817,7 +19557,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22827,11 +19567,6 @@
    i32.store
    local.get $52
    i32.const 688
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22841,7 +19576,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22851,11 +19586,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22865,7 +19595,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22875,11 +19605,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22889,7 +19614,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22899,11 +19624,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22919,23 +19639,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14992
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -22950,7 +19660,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22960,11 +19670,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22974,7 +19679,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -22984,11 +19689,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -22998,7 +19698,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23008,11 +19708,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23022,7 +19717,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 3
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23032,11 +19727,6 @@
    i32.store
    local.get $52
    i32.const 688
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23052,23 +19742,13 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/string/String#split@varargs
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -23083,7 +19763,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23093,11 +19773,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23107,7 +19782,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23117,11 +19792,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23131,7 +19801,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23141,11 +19811,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23161,21 +19826,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 0
   call $~lib/string/String#split
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -23196,21 +19851,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   call $~lib/string/String#split
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -23225,7 +19870,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23235,11 +19880,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23255,21 +19895,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 1
   call $~lib/string/String#split
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -23284,7 +19914,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23294,11 +19924,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23314,21 +19939,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const 4
   call $~lib/string/String#split
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -23343,7 +19958,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23353,11 +19968,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23367,7 +19977,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23377,11 +19987,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23391,7 +19996,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23401,11 +20006,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23421,21 +20021,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const -1
   call $~lib/string/String#split
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -23450,7 +20040,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23460,11 +20050,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23474,7 +20059,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23484,11 +20069,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23498,7 +20078,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23508,11 +20088,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23528,21 +20103,11 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 14816
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 1600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   i32.const -1
   call $~lib/string/String#split
   local.tee $51
-  i32.store offset=92
+  i32.store offset=72
   local.get $51
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -23557,7 +20122,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 0
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23567,11 +20132,6 @@
    i32.store
    local.get $52
    i32.const 784
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23581,7 +20141,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 1
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23591,11 +20151,6 @@
    i32.store
    local.get $52
    i32.const 12336
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23605,7 +20160,7 @@
    local.set $52
    global.get $~lib/memory/__stack_pointer
    local.get $52
-   i32.store offset=8
+   i32.store offset=4
    local.get $52
    i32.const 2
    call $~lib/array/Array<~lib/string/String>#__get
@@ -23615,11 +20170,6 @@
    i32.store
    local.get $52
    i32.const 13440
-   local.set $52
-   global.get $~lib/memory/__stack_pointer
-   local.get $52
-   i32.store offset=4
-   local.get $52
    call $~lib/string/String.__eq
   else
    i32.const 0
@@ -23642,11 +20192,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23666,11 +20211,6 @@
   i32.store
   local.get $52
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23690,11 +20230,6 @@
   i32.store
   local.get $52
   i32.const 16768
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23714,11 +20249,6 @@
   i32.store
   local.get $52
   i32.const 16800
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23738,11 +20268,6 @@
   i32.store
   local.get $52
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23762,11 +20287,6 @@
   i32.store
   local.get $52
   i32.const 16832
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23786,11 +20306,6 @@
   i32.store
   local.get $52
   i32.const 12976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23810,11 +20325,6 @@
   i32.store
   local.get $52
   i32.const 16864
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23834,11 +20344,6 @@
   i32.store
   local.get $52
   i32.const 16896
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23858,11 +20363,6 @@
   i32.store
   local.get $52
   i32.const 16928
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23882,11 +20382,6 @@
   i32.store
   local.get $52
   i32.const 16976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23906,11 +20401,6 @@
   i32.store
   local.get $52
   i32.const 17024
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23930,11 +20420,6 @@
   i32.store
   local.get $52
   i32.const 17072
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23954,11 +20439,6 @@
   i32.store
   local.get $52
   i32.const 17120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -23978,11 +20458,6 @@
   i32.store
   local.get $52
   i32.const 17168
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24002,11 +20477,6 @@
   i32.store
   local.get $52
   i32.const 17216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24026,11 +20496,6 @@
   i32.store
   local.get $52
   i32.const 17264
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24050,11 +20515,6 @@
   i32.store
   local.get $52
   i32.const 17296
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24074,11 +20534,6 @@
   i32.store
   local.get $52
   i32.const 17328
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24098,11 +20553,6 @@
   i32.store
   local.get $52
   i32.const 17216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24122,11 +20572,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24146,11 +20591,6 @@
   i32.store
   local.get $52
   i32.const 17360
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24170,11 +20610,6 @@
   i32.store
   local.get $52
   i32.const 17168
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24194,11 +20629,6 @@
   i32.store
   local.get $52
   i32.const 17392
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24218,11 +20648,6 @@
   i32.store
   local.get $52
   i32.const 17440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24242,11 +20667,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24266,11 +20686,6 @@
   i32.store
   local.get $52
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24290,11 +20705,6 @@
   i32.store
   local.get $52
   i32.const 16768
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24314,11 +20724,6 @@
   i32.store
   local.get $52
   i32.const 13440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24338,11 +20743,6 @@
   i32.store
   local.get $52
   i32.const 17488
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24362,11 +20762,6 @@
   i32.store
   local.get $52
   i32.const 17520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24386,11 +20781,6 @@
   i32.store
   local.get $52
   i32.const 17552
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24410,11 +20800,6 @@
   i32.store
   local.get $52
   i32.const 17584
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24434,11 +20819,6 @@
   i32.store
   local.get $52
   i32.const 17616
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24458,11 +20838,6 @@
   i32.store
   local.get $52
   i32.const 17648
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24482,11 +20857,6 @@
   i32.store
   local.get $52
   i32.const 17680
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24506,11 +20876,6 @@
   i32.store
   local.get $52
   i32.const 17712
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24530,11 +20895,6 @@
   i32.store
   local.get $52
   i32.const 17760
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24554,11 +20914,6 @@
   i32.store
   local.get $52
   i32.const 17808
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24578,11 +20933,6 @@
   i32.store
   local.get $52
   i32.const 17856
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24602,11 +20952,6 @@
   i32.store
   local.get $52
   i32.const 17904
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24626,11 +20971,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24650,11 +20990,6 @@
   i32.store
   local.get $52
   i32.const 16832
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24674,11 +21009,6 @@
   i32.store
   local.get $52
   i32.const 17808
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24698,11 +21028,6 @@
   i32.store
   local.get $52
   i32.const 17952
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24722,11 +21047,6 @@
   i32.store
   local.get $52
   i32.const 18000
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24746,11 +21066,6 @@
   i32.store
   local.get $52
   i32.const 18048
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24770,11 +21085,6 @@
   i32.store
   local.get $52
   i32.const 18048
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24794,11 +21104,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24818,11 +21123,6 @@
   i32.store
   local.get $52
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24842,11 +21142,6 @@
   i32.store
   local.get $52
   i32.const 12880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24866,11 +21161,6 @@
   i32.store
   local.get $52
   i32.const 18096
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24890,11 +21180,6 @@
   i32.store
   local.get $52
   i32.const 18128
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24914,11 +21199,6 @@
   i32.store
   local.get $52
   i32.const 18160
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24938,11 +21218,6 @@
   i32.store
   local.get $52
   i32.const 18192
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24962,11 +21237,6 @@
   i32.store
   local.get $52
   i32.const 18224
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -24986,11 +21256,6 @@
   i32.store
   local.get $52
   i32.const 18272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25010,11 +21275,6 @@
   i32.store
   local.get $52
   i32.const 18352
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25034,11 +21294,6 @@
   i32.store
   local.get $52
   i32.const 18448
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25058,11 +21313,6 @@
   i32.store
   local.get $52
   i32.const 18544
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25082,11 +21332,6 @@
   i32.store
   local.get $52
   i32.const 18640
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25106,11 +21351,6 @@
   i32.store
   local.get $52
   i32.const 18736
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25130,11 +21370,6 @@
   i32.store
   local.get $52
   i32.const 18784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25154,11 +21389,6 @@
   i32.store
   local.get $52
   i32.const 18848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25178,11 +21408,6 @@
   i32.store
   local.get $52
   i32.const 18912
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25202,11 +21427,6 @@
   i32.store
   local.get $52
   i32.const 18960
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25226,11 +21446,6 @@
   i32.store
   local.get $52
   i32.const 19008
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25250,11 +21465,6 @@
   i32.store
   local.get $52
   i32.const 19056
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25274,11 +21484,6 @@
   i32.store
   local.get $52
   i32.const 19104
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25298,11 +21503,6 @@
   i32.store
   local.get $52
   i32.const 19152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25322,11 +21522,6 @@
   i32.store
   local.get $52
   i32.const 19200
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25346,11 +21541,6 @@
   i32.store
   local.get $52
   i32.const 19248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25370,11 +21560,6 @@
   i32.store
   local.get $52
   i32.const 19296
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25394,11 +21579,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25418,11 +21598,6 @@
   i32.store
   local.get $52
   i32.const 16800
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25442,11 +21617,6 @@
   i32.store
   local.get $52
   i32.const 1376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25466,11 +21636,6 @@
   i32.store
   local.get $52
   i32.const 12976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25490,11 +21655,6 @@
   i32.store
   local.get $52
   i32.const 16864
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25514,11 +21674,6 @@
   i32.store
   local.get $52
   i32.const 16896
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25538,11 +21693,6 @@
   i32.store
   local.get $52
   i32.const 16976
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25562,11 +21712,6 @@
   i32.store
   local.get $52
   i32.const 19344
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25586,11 +21731,6 @@
   i32.store
   local.get $52
   i32.const 19392
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25610,11 +21750,6 @@
   i32.store
   local.get $52
   i32.const 17440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25634,11 +21769,6 @@
   i32.store
   local.get $52
   i32.const 19440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25658,11 +21788,6 @@
   i32.store
   local.get $52
   i32.const 19488
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25682,11 +21807,6 @@
   i32.store
   local.get $52
   i32.const 19536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25706,11 +21826,6 @@
   i32.store
   local.get $52
   i32.const 19584
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25730,11 +21845,6 @@
   i32.store
   local.get $52
   i32.const 19632
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25754,11 +21864,6 @@
   i32.store
   local.get $52
   i32.const 19680
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25778,11 +21883,6 @@
   i32.store
   local.get $52
   i32.const 19744
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25802,11 +21902,6 @@
   i32.store
   local.get $52
   i32.const 19808
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25826,11 +21921,6 @@
   i32.store
   local.get $52
   i32.const 19872
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25850,11 +21940,6 @@
   i32.store
   local.get $52
   i32.const 19936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25874,11 +21959,6 @@
   i32.store
   local.get $52
   i32.const 20000
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25898,11 +21978,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25922,11 +21997,6 @@
   i32.store
   local.get $52
   i32.const 20064
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25946,11 +22016,6 @@
   i32.store
   local.get $52
   i32.const 17440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25970,11 +22035,6 @@
   i32.store
   local.get $52
   i32.const 19440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -25994,11 +22054,6 @@
   i32.store
   local.get $52
   i32.const 20096
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26018,11 +22073,6 @@
   i32.store
   local.get $52
   i32.const 19488
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26042,11 +22092,6 @@
   i32.store
   local.get $52
   i32.const 20144
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26066,11 +22111,6 @@
   i32.store
   local.get $52
   i32.const 20192
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26090,11 +22130,6 @@
   i32.store
   local.get $52
   i32.const 20240
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26114,11 +22149,6 @@
   i32.store
   local.get $52
   i32.const 20304
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26138,11 +22168,6 @@
   i32.store
   local.get $52
   i32.const 20368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26162,11 +22187,6 @@
   i32.store
   local.get $52
   i32.const 20432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26186,11 +22206,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26210,11 +22225,6 @@
   i32.store
   local.get $52
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26234,11 +22244,6 @@
   i32.store
   local.get $52
   i32.const 13440
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26258,11 +22263,6 @@
   i32.store
   local.get $52
   i32.const 17520
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26282,11 +22282,6 @@
   i32.store
   local.get $52
   i32.const 17616
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26306,11 +22301,6 @@
   i32.store
   local.get $52
   i32.const 20496
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26330,11 +22320,6 @@
   i32.store
   local.get $52
   i32.const 20544
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26354,11 +22339,6 @@
   i32.store
   local.get $52
   i32.const 20592
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26378,11 +22358,6 @@
   i32.store
   local.get $52
   i32.const 20640
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26402,11 +22377,6 @@
   i32.store
   local.get $52
   i32.const 20688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26426,11 +22396,6 @@
   i32.store
   local.get $52
   i32.const 20736
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26450,11 +22415,6 @@
   i32.store
   local.get $52
   i32.const 20800
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26474,11 +22434,6 @@
   i32.store
   local.get $52
   i32.const 20864
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26498,11 +22453,6 @@
   i32.store
   local.get $52
   i32.const 20928
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26522,11 +22472,6 @@
   i32.store
   local.get $52
   i32.const 20992
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26546,11 +22491,6 @@
   i32.store
   local.get $52
   i32.const 21056
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26570,11 +22510,6 @@
   i32.store
   local.get $52
   i32.const 21056
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26594,11 +22529,6 @@
   i32.store
   local.get $52
   i32.const 2368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26618,11 +22548,6 @@
   i32.store
   local.get $52
   i32.const 2432
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26642,11 +22567,6 @@
   i32.store
   local.get $52
   i32.const 18096
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26666,11 +22586,6 @@
   i32.store
   local.get $52
   i32.const 18128
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26690,11 +22605,6 @@
   i32.store
   local.get $52
   i32.const 18192
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26714,11 +22624,6 @@
   i32.store
   local.get $52
   i32.const 18224
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26738,11 +22643,6 @@
   i32.store
   local.get $52
   i32.const 18640
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26762,11 +22662,6 @@
   i32.store
   local.get $52
   i32.const 21120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26786,11 +22681,6 @@
   i32.store
   local.get $52
   i32.const 21248
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26810,11 +22700,6 @@
   i32.store
   local.get $52
   i32.const 21408
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26834,11 +22719,6 @@
   i32.store
   local.get $52
   i32.const 21504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26858,11 +22738,6 @@
   i32.store
   local.get $52
   i32.const 21616
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26882,11 +22757,6 @@
   i32.store
   local.get $52
   i32.const 21712
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26906,11 +22776,6 @@
   i32.store
   local.get $52
   i32.const 21792
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26930,11 +22795,6 @@
   i32.store
   local.get $52
   i32.const 21856
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26954,11 +22814,6 @@
   i32.store
   local.get $52
   i32.const 21920
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -26978,11 +22833,6 @@
   i32.store
   local.get $52
   i32.const 21984
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27002,11 +22852,6 @@
   i32.store
   local.get $52
   i32.const 22048
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27026,11 +22871,6 @@
   i32.store
   local.get $52
   i32.const 22112
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27050,11 +22890,6 @@
   i32.store
   local.get $52
   i32.const 22160
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27074,11 +22909,6 @@
   i32.store
   local.get $52
   i32.const 22208
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27097,11 +22927,6 @@
   i32.store
   local.get $52
   i32.const 22256
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27120,11 +22945,6 @@
   i32.store
   local.get $52
   i32.const 22256
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27143,11 +22963,6 @@
   i32.store
   local.get $52
   i32.const 6672
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27166,11 +22981,6 @@
   i32.store
   local.get $52
   i32.const 22288
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27190,11 +23000,6 @@
   i32.store
   local.get $52
   i32.const 7936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27213,11 +23018,6 @@
   i32.store
   local.get $52
   i32.const 7152
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27237,11 +23037,6 @@
   i32.store
   local.get $52
   i32.const 23312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27260,11 +23055,6 @@
   i32.store
   local.get $52
   i32.const 7216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27284,11 +23074,6 @@
   i32.store
   local.get $52
   i32.const 23376
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27307,11 +23092,6 @@
   i32.store
   local.get $52
   i32.const 23456
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27331,11 +23111,6 @@
   i32.store
   local.get $52
   i32.const 23504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27354,11 +23129,6 @@
   i32.store
   local.get $52
   i32.const 23552
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27378,11 +23148,6 @@
   i32.store
   local.get $52
   i32.const 23600
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27401,11 +23166,6 @@
   i32.store
   local.get $52
   i32.const 23648
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27424,11 +23184,6 @@
   i32.store
   local.get $52
   i32.const 23712
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27447,11 +23202,6 @@
   i32.store
   local.get $52
   i32.const 23792
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27470,11 +23220,6 @@
   i32.store
   local.get $52
   i32.const 23840
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27493,11 +23238,6 @@
   i32.store
   local.get $52
   i32.const 23904
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27516,11 +23256,6 @@
   i32.store
   local.get $52
   i32.const 23968
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27539,11 +23274,6 @@
   i32.store
   local.get $52
   i32.const 7296
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27562,11 +23292,6 @@
   i32.store
   local.get $52
   i32.const 24032
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27585,11 +23310,6 @@
   i32.store
   local.get $52
   i32.const 4256
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27608,11 +23328,6 @@
   i32.store
   local.get $52
   i32.const 24064
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27631,11 +23346,6 @@
   i32.store
   local.get $52
   i32.const 24096
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27654,11 +23364,6 @@
   i32.store
   local.get $52
   i32.const 24128
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27677,11 +23382,6 @@
   i32.store
   local.get $52
   i32.const 24176
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27700,11 +23400,6 @@
   i32.store
   local.get $52
   i32.const 24224
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27723,11 +23418,6 @@
   i32.store
   local.get $52
   i32.const 24272
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27746,11 +23436,6 @@
   i32.store
   local.get $52
   i32.const 24320
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27769,11 +23454,6 @@
   i32.store
   local.get $52
   i32.const 24368
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27792,11 +23472,6 @@
   i32.store
   local.get $52
   i32.const 4544
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27815,11 +23490,6 @@
   i32.store
   local.get $52
   i32.const 24400
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27838,11 +23508,6 @@
   i32.store
   local.get $52
   i32.const 22288
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27861,11 +23526,6 @@
   i32.store
   local.get $52
   i32.const 7936
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27884,11 +23544,6 @@
   i32.store
   local.get $52
   i32.const 24448
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27907,11 +23562,6 @@
   i32.store
   local.get $52
   i32.const 24480
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27930,11 +23580,6 @@
   i32.store
   local.get $52
   i32.const 24528
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27953,11 +23598,6 @@
   i32.store
   local.get $52
   i32.const 24560
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27976,11 +23616,6 @@
   i32.store
   local.get $52
   i32.const 22256
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -27999,11 +23634,6 @@
   i32.store
   local.get $52
   i32.const 24608
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28022,11 +23652,6 @@
   i32.store
   local.get $52
   i32.const 24656
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28045,11 +23670,6 @@
   i32.store
   local.get $52
   i32.const 24720
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28068,11 +23688,6 @@
   i32.store
   local.get $52
   i32.const 24784
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28091,11 +23706,6 @@
   i32.store
   local.get $52
   i32.const 24032
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28114,11 +23724,6 @@
   i32.store
   local.get $52
   i32.const 24848
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28139,11 +23744,6 @@
   i32.store
   local.get $52
   i32.const 24880
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28162,11 +23762,6 @@
   i32.store
   local.get $52
   i32.const 24944
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28185,11 +23780,6 @@
   i32.store
   local.get $52
   i32.const 25024
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28208,11 +23798,6 @@
   i32.store
   local.get $52
   i32.const 25072
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28231,11 +23816,6 @@
   i32.store
   local.get $52
   i32.const 25120
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28254,11 +23834,6 @@
   i32.store
   local.get $52
   i32.const 25168
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28277,11 +23852,6 @@
   i32.store
   local.get $52
   i32.const 25216
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28300,11 +23870,6 @@
   i32.store
   local.get $52
   i32.const 25264
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28323,11 +23888,6 @@
   i32.store
   local.get $52
   i32.const 25312
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28339,17 +23899,7 @@
    unreachable
   end
   i32.const 25360
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 25392
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -28357,11 +23907,6 @@
   i32.store
   local.get $52
   i32.const 25424
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28373,17 +23918,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 25472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -28391,11 +23926,6 @@
   i32.store
   local.get $52
   i32.const 25472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28407,17 +23937,7 @@
    unreachable
   end
   i32.const 25472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -28425,11 +23945,6 @@
   i32.store
   local.get $52
   i32.const 25472
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28441,17 +23956,7 @@
    unreachable
   end
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=8
-  local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=12
-  local.get $52
   call $~lib/string/String#concat
   local.set $52
   global.get $~lib/memory/__stack_pointer
@@ -28459,11 +23964,6 @@
   i32.store
   local.get $52
   i32.const 688
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28475,17 +23975,7 @@
    unreachable
   end
   i32.const 25504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 25504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28497,17 +23987,7 @@
    unreachable
   end
   i32.const 25504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 25504
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28519,17 +23999,7 @@
    unreachable
   end
   i32.const 25536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 25536
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28541,17 +24011,7 @@
    unreachable
   end
   i32.const 25568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store
-  local.get $52
   i32.const 25568
-  local.set $52
-  global.get $~lib/memory/__stack_pointer
-  local.get $52
-  i32.store offset=4
-  local.get $52
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -28568,7 +24028,7 @@
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 96
+  i32.const 76
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -9918,9 +9918,6 @@
          global.get $~lib/memory/__stack_pointer
          local.get $2
          i32.store offset=4
-         global.get $~lib/memory/__stack_pointer
-         i32.const 1712
-         i32.store offset=24
          local.get $2
          i32.const 1712
          call $~lib/array/Array<~lib/string/String>#push
@@ -9990,9 +9987,6 @@
        global.get $~lib/memory/__stack_pointer
        local.get $2
        i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 1712
-       i32.store offset=24
        local.get $2
        i32.const 1712
        call $~lib/array/Array<~lib/string/String>#push
@@ -10148,7 +10142,7 @@
   (local $5 i32)
   (local $6 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 96
+  i32.const 76
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -10158,7 +10152,7 @@
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 96
+   i32.const 76
    memory.fill
    global.get $std/string/str
    i32.const 1056
@@ -10171,12 +10165,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store offset=4
    i32.const 1168
    i32.const 1168
    call $~lib/string/String.__eq
@@ -10189,12 +10177,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1200
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1200
-   i32.store offset=4
    i32.const 1200
    i32.const 1200
    call $~lib/string/String.__eq
@@ -10207,12 +10189,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1232
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1232
-   i32.store offset=4
    i32.const 1232
    i32.const 1232
    call $~lib/string/String.__eq
@@ -10506,11 +10482,11 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $4
-   i32.store offset=12
+   i32.store offset=8
    local.get $0
    i32.const 0
    local.get $4
@@ -10525,9 +10501,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1744
-   i32.store offset=4
    local.get $0
    i32.const 1744
    call $~lib/string/String.__eq
@@ -10540,9 +10513,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
    i32.const 1712
    call $~lib/string/String.__not
    i32.eqz
@@ -10554,9 +10524,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1776
-   i32.store
    i32.const 1776
    call $~lib/string/String.__not
    if
@@ -10567,9 +10534,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store
    i32.const 1808
    call $~lib/string/String.__not
    if
@@ -10588,9 +10552,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1776
-   i32.store offset=4
    local.get $0
    i32.const 1776
    call $~lib/string/String.__eq
@@ -10611,9 +10572,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1840
-   i32.store offset=4
    local.get $0
    i32.const 1840
    call $~lib/string/String.__eq
@@ -10634,9 +10592,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1872
-   i32.store offset=4
    local.get $0
    i32.const 1872
    call $~lib/string/String.__eq
@@ -10657,9 +10612,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1872
-   i32.store offset=4
    local.get $0
    i32.const 1872
    call $~lib/string/String.__eq
@@ -10679,9 +10631,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1904
-   i32.store offset=4
    local.get $0
    i32.const 1904
    call $~lib/string/String.__eq
@@ -10701,16 +10650,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    call $~lib/string/String.fromCharCodes
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1968
-   i32.store offset=4
    local.get $0
    i32.const 1968
    call $~lib/string/String.__eq
@@ -10730,16 +10676,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    call $~lib/string/String.fromCharCodes
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2032
-   i32.store offset=4
    local.get $0
    i32.const 2032
    call $~lib/string/String.__eq
@@ -10759,16 +10702,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    call $~lib/string/String.fromCharCodes
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2112
-   i32.store offset=4
    local.get $0
    i32.const 2112
    call $~lib/string/String.__eq
@@ -10787,9 +10727,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1776
-   i32.store offset=4
    local.get $0
    i32.const 1776
    call $~lib/string/String.__eq
@@ -10808,9 +10745,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1872
-   i32.store offset=4
    local.get $0
    i32.const 1872
    call $~lib/string/String.__eq
@@ -10829,9 +10763,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2144
-   i32.store offset=4
    local.get $0
    i32.const 2144
    call $~lib/string/String.__eq
@@ -10848,9 +10779,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2176
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -10924,9 +10852,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2208
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -11032,9 +10957,6 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 2240
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -11074,9 +10996,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    local.get $0
    i32.const 0
    i32.const 2272
@@ -11105,9 +11024,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    local.get $0
    i32.const 15
    i32.const 2272
@@ -11132,12 +11048,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    i32.const 1712
    i32.const 3
    i32.const 2272
@@ -11146,9 +11056,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2304
-   i32.store offset=4
    local.get $0
    i32.const 2304
    call $~lib/string/String.__eq
@@ -11161,12 +11068,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
    i32.const 1712
    i32.const 10
    i32.const 1712
@@ -11175,9 +11076,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -11190,12 +11088,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
    i32.const 1808
    i32.const 100
    i32.const 1712
@@ -11204,9 +11096,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    local.get $0
    i32.const 1808
    call $~lib/string/String.__eq
@@ -11219,12 +11108,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    i32.const 2336
    i32.const 5
    i32.const 2272
@@ -11233,9 +11116,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2368
-   i32.store offset=4
    local.get $0
    i32.const 2368
    call $~lib/string/String.__eq
@@ -11248,12 +11128,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store offset=12
    i32.const 2336
    i32.const 6
    i32.const 2400
@@ -11262,9 +11136,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2432
-   i32.store offset=4
    local.get $0
    i32.const 2432
    call $~lib/string/String.__eq
@@ -11277,12 +11148,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store offset=12
    i32.const 2336
    i32.const 8
    i32.const 2400
@@ -11291,9 +11156,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2464
-   i32.store offset=4
    local.get $0
    i32.const 2464
    call $~lib/string/String.__eq
@@ -11310,9 +11172,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    local.get $0
    i32.const 0
    i32.const 2272
@@ -11341,9 +11200,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    local.get $0
    i32.const 15
    i32.const 2272
@@ -11368,12 +11224,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    i32.const 1712
    i32.const 3
    i32.const 2272
@@ -11382,9 +11232,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2304
-   i32.store offset=4
    local.get $0
    i32.const 2304
    call $~lib/string/String.__eq
@@ -11397,12 +11244,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
    i32.const 1712
    i32.const 10
    i32.const 1712
@@ -11411,9 +11252,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -11426,12 +11264,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
    i32.const 1808
    i32.const 100
    i32.const 1712
@@ -11440,9 +11272,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    local.get $0
    i32.const 1808
    call $~lib/string/String.__eq
@@ -11455,12 +11284,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2272
-   i32.store offset=12
    i32.const 2336
    i32.const 5
    i32.const 2272
@@ -11469,9 +11292,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2512
-   i32.store offset=4
    local.get $0
    i32.const 2512
    call $~lib/string/String.__eq
@@ -11484,12 +11304,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=12
    i32.const 2336
    i32.const 6
    i32.const 2336
@@ -11498,9 +11312,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2544
-   i32.store offset=4
    local.get $0
    i32.const 2544
    call $~lib/string/String.__eq
@@ -11513,12 +11324,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=12
    i32.const 2336
    i32.const 8
    i32.const 2336
@@ -11527,9 +11332,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2576
-   i32.store offset=4
    local.get $0
    i32.const 2576
    call $~lib/string/String.__eq
@@ -11542,12 +11344,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1712
    i32.const 1712
    i32.const 0
@@ -11560,12 +11356,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2176
-   i32.store offset=4
    i32.const 1712
    i32.const 2176
    i32.const 0
@@ -11580,12 +11370,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    i32.const 1808
    i32.const 1808
    i32.const 0
@@ -11622,9 +11406,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    i32.const 0
@@ -11641,9 +11422,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    local.get $0
    i32.const 2624
    i32.const 0
@@ -11662,9 +11440,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2656
-   i32.store offset=4
    local.get $0
    i32.const 2656
    i32.const 0
@@ -11683,9 +11458,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    local.get $0
    i32.const 2624
    i32.const 2
@@ -11704,9 +11476,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    local.get $0
    i32.const 2624
    i32.const 3
@@ -11725,9 +11494,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2688
-   i32.store offset=4
    local.get $0
    i32.const 2688
    i32.const -1
@@ -11742,12 +11508,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    i32.const 1712
@@ -11761,12 +11521,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2176
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    i32.const 1712
@@ -11786,9 +11540,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -11817,9 +11568,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -11839,9 +11587,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2656
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -11861,9 +11606,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2720
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -11883,9 +11625,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    local.get $0
    i32.const 2624
    i32.const 2
@@ -11904,9 +11643,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    local.get $0
    i32.const 2624
    i32.const 3
@@ -11925,9 +11661,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2688
-   i32.store offset=4
    local.get $0
    i32.const 2688
    i32.const -1
@@ -11946,9 +11679,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2752
-   i32.store offset=4
    local.get $0
    i32.const 2752
    i32.const 0
@@ -11967,9 +11697,6 @@
    global.get $std/string/str
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2176
-   i32.store offset=4
    local.get $0
    i32.const 2176
    i32.const 0
@@ -11982,12 +11709,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1712
    i32.const 1712
    call $~lib/string/String#localeCompare
@@ -11999,12 +11720,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1808
    i32.const 1712
    call $~lib/string/String#localeCompare
@@ -12018,12 +11733,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    i32.const 1712
    i32.const 1808
    call $~lib/string/String#localeCompare
@@ -12037,12 +11746,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2784
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2784
-   i32.store offset=4
    i32.const 2784
    i32.const 2784
    call $~lib/string/String#localeCompare
@@ -12054,12 +11757,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2816
-   i32.store offset=4
    i32.const 2336
    i32.const 2816
    call $~lib/string/String#localeCompare
@@ -12073,12 +11770,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2848
-   i32.store offset=4
    i32.const 2336
    i32.const 2848
    call $~lib/string/String#localeCompare
@@ -12092,12 +11783,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2816
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    i32.const 2816
    i32.const 2336
    call $~lib/string/String#localeCompare
@@ -12111,12 +11796,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2880
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    i32.const 2880
    i32.const 2336
    call $~lib/string/String#localeCompare
@@ -12130,12 +11809,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2912
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    i32.const 2912
    i32.const 2336
    call $~lib/string/String#localeCompare
@@ -12149,12 +11822,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2880
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2944
-   i32.store offset=4
    i32.const 2880
    i32.const 2944
    call $~lib/string/String#localeCompare
@@ -12168,12 +11835,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2912
-   i32.store offset=4
    i32.const 2336
    i32.const 2912
    call $~lib/string/String#localeCompare
@@ -12187,12 +11848,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2944
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2880
-   i32.store offset=4
    i32.const 2944
    i32.const 2880
    call $~lib/string/String#localeCompare
@@ -12206,12 +11861,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2304
-   i32.store offset=4
    i32.const 1712
    i32.const 2304
    call $~lib/string/String#localeCompare
@@ -12225,12 +11874,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1776
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1776
    i32.const 1712
    call $~lib/string/String#localeCompare
@@ -12244,18 +11887,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
    i32.const 1712
    call $~lib/string/String#trimStart
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -12268,18 +11905,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2976
-   i32.store offset=8
    i32.const 2976
    call $~lib/string/String#trimStart
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2976
-   i32.store offset=4
    local.get $0
    i32.const 2976
    call $~lib/string/String.__eq
@@ -12292,18 +11923,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3008
-   i32.store offset=8
    i32.const 3008
    call $~lib/string/String#trimStart
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3056
-   i32.store offset=4
    local.get $0
    i32.const 3056
    call $~lib/string/String.__eq
@@ -12316,18 +11941,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
    i32.const 1712
    call $~lib/string/String#trimEnd
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -12340,18 +11959,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2976
-   i32.store offset=8
    i32.const 2976
    call $~lib/string/String#trimEnd
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2976
-   i32.store offset=4
    local.get $0
    i32.const 2976
    call $~lib/string/String.__eq
@@ -12364,18 +11977,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3008
-   i32.store offset=8
    i32.const 3008
    call $~lib/string/String#trimEnd
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3104
-   i32.store offset=4
    local.get $0
    i32.const 3104
    call $~lib/string/String.__eq
@@ -12388,18 +11995,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
    i32.const 1712
    call $~lib/string/String#trim
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -12412,18 +12013,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2976
-   i32.store offset=8
    i32.const 2976
    call $~lib/string/String#trim
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2976
-   i32.store offset=4
    local.get $0
    i32.const 2976
    call $~lib/string/String.__eq
@@ -12436,18 +12031,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3008
-   i32.store offset=8
    i32.const 3008
    call $~lib/string/String#trim
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -12574,9 +12163,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store
    i32.const 3392
    i32.const 0
    call $~lib/string/parseInt
@@ -12590,9 +12176,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3424
-   i32.store
    i32.const 3424
    i32.const 0
    call $~lib/string/parseInt
@@ -12606,9 +12189,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store
    i32.const 3456
    i32.const 0
    call $~lib/string/parseInt
@@ -12622,9 +12202,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3488
-   i32.store
    i32.const 3488
    i32.const 0
    call $~lib/string/parseInt
@@ -12638,9 +12215,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3520
-   i32.store
    i32.const 3520
    i32.const 0
    call $~lib/string/parseInt
@@ -12654,9 +12228,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3552
-   i32.store
    i32.const 3552
    i32.const 0
    call $~lib/string/parseInt
@@ -12670,9 +12241,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3584
-   i32.store
    i32.const 3584
    i32.const 0
    call $~lib/string/parseInt
@@ -12686,9 +12254,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3616
-   i32.store
    i32.const 3616
    i32.const 0
    call $~lib/string/parseInt
@@ -12702,9 +12267,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3648
-   i32.store
    i32.const 3648
    i32.const 0
    call $~lib/string/parseInt
@@ -12718,9 +12280,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3680
-   i32.store
    i32.const 3680
    i32.const 0
    call $~lib/string/parseInt
@@ -12734,9 +12293,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3712
-   i32.store
    i32.const 3712
    i32.const 0
    call $~lib/string/parseInt
@@ -12750,9 +12306,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3744
-   i32.store
    i32.const 3744
    i32.const 0
    call $~lib/string/parseInt
@@ -12766,9 +12319,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3776
-   i32.store
    i32.const 3776
    i32.const 0
    call $~lib/string/parseInt
@@ -12782,9 +12332,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store
    i32.const 3392
    i32.const 0
    call $~lib/string/parseInt
@@ -12798,9 +12345,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3808
-   i32.store
    i32.const 3808
    i32.const 0
    call $~lib/string/parseInt
@@ -12814,9 +12358,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3840
-   i32.store
    i32.const 3840
    i32.const 16
    call $~lib/string/parseInt
@@ -12830,9 +12371,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3872
-   i32.store
    i32.const 3872
    i32.const 0
    call $~lib/string/parseInt
@@ -12846,9 +12384,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3904
-   i32.store
    i32.const 3904
    i32.const 0
    call $~lib/string/parseInt
@@ -12862,9 +12397,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3936
-   i32.store
    i32.const 3936
    i32.const 0
    call $~lib/string/parseInt
@@ -12878,9 +12410,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3968
-   i32.store
    i32.const 3968
    i32.const 0
    call $~lib/string/parseInt
@@ -12896,20 +12425,12 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4000
-   i32.store
    i32.const 4000
    i32.const 0
    call $~lib/string/parseInt
-   local.set $1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4048
-   i32.store
    i32.const 4048
    i32.const 16
    call $~lib/string/parseInt
-   local.get $1
    f64.ne
    if
     i32.const 0
@@ -12919,9 +12440,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4080
-   i32.store
    i32.const 4080
    i32.const 0
    call $~lib/string/parseInt
@@ -12935,9 +12453,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4080
-   i32.store
    i32.const 4080
    i32.const 13
    call $~lib/string/parseInt
@@ -12951,9 +12466,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4144
-   i32.store
    i32.const 4144
    i32.const 10
    call $~lib/string/parseInt
@@ -12967,9 +12479,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4224
-   i32.store
    i32.const 4224
    i32.const 16
    call $~lib/string/parseInt
@@ -12983,9 +12492,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4288
-   i32.store
    i32.const 4288
    i32.const 0
    call $~lib/string/parseInt
@@ -12999,9 +12505,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4320
-   i32.store
    i32.const 4320
    i32.const 0
    call $~lib/string/parseInt
@@ -13015,9 +12518,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4368
-   i32.store
    i32.const 4368
    i32.const 0
    call $~lib/string/parseInt
@@ -13031,9 +12531,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4400
-   i32.store
    i32.const 4400
    i32.const 0
    call $~lib/string/parseInt
@@ -13047,9 +12544,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4448
-   i32.store
    i32.const 4448
    i32.const 0
    call $~lib/string/parseInt
@@ -13063,9 +12557,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4480
-   i32.store
    i32.const 4480
    i32.const 0
    call $~lib/string/parseInt
@@ -13079,9 +12570,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4512
-   i32.store
    i32.const 4512
    i32.const 0
    call $~lib/string/parseInt
@@ -13095,9 +12583,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
    i32.const 1712
    i32.const 0
    call $~lib/string/parseInt
@@ -13112,9 +12597,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store
    i32.const 4560
    i32.const 0
    call $~lib/string/parseInt
@@ -13129,9 +12611,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store
    i32.const 4592
    i32.const 0
    call $~lib/string/parseInt
@@ -13146,9 +12625,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store
    i32.const 2400
    i32.const 37
    call $~lib/string/parseInt
@@ -13163,9 +12639,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4624
-   i32.store
    i32.const 4624
    i32.const 0
    call $~lib/string/parseInt
@@ -13180,9 +12653,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4656
-   i32.store
    i32.const 4656
    i32.const 0
    call $~lib/string/parseInt
@@ -13197,9 +12667,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4656
-   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -13233,9 +12700,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4656
-   i32.store
    i32.const 4656
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -13289,9 +12753,6 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 4880
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -13338,9 +12799,6 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 4928
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
@@ -13386,9 +12844,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store
    i32.const 3392
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -13401,9 +12856,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store
    i32.const 3456
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -13416,9 +12868,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4992
-   i32.store
    i32.const 4992
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -13431,9 +12880,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5024
-   i32.store
    i32.const 5024
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -13446,9 +12892,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5056
-   i32.store
    i32.const 5056
    call $~lib/number/F64.parseFloat
    f64.const 1e-05
@@ -13461,9 +12904,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5088
-   i32.store
    i32.const 5088
    call $~lib/number/F64.parseFloat
    f64.const -1e-05
@@ -13476,9 +12916,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5120
-   i32.store
    i32.const 5120
    call $~lib/number/F64.parseFloat
    f64.const -3e-23
@@ -13491,9 +12928,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5168
-   i32.store
    i32.const 5168
    call $~lib/number/F64.parseFloat
    f64.const 3e21
@@ -13506,9 +12940,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5216
-   i32.store
    i32.const 5216
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -13521,9 +12952,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5248
-   i32.store
    i32.const 5248
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -13536,9 +12964,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5280
-   i32.store
    i32.const 5280
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -13551,9 +12976,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5312
-   i32.store
    i32.const 5312
    call $~lib/number/F64.parseFloat
    f64.const 0.25
@@ -13566,9 +12988,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5344
-   i32.store
    i32.const 5344
    call $~lib/number/F64.parseFloat
    f64.const 1e3
@@ -13581,9 +13000,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5376
-   i32.store
    i32.const 5376
    call $~lib/number/F64.parseFloat
    f64.const 1e-10
@@ -13596,9 +13012,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5424
-   i32.store
    i32.const 5424
    call $~lib/number/F64.parseFloat
    f64.const 1e-30
@@ -13611,9 +13024,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5472
-   i32.store
    i32.const 5472
    call $~lib/number/F64.parseFloat
    f64.const 1e-323
@@ -13626,9 +13036,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5520
-   i32.store
    i32.const 5520
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -13641,9 +13048,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5568
-   i32.store
    i32.const 5568
    call $~lib/number/F64.parseFloat
    f64.const 1.e+308
@@ -13656,9 +13060,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5600
-   i32.store
    i32.const 5600
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -13671,9 +13072,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
    i32.const 1712
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -13687,9 +13085,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5632
-   i32.store
    i32.const 5632
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -13702,9 +13097,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5680
-   i32.store
    i32.const 5680
    call $~lib/number/F64.parseFloat
    f64.const 1e-10
@@ -13717,9 +13109,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5728
-   i32.store
    i32.const 5728
    call $~lib/number/F64.parseFloat
    f64.const 10
@@ -13732,9 +13121,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5776
-   i32.store
    i32.const 5776
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -13747,9 +13133,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5808
-   i32.store
    i32.const 5808
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -13762,9 +13145,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5840
-   i32.store
    i32.const 5840
    call $~lib/number/F64.parseFloat
    f64.const 10
@@ -13777,9 +13157,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5888
-   i32.store
    i32.const 5888
    call $~lib/number/F64.parseFloat
    f64.const 123456789
@@ -13792,9 +13169,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5936
-   i32.store
    i32.const 5936
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -13807,9 +13181,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5984
-   i32.store
    i32.const 5984
    call $~lib/number/F64.parseFloat
    f64.const 1e-60
@@ -13822,9 +13193,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6016
-   i32.store
    i32.const 6016
    call $~lib/number/F64.parseFloat
    f64.const 1.e+60
@@ -13837,9 +13205,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6048
-   i32.store
    i32.const 6048
    call $~lib/number/F64.parseFloat
    f64.const 123.4
@@ -13852,9 +13217,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6080
-   i32.store
    i32.const 6080
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -13867,9 +13229,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6112
-   i32.store
    i32.const 6112
    call $~lib/number/F64.parseFloat
    f64.const -1.1
@@ -13882,9 +13241,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6160
-   i32.store
    i32.const 6160
    call $~lib/number/F64.parseFloat
    f64.const 10
@@ -13897,9 +13253,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6208
-   i32.store
    i32.const 6208
    call $~lib/number/F64.parseFloat
    f64.const 10
@@ -13912,9 +13265,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6256
-   i32.store
    i32.const 6256
    call $~lib/number/F64.parseFloat
    f64.const 0.022
@@ -13927,9 +13277,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6304
-   i32.store
    i32.const 6304
    call $~lib/number/F64.parseFloat
    f64.const 11
@@ -13942,9 +13289,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3808
-   i32.store
    i32.const 3808
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -13957,9 +13301,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6336
-   i32.store
    i32.const 6336
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -13972,9 +13313,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6368
-   i32.store
    i32.const 6368
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -13987,9 +13325,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6400
-   i32.store
    i32.const 6400
    call $~lib/number/F64.parseFloat
    f64.const 1.1
@@ -14002,9 +13337,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6432
-   i32.store
    i32.const 6432
    call $~lib/number/F64.parseFloat
    f64.const -1.1
@@ -14017,9 +13349,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6464
-   i32.store
    i32.const 6464
    call $~lib/number/F64.parseFloat
    f64.const -1.1
@@ -14032,9 +13361,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6496
-   i32.store
    i32.const 6496
    call $~lib/number/F64.parseFloat
    f64.const -1.1
@@ -14047,9 +13373,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6528
-   i32.store
    i32.const 6528
    call $~lib/number/F64.parseFloat
    f64.const -1.1
@@ -14062,9 +13385,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6560
-   i32.store
    i32.const 6560
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14077,9 +13397,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6592
-   i32.store
    i32.const 6592
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14092,9 +13409,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6624
-   i32.store
    i32.const 6624
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -14107,9 +13421,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6656
-   i32.store
    i32.const 6656
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14122,9 +13433,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6688
-   i32.store
    i32.const 6688
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14137,9 +13445,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6720
-   i32.store
    i32.const 6720
    call $~lib/number/F64.parseFloat
    f64.const 10
@@ -14152,9 +13457,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6752
-   i32.store
    i32.const 6752
    call $~lib/number/F64.parseFloat
    f64.const 10
@@ -14167,9 +13469,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6800
-   i32.store
    i32.const 6800
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14182,9 +13481,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6832
-   i32.store
    i32.const 6832
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -14197,9 +13493,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6864
-   i32.store
    i32.const 6864
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -14212,9 +13505,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6896
-   i32.store
    i32.const 6896
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -14227,9 +13517,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6928
-   i32.store
    i32.const 6928
    call $~lib/number/F64.parseFloat
    f64.const 10
@@ -14242,9 +13529,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6960
-   i32.store
    i32.const 6960
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -14257,9 +13541,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6992
-   i32.store
    i32.const 6992
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -14272,9 +13553,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7024
-   i32.store
    i32.const 7024
    call $~lib/number/F64.parseFloat
    f64.const 0.01
@@ -14287,9 +13565,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7072
-   i32.store
    i32.const 7072
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14302,9 +13577,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7104
-   i32.store
    i32.const 7104
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14317,9 +13589,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7136
-   i32.store
    i32.const 7136
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14332,9 +13601,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7168
-   i32.store
    i32.const 7168
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -14347,9 +13613,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7200
-   i32.store
    i32.const 7200
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14362,9 +13625,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7232
-   i32.store
    i32.const 7232
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14377,9 +13637,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7264
-   i32.store
    i32.const 7264
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -14392,9 +13649,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7296
-   i32.store
    i32.const 7296
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -14407,9 +13661,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7328
-   i32.store
    i32.const 7328
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14422,9 +13673,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7360
-   i32.store
    i32.const 7360
    call $~lib/number/F64.parseFloat
    i64.reinterpret_f64
@@ -14438,9 +13686,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7392
-   i32.store
    i32.const 7392
    call $~lib/number/F64.parseFloat
    i64.reinterpret_f64
@@ -14454,9 +13699,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7424
-   i32.store
    i32.const 7424
    call $~lib/number/F64.parseFloat
    i64.reinterpret_f64
@@ -14470,9 +13712,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3968
-   i32.store
    i32.const 3968
    call $~lib/number/F64.parseFloat
    i64.reinterpret_f64
@@ -14486,9 +13725,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7456
-   i32.store
    i32.const 7456
    call $~lib/number/F64.parseFloat
    i64.reinterpret_f64
@@ -14502,9 +13738,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store
    i32.const 4592
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14518,9 +13751,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store
    i32.const 4560
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14534,9 +13764,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7504
-   i32.store
    i32.const 7504
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14550,9 +13777,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7536
-   i32.store
    i32.const 7536
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14566,9 +13790,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7568
-   i32.store
    i32.const 7568
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14582,9 +13803,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7600
-   i32.store
    i32.const 7600
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14598,9 +13816,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7632
-   i32.store
    i32.const 7632
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14614,9 +13829,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7664
-   i32.store
    i32.const 7664
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14630,9 +13842,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7696
-   i32.store
    i32.const 7696
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14646,9 +13855,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7728
-   i32.store
    i32.const 7728
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14662,9 +13868,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7760
-   i32.store
    i32.const 7760
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14678,9 +13881,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7792
-   i32.store
    i32.const 7792
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14694,9 +13894,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7824
-   i32.store
    i32.const 7824
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14710,9 +13907,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7856
-   i32.store
    i32.const 7856
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14726,9 +13920,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7888
-   i32.store
    i32.const 7888
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14742,9 +13933,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3360
-   i32.store
    i32.const 3360
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -14758,9 +13946,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7920
-   i32.store
    i32.const 7920
    call $~lib/number/F64.parseFloat
    f64.const 1e22
@@ -14773,9 +13958,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7952
-   i32.store
    i32.const 7952
    call $~lib/number/F64.parseFloat
    f64.const 1e-22
@@ -14788,9 +13970,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7984
-   i32.store
    i32.const 7984
    call $~lib/number/F64.parseFloat
    f64.const 1.e+23
@@ -14803,9 +13982,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8016
-   i32.store
    i32.const 8016
    call $~lib/number/F64.parseFloat
    f64.const 1e-23
@@ -14818,9 +13994,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8048
-   i32.store
    i32.const 8048
    call $~lib/number/F64.parseFloat
    f64.const 1.e+37
@@ -14833,9 +14006,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8080
-   i32.store
    i32.const 8080
    call $~lib/number/F64.parseFloat
    f64.const 1e-37
@@ -14848,9 +14018,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8112
-   i32.store
    i32.const 8112
    call $~lib/number/F64.parseFloat
    f64.const 1.e+38
@@ -14863,9 +14030,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8144
-   i32.store
    i32.const 8144
    call $~lib/number/F64.parseFloat
    f64.const 1e-38
@@ -14878,9 +14042,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8176
-   i32.store
    i32.const 8176
    call $~lib/number/F64.parseFloat
    f64.const 2.220446049250313e-16
@@ -14893,9 +14054,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8240
-   i32.store
    i32.const 8240
    call $~lib/number/F64.parseFloat
    f64.const 1797693134862315708145274e284
@@ -14908,9 +14066,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8320
-   i32.store
    i32.const 8320
    call $~lib/number/F64.parseFloat
    f64.const 5e-324
@@ -14923,9 +14078,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8352
-   i32.store
    i32.const 8352
    call $~lib/number/F64.parseFloat
    f64.const 1.e+308
@@ -14938,9 +14090,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8400
-   i32.store
    i32.const 8400
    call $~lib/number/F64.parseFloat
    f64.const 1
@@ -14953,9 +14102,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8544
-   i32.store
    i32.const 8544
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14968,9 +14114,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8592
-   i32.store
    i32.const 8592
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -14983,9 +14126,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8640
-   i32.store
    i32.const 8640
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -14998,9 +14138,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8688
-   i32.store
    i32.const 8688
    call $~lib/number/F64.parseFloat
    f64.const -inf
@@ -15013,9 +14150,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8736
-   i32.store
    i32.const 8736
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -15028,9 +14162,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8784
-   i32.store
    i32.const 8784
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -15043,9 +14174,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8832
-   i32.store
    i32.const 8832
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -15058,9 +14186,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8864
-   i32.store
    i32.const 8864
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -15073,9 +14198,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8912
-   i32.store
    i32.const 8912
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -15088,9 +14210,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8960
-   i32.store
    i32.const 8960
    call $~lib/number/F64.parseFloat
    f64.const -inf
@@ -15103,9 +14222,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9008
-   i32.store
    i32.const 9008
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -15118,9 +14234,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9056
-   i32.store
    i32.const 9056
    call $~lib/number/F64.parseFloat
    f64.const inf
@@ -15133,9 +14246,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9104
-   i32.store
    i32.const 9104
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -15149,9 +14259,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9136
-   i32.store
    i32.const 9136
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -15165,9 +14272,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9184
-   i32.store
    i32.const 9184
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -15181,9 +14285,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9232
-   i32.store
    i32.const 9232
    call $~lib/number/F64.parseFloat
    f64.const 0
@@ -15196,9 +14297,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9424
-   i32.store
    i32.const 9424
    call $~lib/number/F64.parseFloat
    f64.const 1e-323
@@ -15211,9 +14309,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9616
-   i32.store
    i32.const 9616
    call $~lib/number/F64.parseFloat
    f64.const 2.225073858507202e-308
@@ -15226,32 +14321,20 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9808
-   i32.store offset=72
-   global.get $~lib/memory/__stack_pointer
-   i32.const 9968
-   i32.store offset=76
    i32.const 9808
    i32.const 9968
-   call $~lib/string/String.__concat
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=64
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10128
-   i32.store offset=68
-   local.get $0
-   i32.const 10128
    call $~lib/string/String.__concat
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=12
+   local.get $0
+   i32.const 10128
+   call $~lib/string/String.__concat
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   i32.const 10288
-   i32.store offset=60
+   local.get $0
+   i32.store offset=8
    local.get $0
    i32.const 10288
    call $~lib/string/String.__concat
@@ -15259,9 +14342,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10448
-   i32.store offset=8
    local.get $0
    i32.const 10448
    call $~lib/string/String.__concat
@@ -15281,9 +14361,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10608
-   i32.store
    i32.const 10608
    call $~lib/number/F64.parseFloat
    f64.const 9.753531888799502e-104
@@ -15296,9 +14373,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10720
-   i32.store
    i32.const 10720
    call $~lib/number/F64.parseFloat
    f64.const 0.5961860348131807
@@ -15311,9 +14385,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10832
-   i32.store
    i32.const 10832
    call $~lib/number/F64.parseFloat
    f64.const 0.18150131692180388
@@ -15326,9 +14397,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 10944
-   i32.store
    i32.const 10944
    call $~lib/number/F64.parseFloat
    f64.const 0.42070823575344535
@@ -15341,9 +14409,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11056
-   i32.store
    i32.const 11056
    call $~lib/number/F64.parseFloat
    f64.const 0.6654686306516261
@@ -15356,9 +14421,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11168
-   i32.store
    i32.const 11168
    call $~lib/number/F64.parseFloat
    f64.const 0.6101852922970868
@@ -15371,9 +14433,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11280
-   i32.store
    i32.const 11280
    call $~lib/number/F64.parseFloat
    f64.const 0.7696695208236968
@@ -15386,9 +14445,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11392
-   i32.store
    i32.const 11392
    call $~lib/number/F64.parseFloat
    f64.const 0.25050653222286823
@@ -15401,9 +14457,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11504
-   i32.store
    i32.const 11504
    call $~lib/number/F64.parseFloat
    f64.const 0.2740037230228005
@@ -15416,9 +14469,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11616
-   i32.store
    i32.const 11616
    call $~lib/number/F64.parseFloat
    f64.const 0.20723093500497428
@@ -15431,9 +14481,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11728
-   i32.store
    i32.const 11728
    call $~lib/number/F64.parseFloat
    f64.const 7.900280238081605
@@ -15446,9 +14493,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11840
-   i32.store
    i32.const 11840
    call $~lib/number/F64.parseFloat
    f64.const 98.22860653737297
@@ -15461,9 +14505,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 11952
-   i32.store
    i32.const 11952
    call $~lib/number/F64.parseFloat
    f64.const 746.894972319037
@@ -15476,9 +14517,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12064
-   i32.store
    i32.const 12064
    call $~lib/number/F64.parseFloat
    f64.const 1630.2683202827284
@@ -15491,9 +14529,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12176
-   i32.store
    i32.const 12176
    call $~lib/number/F64.parseFloat
    f64.const 46371.68629719171
@@ -15506,9 +14541,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12288
-   i32.store
    i32.const 12288
    call $~lib/number/F64.parseFloat
    f64.const 653780.5944497711
@@ -15521,9 +14553,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12400
-   i32.store
    i32.const 12400
    call $~lib/number/F64.parseFloat
    f64.const 234632.43565024371
@@ -15536,9 +14565,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12512
-   i32.store
    i32.const 12512
    call $~lib/number/F64.parseFloat
    f64.const 97094817.16420048
@@ -15551,9 +14577,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12624
-   i32.store
    i32.const 12624
    call $~lib/number/F64.parseFloat
    f64.const 499690852.20518744
@@ -15566,9 +14589,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12736
-   i32.store
    i32.const 12736
    call $~lib/number/F64.parseFloat
    f64.const 7925201200557245595648
@@ -15581,9 +14601,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12848
-   i32.store
    i32.const 12848
    call $~lib/number/F64.parseFloat
    f64.const 6096564585983177528398588e5
@@ -15596,9 +14613,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12960
-   i32.store
    i32.const 12960
    call $~lib/number/F64.parseFloat
    f64.const 4800416117477028695992383e42
@@ -15611,9 +14625,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13072
-   i32.store
    i32.const 13072
    call $~lib/number/F64.parseFloat
    f64.const 8524829079817968137287277e80
@@ -15626,9 +14637,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13184
-   i32.store
    i32.const 13184
    call $~lib/number/F64.parseFloat
    f64.const 3271239291709782092398754e243
@@ -15641,9 +14649,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13296
-   i32.store
    i32.const 13296
    call $~lib/number/F64.parseFloat
    local.tee $1
@@ -15657,9 +14662,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13328
-   i32.store
    i32.const 13328
    call $~lib/number/F64.parseFloat
    f64.const 0.1
@@ -15674,22 +14676,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 1808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13360
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
    i32.const 13360
    call $~lib/string/String.__concat
    local.tee $0
-   i32.store offset=80
+   i32.store offset=60
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=4
    local.get $0
    i32.const 13392
    call $~lib/string/String.__eq
@@ -15705,9 +14698,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    local.get $0
    i32.const 1808
    call $~lib/string/String.__ne
@@ -15720,12 +14710,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1712
    i32.const 1712
    call $~lib/string/String.__eq
@@ -15754,11 +14738,8 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.store offset=4
+   i32.store
    i32.const 1712
    i32.const 0
    call $~lib/string/String.__ne
@@ -15774,9 +14755,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 0
    i32.const 1712
    call $~lib/string/String.__ne
@@ -15789,12 +14767,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13360
-   i32.store offset=4
    i32.const 1808
    i32.const 13360
    call $~lib/string/String.__ne
@@ -15807,12 +14779,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    i32.const 1808
    i32.const 1808
    call $~lib/string/String.__eq
@@ -15825,12 +14791,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13424
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13456
-   i32.store offset=4
    i32.const 13424
    i32.const 13456
    call $~lib/string/String.__ne
@@ -15843,12 +14803,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13424
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13424
-   i32.store offset=4
    i32.const 13424
    i32.const 13424
    call $~lib/string/String.__eq
@@ -15861,12 +14815,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13488
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13520
-   i32.store offset=4
    i32.const 13488
    i32.const 13520
    call $~lib/string/String.__ne
@@ -15879,12 +14827,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13552
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13584
-   i32.store offset=4
    i32.const 13552
    i32.const 13584
    call $~lib/string/String.__ne
@@ -15897,12 +14839,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13616
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13616
-   i32.store offset=4
    i32.const 13616
    i32.const 13616
    call $~lib/string/String.__eq
@@ -15915,12 +14851,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13616
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13664
-   i32.store offset=4
    i32.const 13616
    i32.const 13664
    call $~lib/string/String.__ne
@@ -15933,12 +14863,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13760
-   i32.store offset=4
    i32.const 13712
    i32.const 13760
    call $~lib/string/String.__ne
@@ -15951,12 +14875,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13360
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    i32.const 13360
    i32.const 1808
    call $~lib/string/String.__gt
@@ -15969,12 +14887,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    i32.const 13808
    i32.const 1808
    call $~lib/string/String.__gt
@@ -15987,12 +14899,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13840
-   i32.store offset=4
    i32.const 13808
    i32.const 13840
    call $~lib/string/String.__gte
@@ -16005,12 +14911,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=4
    i32.const 13808
    i32.const 13392
    call $~lib/string/String.__gt
@@ -16023,12 +14923,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13808
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=4
    i32.const 13808
    i32.const 13392
    call $~lib/string/String.__lt
@@ -16040,12 +14934,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 2336
    i32.const 1712
    call $~lib/string/String.__gt
@@ -16058,12 +14946,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    i32.const 1712
    i32.const 2336
    call $~lib/string/String.__lt
@@ -16076,12 +14958,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 2336
    i32.const 1712
    call $~lib/string/String.__gte
@@ -16094,12 +14970,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    i32.const 1712
    i32.const 2336
    call $~lib/string/String.__lte
@@ -16112,12 +14982,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 2336
    i32.const 1712
    call $~lib/string/String.__lt
@@ -16129,12 +14993,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    i32.const 1712
    i32.const 2336
    call $~lib/string/String.__gt
@@ -16146,12 +15004,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1712
    i32.const 1712
    call $~lib/string/String.__lt
@@ -16163,12 +15015,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1712
    i32.const 1712
    call $~lib/string/String.__gt
@@ -16180,12 +15026,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1712
    i32.const 1712
    call $~lib/string/String.__gte
@@ -16198,12 +15038,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1712
    i32.const 1712
    call $~lib/string/String.__lte
@@ -16216,12 +15050,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store offset=4
    i32.const 3456
    i32.const 13872
    call $~lib/string/String.__lt
@@ -16234,12 +15062,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    i32.const 13872
    i32.const 3456
    call $~lib/string/String.__gt
@@ -16252,12 +15074,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store offset=4
    i32.const 13904
    i32.const 13872
    call $~lib/string/String.__lt
@@ -16269,12 +15085,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    i32.const 13872
    i32.const 13904
    call $~lib/string/String.__gt
@@ -16286,12 +15096,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store offset=4
    i32.const 13904
    i32.const 13872
    call $~lib/string/String.__gt
@@ -16304,12 +15108,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    i32.const 13872
    i32.const 13904
    call $~lib/string/String.__lt
@@ -16322,12 +15120,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    i32.const 13904
    i32.const 13904
    call $~lib/string/String.__lt
@@ -16339,12 +15131,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    i32.const 13904
    i32.const 13904
    call $~lib/string/String.__gt
@@ -16356,12 +15142,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    i32.const 13904
    i32.const 13904
    call $~lib/string/String.__lte
@@ -16374,12 +15154,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    i32.const 13904
    i32.const 13904
    call $~lib/string/String.__gte
@@ -16392,12 +15166,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13936
-   i32.store offset=4
    i32.const 13872
    i32.const 13936
    call $~lib/string/String.__gte
@@ -16409,12 +15177,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13936
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store offset=4
    i32.const 13936
    i32.const 13872
    call $~lib/string/String.__gte
@@ -16427,12 +15189,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13872
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13936
-   i32.store offset=4
    i32.const 13872
    i32.const 13936
    call $~lib/string/String.__lte
@@ -16445,12 +15201,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    i32.const 3456
    i32.const 3456
    call $~lib/string/String.__eq
@@ -16463,12 +15213,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    i32.const 13904
    i32.const 13904
    call $~lib/string/String.__eq
@@ -16481,12 +15225,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store offset=4
    i32.const 2400
    i32.const 2400
    call $~lib/string/String.__eq
@@ -16499,12 +15237,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13968
-   i32.store offset=4
    i32.const 2400
    i32.const 13968
    call $~lib/string/String.__ne
@@ -16517,12 +15249,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14000
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14000
-   i32.store offset=4
    i32.const 14000
    i32.const 14000
    call $~lib/string/String.__eq
@@ -16535,12 +15261,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14032
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14000
-   i32.store offset=4
    i32.const 14032
    i32.const 14000
    call $~lib/string/String.__ne
@@ -16557,7 +15277,7 @@
    i32.const 65377
    call $~lib/string/String.fromCodePoint
    local.tee $4
-   i32.store offset=84
+   i32.store offset=64
    global.get $~lib/memory/__stack_pointer
    i32.const 55296
    call $~lib/string/String.fromCodePoint
@@ -16575,7 +15295,7 @@
    local.get $0
    call $~lib/string/String.__concat
    local.tee $0
-   i32.store offset=88
+   i32.store offset=68
    global.get $~lib/memory/__stack_pointer
    local.get $4
    i32.store
@@ -16594,9 +15314,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store
    i32.const 2396
    i32.load
    i32.const 1
@@ -16611,9 +15328,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
    i32.const 1712
    i32.const 100
    call $~lib/string/String#repeat
@@ -16621,9 +15335,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -16636,9 +15347,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
    i32.const 1808
    i32.const 0
    call $~lib/string/String#repeat
@@ -16646,9 +15354,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -16661,9 +15366,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
    i32.const 1808
    i32.const 1
    call $~lib/string/String#repeat
@@ -16671,9 +15373,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=4
    local.get $0
    i32.const 1808
    call $~lib/string/String.__eq
@@ -16686,9 +15385,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
    i32.const 1808
    i32.const 2
    call $~lib/string/String#repeat
@@ -16696,9 +15392,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13840
-   i32.store offset=4
    local.get $0
    i32.const 13840
    call $~lib/string/String.__eq
@@ -16711,9 +15404,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
    i32.const 1808
    i32.const 3
    call $~lib/string/String#repeat
@@ -16721,9 +15411,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14112
-   i32.store offset=4
    local.get $0
    i32.const 14112
    call $~lib/string/String.__eq
@@ -16736,9 +15423,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=8
    i32.const 13392
    i32.const 4
    call $~lib/string/String#repeat
@@ -16746,9 +15430,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14144
-   i32.store offset=4
    local.get $0
    i32.const 14144
    call $~lib/string/String.__eq
@@ -16761,9 +15442,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
    i32.const 1808
    i32.const 5
    call $~lib/string/String#repeat
@@ -16771,9 +15449,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14192
-   i32.store offset=4
    local.get $0
    i32.const 14192
    call $~lib/string/String.__eq
@@ -16786,9 +15461,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
    i32.const 1808
    i32.const 6
    call $~lib/string/String#repeat
@@ -16796,9 +15468,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14224
-   i32.store offset=4
    local.get $0
    i32.const 14224
    call $~lib/string/String.__eq
@@ -16811,9 +15480,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=8
    i32.const 1808
    i32.const 7
    call $~lib/string/String#repeat
@@ -16821,9 +15487,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14256
-   i32.store offset=4
    local.get $0
    i32.const 14256
    call $~lib/string/String.__eq
@@ -16836,15 +15499,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 1712
    i32.const 1712
    i32.const 1712
@@ -16853,9 +15507,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -16868,15 +15519,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 1712
    i32.const 1712
    i32.const 4592
@@ -16885,9 +15527,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=4
    local.get $0
    i32.const 4592
    call $~lib/string/String.__eq
@@ -16900,15 +15539,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 4592
    i32.const 4592
    i32.const 1712
@@ -16917,9 +15547,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -16932,15 +15559,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 4592
    i32.const 1712
    i32.const 1712
@@ -16949,9 +15567,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=4
    local.get $0
    i32.const 4592
    call $~lib/string/String.__eq
@@ -16964,15 +15579,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 4560
    i32.const 4592
@@ -16981,9 +15587,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -16996,15 +15599,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 2336
    i32.const 4592
@@ -17013,9 +15607,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=4
    local.get $0
    i32.const 4592
    call $~lib/string/String.__eq
@@ -17028,15 +15619,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2912
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 2912
    i32.const 4592
@@ -17045,9 +15627,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -17060,15 +15639,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=60
    i32.const 2336
    i32.const 13392
    i32.const 13392
@@ -17077,9 +15647,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -17092,15 +15659,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14304
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 14304
    i32.const 4560
    i32.const 4592
@@ -17109,9 +15667,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14336
-   i32.store offset=4
    local.get $0
    i32.const 14336
    call $~lib/string/String.__eq
@@ -17124,15 +15679,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 1712
    i32.const 4592
@@ -17141,9 +15687,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14368
-   i32.store offset=4
    local.get $0
    i32.const 14368
    call $~lib/string/String.__eq
@@ -17156,15 +15699,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14400
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14432
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 14400
    i32.const 14432
    i32.const 4592
@@ -17173,9 +15707,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14368
-   i32.store offset=4
    local.get $0
    i32.const 14368
    call $~lib/string/String.__eq
@@ -17188,15 +15719,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14464
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14496
-   i32.store offset=60
    i32.const 2336
    i32.const 14464
    i32.const 14496
@@ -17205,9 +15727,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14528
-   i32.store offset=4
    local.get $0
    i32.const 14528
    call $~lib/string/String.__eq
@@ -17220,15 +15739,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14464
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 2336
    i32.const 14464
    i32.const 1712
@@ -17237,9 +15747,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=4
    local.get $0
    i32.const 13392
    call $~lib/string/String.__eq
@@ -17252,15 +15759,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=60
    i32.const 1712
    i32.const 1712
    i32.const 2336
@@ -17269,9 +15767,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -17284,15 +15779,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 4560
    i32.const 4592
@@ -17301,9 +15787,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -17316,15 +15799,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2544
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2544
    i32.const 2336
    i32.const 4592
@@ -17333,9 +15807,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14496
-   i32.store offset=4
    local.get $0
    i32.const 14496
    call $~lib/string/String.__eq
@@ -17348,15 +15819,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14560
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 14560
    i32.const 2336
    i32.const 4592
@@ -17365,9 +15827,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14608
-   i32.store offset=4
    local.get $0
    i32.const 14608
    call $~lib/string/String.__eq
@@ -17380,15 +15839,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2544
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=60
    i32.const 2544
    i32.const 13392
    i32.const 13392
@@ -17397,9 +15847,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2544
-   i32.store offset=4
    local.get $0
    i32.const 2544
    call $~lib/string/String.__eq
@@ -17412,15 +15859,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14640
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14608
-   i32.store offset=60
    i32.const 14640
    i32.const 1808
    i32.const 14608
@@ -17429,9 +15867,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14688
-   i32.store offset=4
    local.get $0
    i32.const 14688
    call $~lib/string/String.__eq
@@ -17444,15 +15879,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2544
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14496
-   i32.store offset=60
    i32.const 2544
    i32.const 13392
    i32.const 14496
@@ -17461,9 +15887,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14736
-   i32.store offset=4
    local.get $0
    i32.const 14736
    call $~lib/string/String.__eq
@@ -17476,15 +15899,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14768
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14800
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14496
-   i32.store offset=60
    i32.const 14768
    i32.const 14800
    i32.const 14496
@@ -17493,9 +15907,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14832
-   i32.store offset=4
    local.get $0
    i32.const 14832
    call $~lib/string/String.__eq
@@ -17508,15 +15919,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2912
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 2912
    i32.const 4592
@@ -17525,9 +15927,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -17540,15 +15939,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2912
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14864
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14496
-   i32.store offset=60
    i32.const 2912
    i32.const 14864
    i32.const 14496
@@ -17557,9 +15947,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2912
-   i32.store offset=4
    local.get $0
    i32.const 2912
    call $~lib/string/String.__eq
@@ -17572,15 +15959,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14896
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 14896
    i32.const 4592
@@ -17589,9 +15967,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14928
-   i32.store offset=4
    local.get $0
    i32.const 14928
    call $~lib/string/String.__eq
@@ -17604,15 +15979,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 13392
    i32.const 13392
    i32.const 4592
@@ -17621,9 +15987,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=4
    local.get $0
    i32.const 4592
    call $~lib/string/String.__eq
@@ -17636,15 +15999,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14304
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 14304
    i32.const 4560
    i32.const 4592
@@ -17653,9 +16007,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14960
-   i32.store offset=4
    local.get $0
    i32.const 14960
    call $~lib/string/String.__eq
@@ -17668,15 +16019,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 1712
    i32.const 1712
    i32.const 1712
@@ -17685,9 +16027,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -17700,15 +16039,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 1712
    i32.const 1712
    i32.const 4592
@@ -17717,9 +16047,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=4
    local.get $0
    i32.const 4592
    call $~lib/string/String.__eq
@@ -17732,15 +16059,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 4592
    i32.const 4592
    i32.const 1712
@@ -17749,9 +16067,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -17764,15 +16079,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 4592
    i32.const 1712
    i32.const 1712
@@ -17781,9 +16087,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=4
    local.get $0
    i32.const 4592
    call $~lib/string/String.__eq
@@ -17796,15 +16099,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store offset=60
    i32.const 2336
    i32.const 2336
    i32.const 4560
@@ -17813,9 +16107,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store offset=4
    local.get $0
    i32.const 4560
    call $~lib/string/String.__eq
@@ -17828,15 +16119,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2816
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4560
-   i32.store offset=60
    i32.const 2336
    i32.const 2816
    i32.const 4560
@@ -17845,9 +16127,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -17860,15 +16139,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4592
-   i32.store offset=60
    i32.const 2336
    i32.const 1712
    i32.const 4592
@@ -17877,9 +16147,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14992
-   i32.store offset=4
    local.get $0
    i32.const 14992
    call $~lib/string/String.__eq
@@ -17892,15 +16159,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=60
    i32.const 2336
    i32.const 1712
    i32.const 1712
@@ -17909,9 +16167,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store offset=4
    local.get $0
    i32.const 2336
    call $~lib/string/String.__eq
@@ -17924,15 +16179,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15040
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15072
-   i32.store offset=60
    i32.const 15040
    i32.const 1808
    i32.const 15072
@@ -17941,9 +16187,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15104
-   i32.store offset=4
    local.get $0
    i32.const 15104
    call $~lib/string/String.__eq
@@ -17956,15 +16199,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13392
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15152
-   i32.store offset=60
    i32.const 13392
    i32.const 13392
    i32.const 15152
@@ -17973,9 +16207,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15152
-   i32.store offset=4
    local.get $0
    i32.const 15152
    call $~lib/string/String.__eq
@@ -17988,15 +16219,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14112
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1808
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15184
-   i32.store offset=60
    i32.const 14112
    i32.const 1808
    i32.const 15184
@@ -18005,9 +16227,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15216
-   i32.store offset=4
    local.get $0
    i32.const 15216
    call $~lib/string/String.__eq
@@ -18020,15 +16239,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14112
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13840
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15072
-   i32.store offset=60
    i32.const 14112
    i32.const 13840
    i32.const 15072
@@ -18037,9 +16247,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15264
-   i32.store offset=4
    local.get $0
    i32.const 15264
    call $~lib/string/String.__eq
@@ -18056,7 +16263,7 @@
    global.set $std/string/str
    global.get $~lib/memory/__stack_pointer
    i32.const 15296
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    i32.const 15296
@@ -18066,9 +16273,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15296
-   i32.store offset=4
    local.get $0
    i32.const 15296
    call $~lib/string/String.__eq
@@ -18084,7 +16288,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18094,9 +16298,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15344
-   i32.store offset=4
    local.get $0
    i32.const 15344
    call $~lib/string/String.__eq
@@ -18112,7 +16313,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18122,9 +16323,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15376
-   i32.store offset=4
    local.get $0
    i32.const 15376
    call $~lib/string/String.__eq
@@ -18140,7 +16338,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 2
    i32.const 7
@@ -18149,9 +16347,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15408
-   i32.store offset=4
    local.get $0
    i32.const 15408
    call $~lib/string/String.__eq
@@ -18167,7 +16362,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const -11
    i32.const -6
@@ -18176,9 +16371,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15440
-   i32.store offset=4
    local.get $0
    i32.const 15440
    call $~lib/string/String.__eq
@@ -18194,7 +16386,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 4
    i32.const 3
@@ -18203,9 +16395,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -18221,7 +16410,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    i32.const -1
@@ -18230,9 +16419,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15472
-   i32.store offset=4
    local.get $0
    i32.const 15472
    call $~lib/string/String.__eq
@@ -18248,7 +16434,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18258,9 +16444,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15296
-   i32.store offset=4
    local.get $0
    i32.const 15296
    call $~lib/string/String.__eq
@@ -18276,7 +16459,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18286,9 +16469,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15344
-   i32.store offset=4
    local.get $0
    i32.const 15344
    call $~lib/string/String.__eq
@@ -18304,7 +16484,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18314,9 +16494,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15376
-   i32.store offset=4
    local.get $0
    i32.const 15376
    call $~lib/string/String.__eq
@@ -18332,7 +16509,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 2
    i32.const 7
@@ -18341,9 +16518,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15520
-   i32.store offset=4
    local.get $0
    i32.const 15520
    call $~lib/string/String.__eq
@@ -18359,7 +16533,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const -11
    i32.const -6
@@ -18368,9 +16542,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -18386,7 +16557,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 4
    i32.const 3
@@ -18395,9 +16566,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15568
-   i32.store offset=4
    local.get $0
    i32.const 15568
    call $~lib/string/String.__eq
@@ -18413,7 +16581,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    i32.const -1
@@ -18422,9 +16590,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -18440,7 +16605,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    i32.const 100
@@ -18449,9 +16614,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15296
-   i32.store offset=4
    local.get $0
    i32.const 15296
    call $~lib/string/String.__eq
@@ -18467,7 +16629,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 4
    i32.const 4
@@ -18476,9 +16638,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15600
-   i32.store offset=4
    local.get $0
    i32.const 15600
    call $~lib/string/String.__eq
@@ -18494,7 +16653,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 4
    i32.const -3
@@ -18503,9 +16662,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -18521,7 +16677,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18531,9 +16687,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15296
-   i32.store offset=4
    local.get $0
    i32.const 15296
    call $~lib/string/String.__eq
@@ -18549,7 +16702,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18559,9 +16712,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15296
-   i32.store offset=4
    local.get $0
    i32.const 15296
    call $~lib/string/String.__eq
@@ -18577,7 +16727,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    local.get $0
@@ -18587,9 +16737,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15296
-   i32.store offset=4
    local.get $0
    i32.const 15296
    call $~lib/string/String.__eq
@@ -18605,7 +16752,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 2
    i32.const 7
@@ -18614,9 +16761,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15408
-   i32.store offset=4
    local.get $0
    i32.const 15408
    call $~lib/string/String.__eq
@@ -18632,7 +16776,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const -11
    i32.const -6
@@ -18641,9 +16785,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -18659,7 +16800,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 4
    i32.const 3
@@ -18668,9 +16809,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15632
-   i32.store offset=4
    local.get $0
    i32.const 15632
    call $~lib/string/String.__eq
@@ -18686,7 +16824,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    i32.const -1
@@ -18695,9 +16833,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -18713,7 +16848,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 0
    i32.const 100
@@ -18722,9 +16857,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15296
-   i32.store offset=4
    local.get $0
    i32.const 15296
    call $~lib/string/String.__eq
@@ -18740,7 +16872,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 4
    i32.const 4
@@ -18749,9 +16881,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -18767,7 +16896,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/string/str
    local.tee $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 4
    i32.const -3
@@ -18776,9 +16905,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2912
-   i32.store offset=4
    local.get $0
    i32.const 2912
    call $~lib/string/String.__eq
@@ -18791,9 +16917,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
    i32.const 0
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -18801,7 +16924,7 @@
    i32.const 0
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -18812,7 +16935,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -18820,9 +16943,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1712
-    i32.store offset=4
     local.get $0
     i32.const 1712
     call $~lib/string/String.__eq
@@ -18838,12 +16958,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -18851,7 +16965,7 @@
    i32.const 1712
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -18865,12 +16979,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -18878,7 +16986,7 @@
    i32.const 2624
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -18889,7 +16997,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -18897,9 +17005,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1712
-    i32.store offset=4
     local.get $0
     i32.const 1712
     call $~lib/string/String.__eq
@@ -18915,12 +17020,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15840
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7632
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -18928,7 +17027,7 @@
    i32.const 7632
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -18939,7 +17038,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -18947,9 +17046,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 15840
-    i32.store offset=4
     local.get $0
     i32.const 15840
     call $~lib/string/String.__eq
@@ -18965,12 +17061,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15840
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -18978,7 +17068,7 @@
    i32.const 2624
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -18989,7 +17079,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -18997,9 +17087,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19009,7 +17096,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19017,9 +17104,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19029,7 +17113,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19037,9 +17121,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19055,12 +17136,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15872
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15920
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -19068,7 +17143,7 @@
    i32.const 15920
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19079,7 +17154,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19087,9 +17162,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19099,7 +17171,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19107,9 +17179,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19119,7 +17188,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19127,9 +17196,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19145,12 +17211,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15952
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -19158,7 +17218,7 @@
    i32.const 2624
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19169,7 +17229,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19177,9 +17237,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19189,7 +17246,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19197,9 +17254,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19209,7 +17263,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19217,9 +17271,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1712
-    i32.store offset=4
     local.get $4
     i32.const 1712
     call $~lib/string/String.__eq
@@ -19229,7 +17280,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 3
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19237,9 +17288,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19255,12 +17303,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15984
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -19268,7 +17310,7 @@
    i32.const 2624
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19279,7 +17321,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19287,9 +17329,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1712
-    i32.store offset=4
     local.get $4
     i32.const 1712
     call $~lib/string/String.__eq
@@ -19299,7 +17338,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19307,9 +17346,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19319,7 +17355,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19327,9 +17363,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19339,7 +17372,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 3
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19347,9 +17380,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19365,12 +17395,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16016
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -19378,7 +17402,7 @@
    i32.const 2624
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19389,7 +17413,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19397,9 +17421,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19409,7 +17430,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19417,9 +17438,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19429,7 +17447,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19437,9 +17455,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $4
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19449,7 +17464,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 3
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19457,9 +17472,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1712
-    i32.store offset=4
     local.get $0
     i32.const 1712
     call $~lib/string/String.__eq
@@ -19475,12 +17487,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
@@ -19488,7 +17494,7 @@
    i32.const 1712
    call $~lib/string/String#split@varargs
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19499,7 +17505,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19507,9 +17513,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19519,7 +17522,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19527,9 +17530,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19539,7 +17539,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19547,9 +17547,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19567,17 +17564,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
    i32.const 1712
    i32.const 0
    call $~lib/string/String#split
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19593,17 +17584,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
    i32.const 1712
    i32.const 1
    call $~lib/string/String#split
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19614,7 +17599,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19622,9 +17607,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $0
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19642,17 +17624,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 15840
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15840
    i32.const 2624
    i32.const 1
    call $~lib/string/String#split
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19663,7 +17639,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19671,9 +17647,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $0
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19691,17 +17664,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
    i32.const 1712
    i32.const 4
    call $~lib/string/String#split
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19712,7 +17679,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19720,9 +17687,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19732,7 +17696,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19740,9 +17704,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19752,7 +17713,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19760,9 +17721,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19780,17 +17738,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 2336
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2336
    i32.const 1712
    i32.const -1
    call $~lib/string/String#split
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19801,7 +17753,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19809,9 +17761,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19821,7 +17770,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19829,9 +17778,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19841,7 +17787,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19849,9 +17795,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19869,17 +17812,11 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 15840
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2624
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 15840
    i32.const 2624
    i32.const -1
    call $~lib/string/String#split
    local.tee $0
-   i32.store offset=92
+   i32.store offset=72
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -19890,7 +17827,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 0
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19898,9 +17835,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 1808
-    i32.store offset=4
     local.get $4
     i32.const 1808
     call $~lib/string/String.__eq
@@ -19910,7 +17844,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 1
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19918,9 +17852,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 13360
-    i32.store offset=4
     local.get $4
     i32.const 13360
     call $~lib/string/String.__eq
@@ -19930,7 +17861,7 @@
    if (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
+    i32.store offset=4
     local.get $0
     i32.const 2
     call $~lib/array/Array<~lib/string/String>#__get
@@ -19938,9 +17869,6 @@
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    global.get $~lib/memory/__stack_pointer
-    i32.const 14464
-    i32.store offset=4
     local.get $0
     i32.const 14464
     call $~lib/string/String.__eq
@@ -19963,9 +17891,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -19985,9 +17910,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    local.get $0
    i32.const 3456
    call $~lib/string/String.__eq
@@ -20007,9 +17929,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17792
-   i32.store offset=4
    local.get $0
    i32.const 17792
    call $~lib/string/String.__eq
@@ -20029,9 +17948,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17824
-   i32.store offset=4
    local.get $0
    i32.const 17824
    call $~lib/string/String.__eq
@@ -20051,9 +17967,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store offset=4
    local.get $0
    i32.const 2400
    call $~lib/string/String.__eq
@@ -20073,9 +17986,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17856
-   i32.store offset=4
    local.get $0
    i32.const 17856
    call $~lib/string/String.__eq
@@ -20095,9 +18005,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14000
-   i32.store offset=4
    local.get $0
    i32.const 14000
    call $~lib/string/String.__eq
@@ -20117,9 +18024,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17888
-   i32.store offset=4
    local.get $0
    i32.const 17888
    call $~lib/string/String.__eq
@@ -20139,9 +18043,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17920
-   i32.store offset=4
    local.get $0
    i32.const 17920
    call $~lib/string/String.__eq
@@ -20161,9 +18062,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17952
-   i32.store offset=4
    local.get $0
    i32.const 17952
    call $~lib/string/String.__eq
@@ -20183,9 +18081,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18000
-   i32.store offset=4
    local.get $0
    i32.const 18000
    call $~lib/string/String.__eq
@@ -20205,9 +18100,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18048
-   i32.store offset=4
    local.get $0
    i32.const 18048
    call $~lib/string/String.__eq
@@ -20227,9 +18119,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18096
-   i32.store offset=4
    local.get $0
    i32.const 18096
    call $~lib/string/String.__eq
@@ -20249,9 +18138,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18144
-   i32.store offset=4
    local.get $0
    i32.const 18144
    call $~lib/string/String.__eq
@@ -20271,9 +18157,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18192
-   i32.store offset=4
    local.get $0
    i32.const 18192
    call $~lib/string/String.__eq
@@ -20293,9 +18176,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18240
-   i32.store offset=4
    local.get $0
    i32.const 18240
    call $~lib/string/String.__eq
@@ -20315,9 +18195,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18288
-   i32.store offset=4
    local.get $0
    i32.const 18288
    call $~lib/string/String.__eq
@@ -20337,9 +18214,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18320
-   i32.store offset=4
    local.get $0
    i32.const 18320
    call $~lib/string/String.__eq
@@ -20359,9 +18233,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18352
-   i32.store offset=4
    local.get $0
    i32.const 18352
    call $~lib/string/String.__eq
@@ -20381,9 +18252,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18240
-   i32.store offset=4
    local.get $0
    i32.const 18240
    call $~lib/string/String.__eq
@@ -20403,9 +18271,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -20425,9 +18290,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18384
-   i32.store offset=4
    local.get $0
    i32.const 18384
    call $~lib/string/String.__eq
@@ -20447,9 +18309,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18192
-   i32.store offset=4
    local.get $0
    i32.const 18192
    call $~lib/string/String.__eq
@@ -20469,9 +18328,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18416
-   i32.store offset=4
    local.get $0
    i32.const 18416
    call $~lib/string/String.__eq
@@ -20491,9 +18347,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18464
-   i32.store offset=4
    local.get $0
    i32.const 18464
    call $~lib/string/String.__eq
@@ -20513,9 +18366,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -20535,9 +18385,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    local.get $0
    i32.const 3456
    call $~lib/string/String.__eq
@@ -20557,9 +18404,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17792
-   i32.store offset=4
    local.get $0
    i32.const 17792
    call $~lib/string/String.__eq
@@ -20579,9 +18423,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14464
-   i32.store offset=4
    local.get $0
    i32.const 14464
    call $~lib/string/String.__eq
@@ -20601,9 +18442,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18512
-   i32.store offset=4
    local.get $0
    i32.const 18512
    call $~lib/string/String.__eq
@@ -20623,9 +18461,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18544
-   i32.store offset=4
    local.get $0
    i32.const 18544
    call $~lib/string/String.__eq
@@ -20645,9 +18480,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18576
-   i32.store offset=4
    local.get $0
    i32.const 18576
    call $~lib/string/String.__eq
@@ -20667,9 +18499,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18608
-   i32.store offset=4
    local.get $0
    i32.const 18608
    call $~lib/string/String.__eq
@@ -20689,9 +18518,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18640
-   i32.store offset=4
    local.get $0
    i32.const 18640
    call $~lib/string/String.__eq
@@ -20711,9 +18537,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18672
-   i32.store offset=4
    local.get $0
    i32.const 18672
    call $~lib/string/String.__eq
@@ -20733,9 +18556,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18704
-   i32.store offset=4
    local.get $0
    i32.const 18704
    call $~lib/string/String.__eq
@@ -20755,9 +18575,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18736
-   i32.store offset=4
    local.get $0
    i32.const 18736
    call $~lib/string/String.__eq
@@ -20777,9 +18594,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18784
-   i32.store offset=4
    local.get $0
    i32.const 18784
    call $~lib/string/String.__eq
@@ -20799,9 +18613,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18832
-   i32.store offset=4
    local.get $0
    i32.const 18832
    call $~lib/string/String.__eq
@@ -20821,9 +18632,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18880
-   i32.store offset=4
    local.get $0
    i32.const 18880
    call $~lib/string/String.__eq
@@ -20843,9 +18651,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18928
-   i32.store offset=4
    local.get $0
    i32.const 18928
    call $~lib/string/String.__eq
@@ -20865,9 +18670,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -20887,9 +18689,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17856
-   i32.store offset=4
    local.get $0
    i32.const 17856
    call $~lib/string/String.__eq
@@ -20909,9 +18708,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18832
-   i32.store offset=4
    local.get $0
    i32.const 18832
    call $~lib/string/String.__eq
@@ -20931,9 +18727,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18976
-   i32.store offset=4
    local.get $0
    i32.const 18976
    call $~lib/string/String.__eq
@@ -20953,9 +18746,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19024
-   i32.store offset=4
    local.get $0
    i32.const 19024
    call $~lib/string/String.__eq
@@ -20975,9 +18765,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19072
-   i32.store offset=4
    local.get $0
    i32.const 19072
    call $~lib/string/String.__eq
@@ -20997,9 +18784,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19072
-   i32.store offset=4
    local.get $0
    i32.const 19072
    call $~lib/string/String.__eq
@@ -21019,9 +18803,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -21041,9 +18822,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    local.get $0
    i32.const 3456
    call $~lib/string/String.__eq
@@ -21063,9 +18841,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 13904
-   i32.store offset=4
    local.get $0
    i32.const 13904
    call $~lib/string/String.__eq
@@ -21085,9 +18860,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19120
-   i32.store offset=4
    local.get $0
    i32.const 19120
    call $~lib/string/String.__eq
@@ -21107,9 +18879,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19152
-   i32.store offset=4
    local.get $0
    i32.const 19152
    call $~lib/string/String.__eq
@@ -21129,9 +18898,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19184
-   i32.store offset=4
    local.get $0
    i32.const 19184
    call $~lib/string/String.__eq
@@ -21151,9 +18917,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19216
-   i32.store offset=4
    local.get $0
    i32.const 19216
    call $~lib/string/String.__eq
@@ -21173,9 +18936,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19248
-   i32.store offset=4
    local.get $0
    i32.const 19248
    call $~lib/string/String.__eq
@@ -21195,9 +18955,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19296
-   i32.store offset=4
    local.get $0
    i32.const 19296
    call $~lib/string/String.__eq
@@ -21217,9 +18974,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19376
-   i32.store offset=4
    local.get $0
    i32.const 19376
    call $~lib/string/String.__eq
@@ -21239,9 +18993,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19472
-   i32.store offset=4
    local.get $0
    i32.const 19472
    call $~lib/string/String.__eq
@@ -21261,9 +19012,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19568
-   i32.store offset=4
    local.get $0
    i32.const 19568
    call $~lib/string/String.__eq
@@ -21283,9 +19031,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19664
-   i32.store offset=4
    local.get $0
    i32.const 19664
    call $~lib/string/String.__eq
@@ -21305,9 +19050,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19760
-   i32.store offset=4
    local.get $0
    i32.const 19760
    call $~lib/string/String.__eq
@@ -21327,9 +19069,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19808
-   i32.store offset=4
    local.get $0
    i32.const 19808
    call $~lib/string/String.__eq
@@ -21349,9 +19088,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19872
-   i32.store offset=4
    local.get $0
    i32.const 19872
    call $~lib/string/String.__eq
@@ -21371,9 +19107,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19936
-   i32.store offset=4
    local.get $0
    i32.const 19936
    call $~lib/string/String.__eq
@@ -21393,9 +19126,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19984
-   i32.store offset=4
    local.get $0
    i32.const 19984
    call $~lib/string/String.__eq
@@ -21415,9 +19145,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20032
-   i32.store offset=4
    local.get $0
    i32.const 20032
    call $~lib/string/String.__eq
@@ -21437,9 +19164,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20080
-   i32.store offset=4
    local.get $0
    i32.const 20080
    call $~lib/string/String.__eq
@@ -21459,9 +19183,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20128
-   i32.store offset=4
    local.get $0
    i32.const 20128
    call $~lib/string/String.__eq
@@ -21481,9 +19202,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20176
-   i32.store offset=4
    local.get $0
    i32.const 20176
    call $~lib/string/String.__eq
@@ -21503,9 +19221,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20224
-   i32.store offset=4
    local.get $0
    i32.const 20224
    call $~lib/string/String.__eq
@@ -21525,9 +19240,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20272
-   i32.store offset=4
    local.get $0
    i32.const 20272
    call $~lib/string/String.__eq
@@ -21547,9 +19259,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20320
-   i32.store offset=4
    local.get $0
    i32.const 20320
    call $~lib/string/String.__eq
@@ -21569,9 +19278,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -21591,9 +19297,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17824
-   i32.store offset=4
    local.get $0
    i32.const 17824
    call $~lib/string/String.__eq
@@ -21613,9 +19316,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2400
-   i32.store offset=4
    local.get $0
    i32.const 2400
    call $~lib/string/String.__eq
@@ -21635,9 +19335,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14000
-   i32.store offset=4
    local.get $0
    i32.const 14000
    call $~lib/string/String.__eq
@@ -21657,9 +19354,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17888
-   i32.store offset=4
    local.get $0
    i32.const 17888
    call $~lib/string/String.__eq
@@ -21679,9 +19373,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 17920
-   i32.store offset=4
    local.get $0
    i32.const 17920
    call $~lib/string/String.__eq
@@ -21701,9 +19392,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18000
-   i32.store offset=4
    local.get $0
    i32.const 18000
    call $~lib/string/String.__eq
@@ -21723,9 +19411,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20368
-   i32.store offset=4
    local.get $0
    i32.const 20368
    call $~lib/string/String.__eq
@@ -21745,9 +19430,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20416
-   i32.store offset=4
    local.get $0
    i32.const 20416
    call $~lib/string/String.__eq
@@ -21767,9 +19449,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18464
-   i32.store offset=4
    local.get $0
    i32.const 18464
    call $~lib/string/String.__eq
@@ -21789,9 +19468,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20464
-   i32.store offset=4
    local.get $0
    i32.const 20464
    call $~lib/string/String.__eq
@@ -21811,9 +19487,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20512
-   i32.store offset=4
    local.get $0
    i32.const 20512
    call $~lib/string/String.__eq
@@ -21833,9 +19506,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20560
-   i32.store offset=4
    local.get $0
    i32.const 20560
    call $~lib/string/String.__eq
@@ -21855,9 +19525,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20608
-   i32.store offset=4
    local.get $0
    i32.const 20608
    call $~lib/string/String.__eq
@@ -21877,9 +19544,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20656
-   i32.store offset=4
    local.get $0
    i32.const 20656
    call $~lib/string/String.__eq
@@ -21899,9 +19563,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20704
-   i32.store offset=4
    local.get $0
    i32.const 20704
    call $~lib/string/String.__eq
@@ -21921,9 +19582,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20768
-   i32.store offset=4
    local.get $0
    i32.const 20768
    call $~lib/string/String.__eq
@@ -21943,9 +19601,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20832
-   i32.store offset=4
    local.get $0
    i32.const 20832
    call $~lib/string/String.__eq
@@ -21965,9 +19620,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20896
-   i32.store offset=4
    local.get $0
    i32.const 20896
    call $~lib/string/String.__eq
@@ -21987,9 +19639,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20960
-   i32.store offset=4
    local.get $0
    i32.const 20960
    call $~lib/string/String.__eq
@@ -22009,9 +19658,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21024
-   i32.store offset=4
    local.get $0
    i32.const 21024
    call $~lib/string/String.__eq
@@ -22031,9 +19677,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -22053,9 +19696,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21088
-   i32.store offset=4
    local.get $0
    i32.const 21088
    call $~lib/string/String.__eq
@@ -22075,9 +19715,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18464
-   i32.store offset=4
    local.get $0
    i32.const 18464
    call $~lib/string/String.__eq
@@ -22097,9 +19734,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20464
-   i32.store offset=4
    local.get $0
    i32.const 20464
    call $~lib/string/String.__eq
@@ -22119,9 +19753,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21120
-   i32.store offset=4
    local.get $0
    i32.const 21120
    call $~lib/string/String.__eq
@@ -22141,9 +19772,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 20512
-   i32.store offset=4
    local.get $0
    i32.const 20512
    call $~lib/string/String.__eq
@@ -22163,9 +19791,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21168
-   i32.store offset=4
    local.get $0
    i32.const 21168
    call $~lib/string/String.__eq
@@ -22185,9 +19810,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21216
-   i32.store offset=4
    local.get $0
    i32.const 21216
    call $~lib/string/String.__eq
@@ -22207,9 +19829,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21264
-   i32.store offset=4
    local.get $0
    i32.const 21264
    call $~lib/string/String.__eq
@@ -22229,9 +19848,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21328
-   i32.store offset=4
    local.get $0
    i32.const 21328
    call $~lib/string/String.__eq
@@ -22251,9 +19867,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21392
-   i32.store offset=4
    local.get $0
    i32.const 21392
    call $~lib/string/String.__eq
@@ -22273,9 +19886,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21456
-   i32.store offset=4
    local.get $0
    i32.const 21456
    call $~lib/string/String.__eq
@@ -22295,9 +19905,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -22317,9 +19924,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    local.get $0
    i32.const 3456
    call $~lib/string/String.__eq
@@ -22339,9 +19943,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 14464
-   i32.store offset=4
    local.get $0
    i32.const 14464
    call $~lib/string/String.__eq
@@ -22361,9 +19962,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18544
-   i32.store offset=4
    local.get $0
    i32.const 18544
    call $~lib/string/String.__eq
@@ -22383,9 +19981,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 18640
-   i32.store offset=4
    local.get $0
    i32.const 18640
    call $~lib/string/String.__eq
@@ -22405,9 +20000,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21520
-   i32.store offset=4
    local.get $0
    i32.const 21520
    call $~lib/string/String.__eq
@@ -22427,9 +20019,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21568
-   i32.store offset=4
    local.get $0
    i32.const 21568
    call $~lib/string/String.__eq
@@ -22449,9 +20038,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21616
-   i32.store offset=4
    local.get $0
    i32.const 21616
    call $~lib/string/String.__eq
@@ -22471,9 +20057,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21664
-   i32.store offset=4
    local.get $0
    i32.const 21664
    call $~lib/string/String.__eq
@@ -22493,9 +20076,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21712
-   i32.store offset=4
    local.get $0
    i32.const 21712
    call $~lib/string/String.__eq
@@ -22515,9 +20095,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21760
-   i32.store offset=4
    local.get $0
    i32.const 21760
    call $~lib/string/String.__eq
@@ -22537,9 +20114,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21824
-   i32.store offset=4
    local.get $0
    i32.const 21824
    call $~lib/string/String.__eq
@@ -22559,9 +20133,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21888
-   i32.store offset=4
    local.get $0
    i32.const 21888
    call $~lib/string/String.__eq
@@ -22581,9 +20152,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 21952
-   i32.store offset=4
    local.get $0
    i32.const 21952
    call $~lib/string/String.__eq
@@ -22603,9 +20171,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22016
-   i32.store offset=4
    local.get $0
    i32.const 22016
    call $~lib/string/String.__eq
@@ -22625,9 +20190,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22080
-   i32.store offset=4
    local.get $0
    i32.const 22080
    call $~lib/string/String.__eq
@@ -22647,9 +20209,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22080
-   i32.store offset=4
    local.get $0
    i32.const 22080
    call $~lib/string/String.__eq
@@ -22669,9 +20228,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3392
-   i32.store offset=4
    local.get $0
    i32.const 3392
    call $~lib/string/String.__eq
@@ -22691,9 +20247,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3456
-   i32.store offset=4
    local.get $0
    i32.const 3456
    call $~lib/string/String.__eq
@@ -22713,9 +20266,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19120
-   i32.store offset=4
    local.get $0
    i32.const 19120
    call $~lib/string/String.__eq
@@ -22735,9 +20285,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19152
-   i32.store offset=4
    local.get $0
    i32.const 19152
    call $~lib/string/String.__eq
@@ -22757,9 +20304,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19216
-   i32.store offset=4
    local.get $0
    i32.const 19216
    call $~lib/string/String.__eq
@@ -22779,9 +20323,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19248
-   i32.store offset=4
    local.get $0
    i32.const 19248
    call $~lib/string/String.__eq
@@ -22801,9 +20342,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 19664
-   i32.store offset=4
    local.get $0
    i32.const 19664
    call $~lib/string/String.__eq
@@ -22823,9 +20361,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22144
-   i32.store offset=4
    local.get $0
    i32.const 22144
    call $~lib/string/String.__eq
@@ -22845,9 +20380,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22272
-   i32.store offset=4
    local.get $0
    i32.const 22272
    call $~lib/string/String.__eq
@@ -22867,9 +20399,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22432
-   i32.store offset=4
    local.get $0
    i32.const 22432
    call $~lib/string/String.__eq
@@ -22889,9 +20418,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22528
-   i32.store offset=4
    local.get $0
    i32.const 22528
    call $~lib/string/String.__eq
@@ -22911,9 +20437,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22640
-   i32.store offset=4
    local.get $0
    i32.const 22640
    call $~lib/string/String.__eq
@@ -22933,9 +20456,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22736
-   i32.store offset=4
    local.get $0
    i32.const 22736
    call $~lib/string/String.__eq
@@ -22955,9 +20475,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22816
-   i32.store offset=4
    local.get $0
    i32.const 22816
    call $~lib/string/String.__eq
@@ -22977,9 +20494,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22880
-   i32.store offset=4
    local.get $0
    i32.const 22880
    call $~lib/string/String.__eq
@@ -22999,9 +20513,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 22944
-   i32.store offset=4
    local.get $0
    i32.const 22944
    call $~lib/string/String.__eq
@@ -23021,9 +20532,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23008
-   i32.store offset=4
    local.get $0
    i32.const 23008
    call $~lib/string/String.__eq
@@ -23043,9 +20551,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23072
-   i32.store offset=4
    local.get $0
    i32.const 23072
    call $~lib/string/String.__eq
@@ -23065,9 +20570,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23136
-   i32.store offset=4
    local.get $0
    i32.const 23136
    call $~lib/string/String.__eq
@@ -23087,9 +20589,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23184
-   i32.store offset=4
    local.get $0
    i32.const 23184
    call $~lib/string/String.__eq
@@ -23109,9 +20608,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23232
-   i32.store offset=4
    local.get $0
    i32.const 23232
    call $~lib/string/String.__eq
@@ -23130,9 +20626,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23280
-   i32.store offset=4
    local.get $0
    i32.const 23280
    call $~lib/string/String.__eq
@@ -23151,9 +20644,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23280
-   i32.store offset=4
    local.get $0
    i32.const 23280
    call $~lib/string/String.__eq
@@ -23172,9 +20662,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7696
-   i32.store offset=4
    local.get $0
    i32.const 7696
    call $~lib/string/String.__eq
@@ -23193,9 +20680,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23312
-   i32.store offset=4
    local.get $0
    i32.const 23312
    call $~lib/string/String.__eq
@@ -23214,9 +20698,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8960
-   i32.store offset=4
    local.get $0
    i32.const 8960
    call $~lib/string/String.__eq
@@ -23235,9 +20716,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8176
-   i32.store offset=4
    local.get $0
    i32.const 8176
    call $~lib/string/String.__eq
@@ -23256,9 +20734,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24336
-   i32.store offset=4
    local.get $0
    i32.const 24336
    call $~lib/string/String.__eq
@@ -23277,9 +20752,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8240
-   i32.store offset=4
    local.get $0
    i32.const 8240
    call $~lib/string/String.__eq
@@ -23298,9 +20770,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24400
-   i32.store offset=4
    local.get $0
    i32.const 24400
    call $~lib/string/String.__eq
@@ -23319,9 +20788,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24480
-   i32.store offset=4
    local.get $0
    i32.const 24480
    call $~lib/string/String.__eq
@@ -23340,9 +20806,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24528
-   i32.store offset=4
    local.get $0
    i32.const 24528
    call $~lib/string/String.__eq
@@ -23361,9 +20824,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24576
-   i32.store offset=4
    local.get $0
    i32.const 24576
    call $~lib/string/String.__eq
@@ -23382,9 +20842,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24624
-   i32.store offset=4
    local.get $0
    i32.const 24624
    call $~lib/string/String.__eq
@@ -23403,9 +20860,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24672
-   i32.store offset=4
    local.get $0
    i32.const 24672
    call $~lib/string/String.__eq
@@ -23424,9 +20878,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24736
-   i32.store offset=4
    local.get $0
    i32.const 24736
    call $~lib/string/String.__eq
@@ -23445,9 +20896,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24816
-   i32.store offset=4
    local.get $0
    i32.const 24816
    call $~lib/string/String.__eq
@@ -23466,9 +20914,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24864
-   i32.store offset=4
    local.get $0
    i32.const 24864
    call $~lib/string/String.__eq
@@ -23487,9 +20932,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24928
-   i32.store offset=4
    local.get $0
    i32.const 24928
    call $~lib/string/String.__eq
@@ -23508,9 +20950,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 24992
-   i32.store offset=4
    local.get $0
    i32.const 24992
    call $~lib/string/String.__eq
@@ -23529,9 +20968,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8320
-   i32.store offset=4
    local.get $0
    i32.const 8320
    call $~lib/string/String.__eq
@@ -23550,9 +20986,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25056
-   i32.store offset=4
    local.get $0
    i32.const 25056
    call $~lib/string/String.__eq
@@ -23571,9 +21004,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5280
-   i32.store offset=4
    local.get $0
    i32.const 5280
    call $~lib/string/String.__eq
@@ -23592,9 +21022,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25088
-   i32.store offset=4
    local.get $0
    i32.const 25088
    call $~lib/string/String.__eq
@@ -23613,9 +21040,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25120
-   i32.store offset=4
    local.get $0
    i32.const 25120
    call $~lib/string/String.__eq
@@ -23634,9 +21058,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25152
-   i32.store offset=4
    local.get $0
    i32.const 25152
    call $~lib/string/String.__eq
@@ -23655,9 +21076,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25200
-   i32.store offset=4
    local.get $0
    i32.const 25200
    call $~lib/string/String.__eq
@@ -23676,9 +21094,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25248
-   i32.store offset=4
    local.get $0
    i32.const 25248
    call $~lib/string/String.__eq
@@ -23697,9 +21112,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25296
-   i32.store offset=4
    local.get $0
    i32.const 25296
    call $~lib/string/String.__eq
@@ -23718,9 +21130,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25344
-   i32.store offset=4
    local.get $0
    i32.const 25344
    call $~lib/string/String.__eq
@@ -23739,9 +21148,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25392
-   i32.store offset=4
    local.get $0
    i32.const 25392
    call $~lib/string/String.__eq
@@ -23760,9 +21166,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5568
-   i32.store offset=4
    local.get $0
    i32.const 5568
    call $~lib/string/String.__eq
@@ -23781,9 +21184,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25424
-   i32.store offset=4
    local.get $0
    i32.const 25424
    call $~lib/string/String.__eq
@@ -23802,9 +21202,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23312
-   i32.store offset=4
    local.get $0
    i32.const 23312
    call $~lib/string/String.__eq
@@ -23823,9 +21220,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8960
-   i32.store offset=4
    local.get $0
    i32.const 8960
    call $~lib/string/String.__eq
@@ -23844,9 +21238,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25472
-   i32.store offset=4
    local.get $0
    i32.const 25472
    call $~lib/string/String.__eq
@@ -23865,9 +21256,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25504
-   i32.store offset=4
    local.get $0
    i32.const 25504
    call $~lib/string/String.__eq
@@ -23886,9 +21274,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25552
-   i32.store offset=4
    local.get $0
    i32.const 25552
    call $~lib/string/String.__eq
@@ -23907,9 +21292,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25584
-   i32.store offset=4
    local.get $0
    i32.const 25584
    call $~lib/string/String.__eq
@@ -23928,9 +21310,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 23280
-   i32.store offset=4
    local.get $0
    i32.const 23280
    call $~lib/string/String.__eq
@@ -23977,9 +21356,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $4
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25632
-   i32.store offset=4
    local.get $4
    i32.const 25632
    call $~lib/string/String.__eq
@@ -23998,9 +21374,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25680
-   i32.store offset=4
    local.get $0
    i32.const 25680
    call $~lib/string/String.__eq
@@ -24019,9 +21392,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25744
-   i32.store offset=4
    local.get $0
    i32.const 25744
    call $~lib/string/String.__eq
@@ -24040,9 +21410,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25808
-   i32.store offset=4
    local.get $0
    i32.const 25808
    call $~lib/string/String.__eq
@@ -24061,9 +21428,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25056
-   i32.store offset=4
    local.get $0
    i32.const 25056
    call $~lib/string/String.__eq
@@ -24082,9 +21446,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25872
-   i32.store offset=4
    local.get $0
    i32.const 25872
    call $~lib/string/String.__eq
@@ -24103,9 +21464,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25904
-   i32.store offset=4
    local.get $0
    i32.const 25904
    call $~lib/string/String.__eq
@@ -24124,9 +21482,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 25968
-   i32.store offset=4
    local.get $0
    i32.const 25968
    call $~lib/string/String.__eq
@@ -24145,9 +21500,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26048
-   i32.store offset=4
    local.get $0
    i32.const 26048
    call $~lib/string/String.__eq
@@ -24166,9 +21518,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26096
-   i32.store offset=4
    local.get $0
    i32.const 26096
    call $~lib/string/String.__eq
@@ -24187,9 +21536,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26144
-   i32.store offset=4
    local.get $0
    i32.const 26144
    call $~lib/string/String.__eq
@@ -24208,9 +21554,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26192
-   i32.store offset=4
    local.get $0
    i32.const 26192
    call $~lib/string/String.__eq
@@ -24229,9 +21572,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26240
-   i32.store offset=4
    local.get $0
    i32.const 26240
    call $~lib/string/String.__eq
@@ -24250,9 +21590,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26288
-   i32.store offset=4
    local.get $0
    i32.const 26288
    call $~lib/string/String.__eq
@@ -24271,9 +21608,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26336
-   i32.store offset=4
    local.get $0
    i32.const 26336
    call $~lib/string/String.__eq
@@ -24286,12 +21620,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26384
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26416
-   i32.store offset=12
    i32.const 26384
    i32.const 26416
    call $~lib/string/String#concat
@@ -24299,9 +21627,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26448
-   i32.store offset=4
    local.get $0
    i32.const 26448
    call $~lib/string/String.__eq
@@ -24314,12 +21639,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26496
-   i32.store offset=12
    i32.const 1712
    i32.const 26496
    call $~lib/string/String#concat
@@ -24327,9 +21646,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26496
-   i32.store offset=4
    local.get $0
    i32.const 26496
    call $~lib/string/String.__eq
@@ -24342,12 +21658,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26496
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
    i32.const 26496
    i32.const 1712
    call $~lib/string/String#concat
@@ -24355,9 +21665,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26496
-   i32.store offset=4
    local.get $0
    i32.const 26496
    call $~lib/string/String.__eq
@@ -24370,12 +21677,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=12
    i32.const 1712
    i32.const 1712
    call $~lib/string/String#concat
@@ -24383,9 +21684,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1712
-   i32.store offset=4
    local.get $0
    i32.const 1712
    call $~lib/string/String.__eq
@@ -24398,12 +21696,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26528
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26528
-   i32.store offset=4
    i32.const 26528
    i32.const 26528
    call $~lib/string/String.__eq
@@ -24416,12 +21708,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26528
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26528
-   i32.store offset=4
    i32.const 26528
    i32.const 26528
    call $~lib/string/String.__eq
@@ -24434,12 +21720,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26560
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26560
-   i32.store offset=4
    i32.const 26560
    i32.const 26560
    call $~lib/string/String.__eq
@@ -24452,12 +21732,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26592
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 26592
-   i32.store offset=4
    i32.const 26592
    i32.const 26592
    call $~lib/string/String.__eq
@@ -24508,7 +21782,7 @@
    i32.add
    global.set $~lib/rt/itcms/threshold
    global.get $~lib/memory/__stack_pointer
-   i32.const 96
+   i32.const 76
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -4913,14 +4913,16 @@
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   local.get $this
   local.set $id
   global.get $~lib/memory/__stack_pointer
@@ -5085,24 +5087,7 @@
    br $break|0
   end
   i32.const 1392
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   local.get $str
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=16
-  local.get $4
-  call $~lib/string/String.__concat
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 1440
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
@@ -5111,7 +5096,14 @@
   call $~lib/string/String.__concat
   local.set $4
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  local.get $4
+  i32.store offset=4
+  local.get $4
+  i32.const 1440
+  call $~lib/string/String.__concat
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $4
@@ -5133,19 +5125,9 @@
   i64.const 0
   i64.store offset=8
   i32.const 32
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store
-  local.get $2
   call $~lib/symbol/Symbol
   global.set $std/symbol/sym1
   i32.const 32
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store
-  local.get $2
   call $~lib/symbol/Symbol
   global.set $std/symbol/sym2
   global.get $std/symbol/sym1
@@ -5184,19 +5166,9 @@
   call $"~lib/map/Map<usize,~lib/string/String>#constructor"
   global.set $~lib/symbol/idToString
   i32.const 32
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store
-  local.get $2
   call $~lib/symbol/_Symbol.for
   global.set $std/symbol/sym3
   i32.const 32
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store
-  local.get $2
   call $~lib/symbol/_Symbol.for
   global.set $std/symbol/sym4
   global.get $std/symbol/sym3
@@ -5292,11 +5264,6 @@
   i32.store
   local.get $2
   i32.const 32
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5338,11 +5305,6 @@
   i32.store
   local.get $2
   i32.const 1472
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5361,11 +5323,6 @@
   i32.store
   local.get $2
   i32.const 1520
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5388,11 +5345,6 @@
   i32.store
   local.get $2
   i32.const 1568
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5411,11 +5363,6 @@
   i32.store
   local.get $2
   i32.const 1632
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -3571,7 +3571,7 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -3586,9 +3586,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   i32.const 1888
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3715,11 +3717,8 @@
    end
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 2416
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=16
+  i32.store offset=8
   i32.const 2416
   local.get $1
   call $~lib/string/String.__concat
@@ -3727,14 +3726,11 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2464
-  i32.store offset=8
   local.get $0
   i32.const 2464
   call $~lib/string/String.__concat
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -3756,9 +3752,6 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
    global.get $~lib/symbol/nextId
    local.tee $0
    i32.const 1
@@ -3771,9 +3764,6 @@
    end
    local.get $0
    global.set $std/symbol/sym1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
    global.get $~lib/symbol/nextId
    local.tee $0
    i32.const 1
@@ -3993,14 +3983,8 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    global.set $~lib/symbol/idToString
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
    call $~lib/symbol/_Symbol.for
    global.set $std/symbol/sym3
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
    call $~lib/symbol/_Symbol.for
    global.set $std/symbol/sym4
    global.get $std/symbol/sym3
@@ -4090,9 +4074,6 @@
    global.get $std/symbol/key3
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=12
    local.get $0
    i32.const 1056
    call $~lib/string/String.__eq
@@ -4141,9 +4122,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2496
-   i32.store offset=12
    local.get $0
    i32.const 2496
    call $~lib/string/String.__eq
@@ -4162,9 +4140,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2544
-   i32.store offset=12
    local.get $0
    i32.const 2544
    call $~lib/string/String.__eq
@@ -4185,9 +4160,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2592
-   i32.store offset=12
    local.get $0
    i32.const 2592
    call $~lib/string/String.__eq
@@ -4206,9 +4178,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2656
-   i32.store offset=12
    local.get $0
    i32.const 2656
    call $~lib/string/String.__eq

--- a/tests/compiler/std/trace.debug.wat
+++ b/tests/compiler/std/trace.debug.wat
@@ -1,9 +1,7 @@
 (module
  (type $0 (func))
  (type $1 (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $2 (func (param i32 i32 i32 i32)))
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
- (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/memory/__data_end i32 (i32.const 396))
  (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33164))
  (global $~lib/memory/__heap_base i32 (i32.const 33164))
@@ -21,44 +19,8 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
- (func $~start
-  global.get $~started
-  if
-   return
-  end
-  i32.const 1
-  global.set $~started
-  call $start:std/trace
- )
- (func $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__data_end
-  i32.lt_s
-  if
-   i32.const 33184
-   i32.const 33232
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
- )
  (func $start:std/trace
-  (local $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 0
   f64.const 0
   f64.const 0
@@ -67,11 +29,6 @@
   f64.const 0
   call $~lib/builtins/trace
   i32.const 80
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 0
   f64.const 0
   f64.const 0
@@ -80,11 +37,6 @@
   f64.const 0
   call $~lib/builtins/trace
   i32.const 128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 1
   f64.const 1
   f64.const 0
@@ -93,11 +45,6 @@
   f64.const 0
   call $~lib/builtins/trace
   i32.const 176
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 2
   f64.const 1
   f64.const 2
@@ -106,11 +53,6 @@
   f64.const 0
   call $~lib/builtins/trace
   i32.const 224
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 3
   f64.const 1
   f64.const 2
@@ -119,11 +61,6 @@
   f64.const 0
   call $~lib/builtins/trace
   i32.const 272
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 4
   f64.const 1
   f64.const 2
@@ -132,11 +69,6 @@
   f64.const 0
   call $~lib/builtins/trace
   i32.const 320
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 5
   f64.const 1
   f64.const 2
@@ -145,11 +77,6 @@
   f64.const 5
   call $~lib/builtins/trace
   i32.const 368
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 5
   f64.const 1.1
   f64.const 2.2
@@ -157,9 +84,14 @@
   f64.const 4.4
   f64.const 5.5
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~start
+  global.get $~started
+  if
+   return
+  end
+  i32.const 1
+  global.set $~started
+  call $start:std/trace
  )
 )

--- a/tests/compiler/std/trace.release.wat
+++ b/tests/compiler/std/trace.release.wat
@@ -1,10 +1,7 @@
 (module
  (type $0 (func (param i32 i32 f64 f64 f64 f64 f64)))
  (type $1 (func))
- (type $2 (func (param i32 i32 i32 i32)))
  (import "env" "trace" (func $~lib/builtins/trace (param i32 i32 f64 f64 f64 f64 f64)))
- (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34188))
  (global $~started (mut i32) (i32.const 0))
  (memory $0 1)
  (data $0 (i32.const 1036) ",")
@@ -32,27 +29,6 @@
   end
   i32.const 1
   global.set $~started
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1420
-  i32.lt_s
-  if
-   i32.const 34208
-   i32.const 34256
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store
   i32.const 1056
   i32.const 0
   f64.const 0
@@ -61,9 +37,6 @@
   f64.const 0
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1104
-  i32.store
   i32.const 1104
   i32.const 0
   f64.const 0
@@ -72,9 +45,6 @@
   f64.const 0
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1152
-  i32.store
   i32.const 1152
   i32.const 1
   f64.const 1
@@ -83,9 +53,6 @@
   f64.const 0
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1200
-  i32.store
   i32.const 1200
   i32.const 2
   f64.const 1
@@ -94,9 +61,6 @@
   f64.const 0
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1248
-  i32.store
   i32.const 1248
   i32.const 3
   f64.const 1
@@ -105,9 +69,6 @@
   f64.const 0
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1296
-  i32.store
   i32.const 1296
   i32.const 4
   f64.const 1
@@ -116,9 +77,6 @@
   f64.const 4
   f64.const 0
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1344
-  i32.store
   i32.const 1344
   i32.const 5
   f64.const 1
@@ -127,9 +85,6 @@
   f64.const 4
   f64.const 5
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1392
-  i32.store
   i32.const 1392
   i32.const 5
   f64.const 1.1
@@ -138,9 +93,5 @@
   f64.const 4.4
   f64.const 5.5
   call $~lib/builtins/trace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
 )

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -57229,13 +57229,13 @@
  (func $~lib/typedarray/Int8Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -57243,15 +57243,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Int8Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -57261,14 +57256,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -57326,14 +57323,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Int8Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -57341,11 +57333,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -57360,7 +57347,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Int8Array#toString
   local.set $1
@@ -57369,11 +57356,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -57385,7 +57367,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -57610,13 +57592,13 @@
  (func $~lib/typedarray/Uint8Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -57624,15 +57606,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Uint8Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -57642,14 +57619,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -57707,14 +57686,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Uint8Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -57722,11 +57696,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -57741,7 +57710,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Uint8Array#toString
   local.set $1
@@ -57750,11 +57719,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -57766,7 +57730,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -57812,13 +57776,13 @@
  (func $~lib/typedarray/Uint8ClampedArray#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -57826,15 +57790,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Uint8ClampedArray#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -57844,14 +57803,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -57909,14 +57870,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Uint8ClampedArray#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -57924,11 +57880,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -57943,7 +57894,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Uint8ClampedArray#toString
   local.set $1
@@ -57952,11 +57903,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -57968,7 +57914,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -58193,13 +58139,13 @@
  (func $~lib/typedarray/Int16Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -58207,15 +58153,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Int16Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -58225,14 +58166,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -58290,14 +58233,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Int16Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -58305,11 +58243,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -58324,7 +58257,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Int16Array#toString
   local.set $1
@@ -58333,11 +58266,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -58349,7 +58277,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -58574,13 +58502,13 @@
  (func $~lib/typedarray/Uint16Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -58588,15 +58516,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Uint16Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -58606,14 +58529,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -58671,14 +58596,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Uint16Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -58686,11 +58606,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -58705,7 +58620,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Uint16Array#toString
   local.set $1
@@ -58714,11 +58629,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -58730,7 +58640,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -58955,13 +58865,13 @@
  (func $~lib/typedarray/Int32Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -58969,15 +58879,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Int32Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -58987,14 +58892,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -59052,14 +58959,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Int32Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -59067,11 +58969,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -59086,7 +58983,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Int32Array#toString
   local.set $1
@@ -59095,11 +58992,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -59111,7 +59003,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -59336,13 +59228,13 @@
  (func $~lib/typedarray/Uint32Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -59350,15 +59242,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Uint32Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -59368,14 +59255,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -59433,14 +59322,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Uint32Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -59448,11 +59332,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -59467,7 +59346,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Uint32Array#toString
   local.set $1
@@ -59476,11 +59355,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -59492,7 +59366,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -59719,13 +59593,13 @@
  (func $~lib/typedarray/Int64Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -59733,15 +59607,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Int64Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -59751,14 +59620,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -59816,14 +59687,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Int64Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -59831,11 +59697,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -59850,7 +59711,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Int64Array#toString
   local.set $1
@@ -59859,11 +59720,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -59875,7 +59731,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -60100,13 +59956,13 @@
  (func $~lib/typedarray/Uint64Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -60114,15 +59970,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Uint64Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -60132,14 +59983,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -60197,14 +60050,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Uint64Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -60212,11 +60060,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -60231,7 +60074,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Uint64Array#toString
   local.set $1
@@ -60240,11 +60083,6 @@
   i32.store offset=4
   local.get $1
   i32.const 8592
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -60256,7 +60094,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -60471,13 +60309,13 @@
  (func $~lib/typedarray/Float32Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -60485,15 +60323,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Float32Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -60503,14 +60336,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -60568,14 +60403,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Float32Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -60583,11 +60413,6 @@
   i32.store offset=4
   local.get $1
   i32.const 9776
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -60602,7 +60427,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Float32Array#toString
   local.set $1
@@ -60611,11 +60436,6 @@
   i32.store offset=4
   local.get $1
   i32.const 9776
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -60627,7 +60447,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -60842,13 +60662,13 @@
  (func $~lib/typedarray/Float64Array#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -60856,15 +60676,10 @@
   i32.store
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   call $~lib/typedarray/Float64Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -60874,14 +60689,16 @@
   (local $array i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 20
-  memory.fill
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 5
@@ -60939,14 +60756,9 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   i32.const 8560
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=16
-  local.get $1
   call $~lib/typedarray/Float64Array#join
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -60954,11 +60766,6 @@
   i32.store offset=4
   local.get $1
   i32.const 9776
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -60973,7 +60780,7 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=12
+  i32.store offset=8
   local.get $1
   call $~lib/typedarray/Float64Array#toString
   local.set $1
@@ -60982,11 +60789,6 @@
   i32.store offset=4
   local.get $1
   i32.const 9776
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -60998,7 +60800,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -65247,11 +65049,6 @@
     i32.ne
     if
      i32.const 10320
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -66690,11 +66487,6 @@
     i32.ne
     if
      i32.const 10528
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -68047,11 +67839,6 @@
     i32.ne
     if
      i32.const 10736
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -69539,11 +69326,6 @@
     i32.ne
     if
      i32.const 10976
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -70966,11 +70748,6 @@
     i32.ne
     if
      i32.const 11264
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -72336,11 +72113,6 @@
     i32.ne
     if
      i32.const 11568
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -73763,11 +73535,6 @@
     i32.ne
     if
      i32.const 11936
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -75225,11 +74992,6 @@
     i64.ne
     if
      i32.const 12352
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -76657,11 +76419,6 @@
     i64.ne
     if
      i32.const 12960
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -78064,11 +77821,6 @@
     f32.ne
     if
      i32.const 13520
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s
@@ -79287,11 +79039,6 @@
     f64.ne
     if
      i32.const 13872
-     local.set $6
-     global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store
-     local.get $6
      i32.const 3
      local.get $i
      f64.convert_i32_s

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -35797,7 +35797,7 @@
  )
  (func $~lib/typedarray/Uint8Array#toString (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -35812,18 +35812,15 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 9584
-  i32.store offset=4
   local.get $0
   call $~lib/typedarray/Uint8Array#join
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -40491,9 +40488,6 @@
      local.get $5
      i32.ne
      if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 11344
-      i32.store
       i32.const 11344
       i32.const 3
       local.get $2
@@ -41397,9 +41391,6 @@
     local.get $4
     i32.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 11552
-     i32.store
      i32.const 11552
      i32.const 3
      local.get $2
@@ -41933,9 +41924,6 @@
     local.get $4
     i32.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 11760
-     i32.store
      i32.const 11760
      i32.const 3
      local.get $2
@@ -43022,9 +43010,6 @@
     local.get $4
     i32.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12000
-     i32.store
      i32.const 12000
      i32.const 3
      local.get $2
@@ -43956,9 +43941,6 @@
     local.get $4
     i32.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12288
-     i32.store
      i32.const 12288
      i32.const 3
      local.get $2
@@ -44612,9 +44594,6 @@
     local.get $4
     i32.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12592
-     i32.store
      i32.const 12592
      i32.const 3
      local.get $2
@@ -45574,9 +45553,6 @@
     local.get $4
     i32.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12960
-     i32.store
      i32.const 12960
      i32.const 3
      local.get $2
@@ -46247,9 +46223,6 @@
     local.get $4
     i64.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 13376
-     i32.store
      i32.const 13376
      i32.const 3
      local.get $2
@@ -47182,9 +47155,6 @@
     local.get $4
     i64.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 13984
-     i32.store
      i32.const 13984
      i32.const 3
      local.get $2
@@ -47757,9 +47727,6 @@
     local.get $4
     f32.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 14544
-     i32.store
      i32.const 14544
      i32.const 3
      local.get $2
@@ -48515,9 +48482,6 @@
     local.get $4
     f64.ne
     if
-     global.get $~lib/memory/__stack_pointer
-     i32.const 14896
-     i32.store
      i32.const 14896
      i32.const 3
      local.get $2
@@ -53542,15 +53506,15 @@
   i32.const 124
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner25
-   block $folding-inner24
-    block $folding-inner23
-     block $folding-inner22
-      block $folding-inner21
-       block $folding-inner20
-        block $folding-inner19
-         block $folding-inner18
-          block $folding-inner17
+  block $folding-inner23
+   block $folding-inner22
+    block $folding-inner21
+     block $folding-inner20
+      block $folding-inner19
+       block $folding-inner18
+        block $folding-inner17
+         block $folding-inner16
+          block $folding-inner15
            block $folding-inner13
             block $folding-inner12
              block $folding-inner11
@@ -53565,7 +53529,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
                       i32.const 124
@@ -55831,7 +55795,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -55877,7 +55841,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -55941,7 +55905,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -55953,7 +55917,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -55999,7 +55963,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56011,7 +55975,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56057,7 +56021,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56071,7 +56035,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56117,7 +56081,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56185,7 +56149,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56199,7 +56163,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56245,7 +56209,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56313,7 +56277,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56327,7 +56291,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56373,7 +56337,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56439,7 +56403,7 @@
                       local.get $1
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56453,7 +56417,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56499,7 +56463,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56565,7 +56529,7 @@
                       local.get $1
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56579,7 +56543,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56625,7 +56589,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56689,7 +56653,7 @@
                       local.get $3
                       i64.const 6
                       i64.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56705,7 +56669,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56751,7 +56715,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56815,7 +56779,7 @@
                       local.get $3
                       i64.const 6
                       i64.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56829,7 +56793,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56875,7 +56839,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56939,7 +56903,7 @@
                       local.get $4
                       f32.const 6
                       f32.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -56953,7 +56917,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -56999,7 +56963,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57063,7 +57027,7 @@
                       local.get $5
                       f64.const 6
                       f64.ne
-                      br_if $folding-inner18
+                      br_if $folding-inner20
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -57075,7 +57039,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57143,7 +57107,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57211,7 +57175,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57279,7 +57243,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57347,7 +57311,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57415,7 +57379,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57483,7 +57447,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57551,7 +57515,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57619,7 +57583,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57687,7 +57651,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57755,7 +57719,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57823,7 +57787,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57869,7 +57833,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57937,7 +57901,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -57949,7 +57913,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -57995,7 +57959,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58007,7 +57971,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58053,7 +58017,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58065,7 +58029,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58111,7 +58075,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58181,7 +58145,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58193,7 +58157,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58239,7 +58203,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58309,7 +58273,7 @@
                       i32.and
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58321,7 +58285,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58367,7 +58331,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58435,7 +58399,7 @@
                       local.get $1
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58447,7 +58411,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58493,7 +58457,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58561,7 +58525,7 @@
                       local.get $1
                       i32.const 6
                       i32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58575,7 +58539,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58621,7 +58585,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58687,7 +58651,7 @@
                       local.get $3
                       i64.const 6
                       i64.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58701,7 +58665,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58747,7 +58711,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58813,7 +58777,7 @@
                       local.get $3
                       i64.const 6
                       i64.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58827,7 +58791,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58873,7 +58837,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58939,7 +58903,7 @@
                       local.get $4
                       f32.const 6
                       f32.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -58953,7 +58917,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -58999,7 +58963,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59065,7 +59029,7 @@
                       local.get $5
                       f64.const 6
                       f64.ne
-                      br_if $folding-inner20
+                      br_if $folding-inner22
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -59099,7 +59063,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59164,7 +59128,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59229,7 +59193,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59294,7 +59258,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59359,7 +59323,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59424,7 +59388,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59489,7 +59453,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59554,7 +59518,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59619,7 +59583,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59684,7 +59648,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59749,7 +59713,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59814,7 +59778,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59882,7 +59846,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -59950,7 +59914,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60018,7 +59982,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60086,7 +60050,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60154,7 +60118,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60222,7 +60186,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60290,7 +60254,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60358,7 +60322,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60426,7 +60390,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60494,7 +60458,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60562,7 +60526,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60630,7 +60594,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60698,7 +60662,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60766,7 +60730,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60834,7 +60798,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60902,7 +60866,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -60970,7 +60934,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61038,7 +61002,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61106,7 +61070,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61174,7 +61138,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61242,7 +61206,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61310,7 +61274,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61375,7 +61339,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61440,7 +61404,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61505,7 +61469,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61570,7 +61534,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61635,7 +61599,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61700,7 +61664,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61765,7 +61729,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61830,7 +61794,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61895,7 +61859,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -61960,7 +61924,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62027,7 +61991,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62095,7 +62059,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62153,7 +62117,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -62165,7 +62129,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62235,7 +62199,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -62247,7 +62211,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62317,7 +62281,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -62331,7 +62295,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62399,7 +62363,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62459,7 +62423,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -62473,7 +62437,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62544,7 +62508,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62604,7 +62568,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -62618,7 +62582,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62683,7 +62647,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62743,7 +62707,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -62757,7 +62721,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62822,7 +62786,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62882,7 +62846,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -62896,7 +62860,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -62964,7 +62928,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63024,7 +62988,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -63038,7 +63002,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63106,7 +63070,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63166,7 +63130,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -63180,7 +63144,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63248,7 +63212,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63308,7 +63272,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -63322,7 +63286,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63390,7 +63354,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63450,7 +63414,7 @@
                       global.get $std/typedarray/forEachCallCount
                       i32.const 3
                       i32.ne
-                      br_if $folding-inner21
+                      br_if $folding-inner23
                       global.get $~lib/memory/__stack_pointer
                       i32.const 12
                       i32.add
@@ -63518,7 +63482,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63626,7 +63590,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -63694,17 +63658,19 @@
                        unreachable
                       end
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Int8Array#constructor
@@ -63747,78 +63713,68 @@
                       call $~lib/typedarray/Int8Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Int8Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Int8Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Uint8Array#constructor
@@ -63861,57 +63817,50 @@
                       call $~lib/typedarray/Uint8Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Uint8Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Uint8Array#toString
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Uint8ClampedArray#constructor
@@ -63954,57 +63903,50 @@
                       call $~lib/typedarray/Uint8ClampedArray#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Uint8Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Uint8Array#toString
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Int16Array#constructor
@@ -64047,78 +63989,68 @@
                       call $~lib/typedarray/Int16Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Int16Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Int16Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Uint16Array#constructor
@@ -64161,78 +64093,68 @@
                       call $~lib/typedarray/Uint16Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Uint16Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Uint16Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Int32Array#constructor
@@ -64275,78 +64197,68 @@
                       call $~lib/typedarray/Int32Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Int32Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Int32Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Uint32Array#constructor
@@ -64389,78 +64301,68 @@
                       call $~lib/typedarray/Uint32Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Uint32Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Uint32Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Int64Array#constructor
@@ -64503,78 +64405,68 @@
                       call $~lib/typedarray/Int64Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Int64Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Int64Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Uint64Array#constructor
@@ -64617,78 +64509,68 @@
                       call $~lib/typedarray/Uint64Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Uint64Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $1
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner22
+                      br_if $folding-inner15
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Uint64Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9616
-                      i32.store offset=8
                       local.get $0
                       i32.const 9616
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner23
+                      br_if $folding-inner16
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Float32Array#constructor
@@ -64731,78 +64613,68 @@
                       call $~lib/typedarray/Float32Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Float32Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 10800
-                      i32.store offset=8
                       local.get $1
                       i32.const 10800
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner24
+                      br_if $folding-inner17
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Float32Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 10800
-                      i32.store offset=8
                       local.get $0
                       i32.const 10800
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner25
+                      br_if $folding-inner18
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
+                      global.get $~lib/memory/__stack_pointer
+                      i64.const 0
+                      i64.store
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
-                      i32.const 20
-                      memory.fill
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
                       i32.const 5
                       call $~lib/typedarray/Float64Array#constructor
@@ -64845,64 +64717,52 @@
                       call $~lib/typedarray/Float64Array#__set
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=16
+                      i32.store offset=8
                       local.get $0
                       call $~lib/typedarray/Float64Array#join
                       local.set $1
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 10800
-                      i32.store offset=8
                       local.get $1
                       i32.const 10800
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner24
+                      br_if $folding-inner17
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
-                      i32.store offset=12
+                      i32.store offset=8
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.sub
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
-                      i64.const 0
-                      i64.store
+                      i32.const 0
+                      i32.store
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 9584
-                      i32.store offset=4
                       local.get $0
                       call $~lib/typedarray/Float64Array#join
                       local.set $0
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 8
+                      i32.const 4
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
                       local.get $0
                       i32.store offset=4
-                      global.get $~lib/memory/__stack_pointer
-                      i32.const 10800
-                      i32.store offset=8
                       local.get $0
                       i32.const 10800
                       call $~lib/string/String.__eq
                       i32.eqz
-                      br_if $folding-inner25
+                      br_if $folding-inner18
                       global.get $~lib/memory/__stack_pointer
-                      i32.const 20
+                      i32.const 12
                       i32.add
                       global.set $~lib/memory/__stack_pointer
                       global.get $~lib/memory/__stack_pointer
@@ -64971,7 +64831,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i32.const 0
                       i32.const 24
@@ -64990,7 +64850,7 @@
                       call $~lib/typedarray/Uint8Array#constructor
                       local.tee $1
                       i32.store offset=8
-                      loop $for-loop|062
+                      loop $for-loop|053
                        local.get $0
                        local.get $2
                        i32.gt_s
@@ -65013,7 +64873,7 @@
                         i32.const 1
                         i32.add
                         local.set $2
-                        br $for-loop|062
+                        br $for-loop|053
                        end
                       end
                       global.get $~lib/memory/__stack_pointer
@@ -65217,7 +65077,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -65245,7 +65105,7 @@
                       i32.const 1
                       i32.add
                       i32.lt_s
-                      br_if $folding-inner17
+                      br_if $folding-inner19
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=8
@@ -65262,7 +65122,7 @@
                       local.set $0
                       i32.const 0
                       local.set $2
-                      loop $for-loop|0663
+                      loop $for-loop|0654
                        local.get $2
                        local.get $8
                        i32.lt_s
@@ -65296,7 +65156,7 @@
                         i32.const 1
                         i32.add
                         local.set $2
-                        br $for-loop|0663
+                        br $for-loop|0654
                        end
                       end
                       global.get $~lib/memory/__stack_pointer
@@ -65326,7 +65186,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -65354,7 +65214,7 @@
                       i32.const 8
                       i32.add
                       i32.lt_s
-                      br_if $folding-inner17
+                      br_if $folding-inner19
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=8
@@ -65504,7 +65364,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -65530,7 +65390,7 @@
                       call $~lib/typedarray/Int8Array#get:length
                       local.get $6
                       i32.lt_s
-                      br_if $folding-inner17
+                      br_if $folding-inner19
                       global.get $~lib/memory/__stack_pointer
                       local.get $1
                       i32.store offset=8
@@ -65545,7 +65405,7 @@
                       local.set $8
                       i32.const 0
                       local.set $0
-                      loop $for-loop|0864
+                      loop $for-loop|0855
                        local.get $0
                        local.get $6
                        i32.lt_s
@@ -65570,7 +65430,7 @@
                         i32.const 1
                         i32.add
                         local.set $0
-                        br $for-loop|0864
+                        br $for-loop|0855
                        end
                       end
                       global.get $~lib/memory/__stack_pointer
@@ -67609,7 +67469,7 @@
                       global.get $~lib/memory/__stack_pointer
                       i32.const 16320
                       i32.lt_s
-                      br_if $folding-inner19
+                      br_if $folding-inner21
                       global.get $~lib/memory/__stack_pointer
                       i64.const 0
                       i64.store
@@ -67880,66 +67740,66 @@
            call $~lib/builtins/abort
            unreachable
           end
-          i32.const 1360
-          i32.const 1632
-          i32.const 1902
+          i32.const 0
+          i32.const 1568
+          i32.const 675
           i32.const 5
           call $~lib/builtins/abort
           unreachable
          end
          i32.const 0
          i32.const 1568
-         i32.const 323
-         i32.const 3
+         i32.const 676
+         i32.const 5
          call $~lib/builtins/abort
          unreachable
         end
-        i32.const 49120
-        i32.const 49168
-        i32.const 1
-        i32.const 1
+        i32.const 0
+        i32.const 1568
+        i32.const 672
+        i32.const 5
         call $~lib/builtins/abort
         unreachable
        end
        i32.const 0
        i32.const 1568
-       i32.const 367
-       i32.const 3
+       i32.const 673
+       i32.const 5
        call $~lib/builtins/abort
        unreachable
       end
-      i32.const 0
-      i32.const 1568
-      i32.const 541
-      i32.const 3
+      i32.const 1360
+      i32.const 1632
+      i32.const 1902
+      i32.const 5
       call $~lib/builtins/abort
       unreachable
      end
      i32.const 0
      i32.const 1568
-     i32.const 675
-     i32.const 5
+     i32.const 323
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
-    i32.const 0
-    i32.const 1568
-    i32.const 676
-    i32.const 5
+    i32.const 49120
+    i32.const 49168
+    i32.const 1
+    i32.const 1
     call $~lib/builtins/abort
     unreachable
    end
    i32.const 0
    i32.const 1568
-   i32.const 672
-   i32.const 5
+   i32.const 367
+   i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   i32.const 0
   i32.const 1568
-  i32.const 673
-  i32.const 5
+  i32.const 541
+  i32.const 3
   call $~lib/builtins/abort
   unreachable
  )

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -3679,16 +3679,13 @@
  (func $start:std/uri
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.store offset=8
+  i32.store
   memory.size
   i32.const 16
   i32.shl
@@ -3707,11 +3704,6 @@
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3719,11 +3711,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3735,11 +3722,6 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3747,11 +3729,6 @@
   i32.store
   local.get $0
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3763,11 +3740,6 @@
    unreachable
   end
   i32.const 768
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3775,11 +3747,6 @@
   i32.store
   local.get $0
   i32.const 768
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3791,11 +3758,6 @@
    unreachable
   end
   i32.const 800
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3803,11 +3765,6 @@
   i32.store
   local.get $0
   i32.const 800
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3819,11 +3776,6 @@
    unreachable
   end
   i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3831,11 +3783,6 @@
   i32.store
   local.get $0
   i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3847,11 +3794,6 @@
    unreachable
   end
   i32.const 928
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3859,11 +3801,6 @@
   i32.store
   local.get $0
   i32.const 960
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3875,11 +3812,6 @@
    unreachable
   end
   i32.const 992
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3887,11 +3819,6 @@
   i32.store
   local.get $0
   i32.const 1024
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3903,11 +3830,6 @@
    unreachable
   end
   i32.const 1056
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3915,11 +3837,6 @@
   i32.store
   local.get $0
   i32.const 1088
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3931,11 +3848,6 @@
    unreachable
   end
   i32.const 1136
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3943,11 +3855,6 @@
   i32.store
   local.get $0
   i32.const 1168
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3959,11 +3866,6 @@
    unreachable
   end
   i32.const 1216
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3971,11 +3873,6 @@
   i32.store
   local.get $0
   i32.const 1248
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3987,11 +3884,6 @@
    unreachable
   end
   i32.const 1280
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -3999,11 +3891,6 @@
   i32.store
   local.get $0
   i32.const 1312
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4015,11 +3902,6 @@
    unreachable
   end
   i32.const 1360
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4027,11 +3909,6 @@
   i32.store
   local.get $0
   i32.const 1392
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4043,11 +3920,6 @@
    unreachable
   end
   i32.const 1488
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4055,11 +3927,6 @@
   i32.store
   local.get $0
   i32.const 1520
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4071,11 +3938,6 @@
    unreachable
   end
   i32.const 1632
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4083,11 +3945,6 @@
   i32.store
   local.get $0
   i32.const 1664
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4099,11 +3956,6 @@
    unreachable
   end
   i32.const 1712
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4111,11 +3963,6 @@
   i32.store
   local.get $0
   i32.const 1744
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4127,11 +3974,6 @@
    unreachable
   end
   i32.const 1792
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4139,11 +3981,6 @@
   i32.store
   local.get $0
   i32.const 1824
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4155,11 +3992,6 @@
    unreachable
   end
   i32.const 1904
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4167,11 +3999,6 @@
   i32.store
   local.get $0
   i32.const 1936
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4183,11 +4010,6 @@
    unreachable
   end
   i32.const 2000
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4195,11 +4017,6 @@
   i32.store
   local.get $0
   i32.const 2048
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4211,11 +4028,6 @@
    unreachable
   end
   i32.const 2128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4223,11 +4035,6 @@
   i32.store
   local.get $0
   i32.const 2240
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4239,11 +4046,6 @@
    unreachable
   end
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4251,11 +4053,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4267,11 +4064,6 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4279,11 +4071,6 @@
   i32.store
   local.get $0
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4295,11 +4082,6 @@
    unreachable
   end
   i32.const 2480
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4307,11 +4089,6 @@
   i32.store
   local.get $0
   i32.const 2480
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4323,11 +4100,6 @@
    unreachable
   end
   i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4335,11 +4107,6 @@
   i32.store
   local.get $0
   i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4351,11 +4118,6 @@
    unreachable
   end
   i32.const 2528
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4363,11 +4125,6 @@
   i32.store
   local.get $0
   i32.const 2560
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4379,11 +4136,6 @@
    unreachable
   end
   i32.const 1632
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4391,11 +4143,6 @@
   i32.store
   local.get $0
   i32.const 1664
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4407,11 +4154,6 @@
    unreachable
   end
   i32.const 1712
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4419,11 +4161,6 @@
   i32.store
   local.get $0
   i32.const 1744
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4435,11 +4172,6 @@
    unreachable
   end
   i32.const 1904
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4447,11 +4179,6 @@
   i32.store
   local.get $0
   i32.const 1936
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4463,11 +4190,6 @@
    unreachable
   end
   i32.const 2128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4475,11 +4197,6 @@
   i32.store
   local.get $0
   i32.const 2128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4491,11 +4208,6 @@
    unreachable
   end
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4503,11 +4215,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4519,11 +4226,6 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4531,11 +4233,6 @@
   i32.store
   local.get $0
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4547,11 +4244,6 @@
    unreachable
   end
   i32.const 2624
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4559,11 +4251,6 @@
   i32.store
   local.get $0
   i32.const 2656
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4575,11 +4262,6 @@
    unreachable
   end
   i32.const 2688
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4587,11 +4269,6 @@
   i32.store
   local.get $0
   i32.const 2720
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4603,11 +4280,6 @@
    unreachable
   end
   i32.const 2752
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4615,11 +4287,6 @@
   i32.store
   local.get $0
   i32.const 2752
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4631,11 +4298,6 @@
    unreachable
   end
   i32.const 1712
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4643,11 +4305,6 @@
   i32.store
   local.get $0
   i32.const 1712
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4659,11 +4316,6 @@
    unreachable
   end
   i32.const 2784
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4671,11 +4323,6 @@
   i32.store
   local.get $0
   i32.const 2864
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4687,11 +4334,6 @@
    unreachable
   end
   i32.const 2912
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4699,11 +4341,6 @@
   i32.store
   local.get $0
   i32.const 2864
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4715,11 +4352,6 @@
    unreachable
   end
   i32.const 2992
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4727,11 +4359,6 @@
   i32.store
   local.get $0
   i32.const 2128
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4743,11 +4370,6 @@
    unreachable
   end
   i32.const 1392
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4755,11 +4377,6 @@
   i32.store
   local.get $0
   i32.const 1360
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4771,11 +4388,6 @@
    unreachable
   end
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4783,11 +4395,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4799,11 +4406,6 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4811,11 +4413,6 @@
   i32.store
   local.get $0
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4827,11 +4424,6 @@
    unreachable
   end
   i32.const 2624
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4839,11 +4431,6 @@
   i32.store
   local.get $0
   i32.const 2624
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4855,11 +4442,6 @@
    unreachable
   end
   i32.const 3120
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4867,11 +4449,6 @@
   i32.store
   local.get $0
   i32.const 3152
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4883,11 +4460,6 @@
    unreachable
   end
   i32.const 3184
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4895,11 +4467,6 @@
   i32.store
   local.get $0
   i32.const 3216
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4911,11 +4478,6 @@
    unreachable
   end
   i32.const 2752
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4923,11 +4485,6 @@
   i32.store
   local.get $0
   i32.const 2752
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4939,11 +4496,6 @@
    unreachable
   end
   i32.const 1712
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4951,11 +4503,6 @@
   i32.store
   local.get $0
   i32.const 1712
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4967,11 +4514,6 @@
    unreachable
   end
   i32.const 2784
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4979,11 +4521,6 @@
   i32.store
   local.get $0
   i32.const 2784
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -4995,11 +4532,6 @@
    unreachable
   end
   i32.const 1392
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -5007,11 +4539,6 @@
   i32.store
   local.get $0
   i32.const 1360
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5023,11 +4550,6 @@
    unreachable
   end
   i32.const 3248
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -5035,11 +4557,6 @@
   i32.store
   local.get $0
   i32.const 3248
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5051,11 +4568,6 @@
    unreachable
   end
   i32.const 3296
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -5063,11 +4575,6 @@
   i32.store
   local.get $0
   i32.const 3296
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5079,11 +4586,6 @@
    unreachable
   end
   i32.const 2992
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -5091,11 +4593,6 @@
   i32.store
   local.get $0
   i32.const 2992
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5110,7 +4607,7 @@
   global.set $~lib/memory/__stack_pointer
   call $~lib/rt/itcms/__collect
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -2946,7 +2946,7 @@
  (func $start:std/uri
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2961,11 +2961,8 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.store offset=8
+  i32.store
   memory.size
   i32.const 16
   i32.shl
@@ -2998,18 +2995,12 @@
   i32.store
   i32.const 1472
   global.set $~lib/rt/itcms/fromSpace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=8
   i32.const 1056
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   local.get $0
   i32.const 1056
   call $~lib/string/String.__eq
@@ -3022,18 +3013,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=8
   i32.const 1760
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=4
   local.get $0
   i32.const 1760
   call $~lib/string/String.__eq
@@ -3046,18 +3031,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1792
-  i32.store offset=8
   i32.const 1792
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1792
-  i32.store offset=4
   local.get $0
   i32.const 1792
   call $~lib/string/String.__eq
@@ -3070,18 +3049,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1824
-  i32.store offset=8
   i32.const 1824
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1824
-  i32.store offset=4
   local.get $0
   i32.const 1824
   call $~lib/string/String.__eq
@@ -3094,18 +3067,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=8
   i32.const 1856
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=4
   local.get $0
   i32.const 1856
   call $~lib/string/String.__eq
@@ -3118,18 +3085,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1952
-  i32.store offset=8
   i32.const 1952
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1984
-  i32.store offset=4
   local.get $0
   i32.const 1984
   call $~lib/string/String.__eq
@@ -3142,18 +3103,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2016
-  i32.store offset=8
   i32.const 2016
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2048
-  i32.store offset=4
   local.get $0
   i32.const 2048
   call $~lib/string/String.__eq
@@ -3166,18 +3121,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2080
-  i32.store offset=8
   i32.const 2080
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2112
-  i32.store offset=4
   local.get $0
   i32.const 2112
   call $~lib/string/String.__eq
@@ -3190,18 +3139,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2160
-  i32.store offset=8
   i32.const 2160
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2192
-  i32.store offset=4
   local.get $0
   i32.const 2192
   call $~lib/string/String.__eq
@@ -3214,18 +3157,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2240
-  i32.store offset=8
   i32.const 2240
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2272
-  i32.store offset=4
   local.get $0
   i32.const 2272
   call $~lib/string/String.__eq
@@ -3238,18 +3175,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2304
-  i32.store offset=8
   i32.const 2304
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2336
-  i32.store offset=4
   local.get $0
   i32.const 2336
   call $~lib/string/String.__eq
@@ -3262,18 +3193,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2384
-  i32.store offset=8
   i32.const 2384
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2416
-  i32.store offset=4
   local.get $0
   i32.const 2416
   call $~lib/string/String.__eq
@@ -3286,18 +3211,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2512
-  i32.store offset=8
   i32.const 2512
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2544
-  i32.store offset=4
   local.get $0
   i32.const 2544
   call $~lib/string/String.__eq
@@ -3310,18 +3229,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2656
-  i32.store offset=8
   i32.const 2656
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2688
-  i32.store offset=4
   local.get $0
   i32.const 2688
   call $~lib/string/String.__eq
@@ -3334,18 +3247,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2736
-  i32.store offset=8
   i32.const 2736
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2768
-  i32.store offset=4
   local.get $0
   i32.const 2768
   call $~lib/string/String.__eq
@@ -3358,18 +3265,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2816
-  i32.store offset=8
   i32.const 2816
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2848
-  i32.store offset=4
   local.get $0
   i32.const 2848
   call $~lib/string/String.__eq
@@ -3382,18 +3283,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2928
-  i32.store offset=8
   i32.const 2928
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2960
-  i32.store offset=4
   local.get $0
   i32.const 2960
   call $~lib/string/String.__eq
@@ -3406,18 +3301,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3024
-  i32.store offset=8
   i32.const 3024
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3072
-  i32.store offset=4
   local.get $0
   i32.const 3072
   call $~lib/string/String.__eq
@@ -3430,18 +3319,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3152
-  i32.store offset=8
   i32.const 3152
   call $~lib/uri/encodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3264
-  i32.store offset=4
   local.get $0
   i32.const 3264
   call $~lib/string/String.__eq
@@ -3454,18 +3337,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=8
   i32.const 1056
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   local.get $0
   i32.const 1056
   call $~lib/string/String.__eq
@@ -3478,18 +3355,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=8
   i32.const 1760
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=4
   local.get $0
   i32.const 1760
   call $~lib/string/String.__eq
@@ -3502,18 +3373,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3504
-  i32.store offset=8
   i32.const 3504
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3504
-  i32.store offset=4
   local.get $0
   i32.const 3504
   call $~lib/string/String.__eq
@@ -3526,18 +3391,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=8
   i32.const 1856
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=4
   local.get $0
   i32.const 1856
   call $~lib/string/String.__eq
@@ -3550,18 +3409,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3552
-  i32.store offset=8
   i32.const 3552
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3584
-  i32.store offset=4
   local.get $0
   i32.const 3584
   call $~lib/string/String.__eq
@@ -3574,18 +3427,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2656
-  i32.store offset=8
   i32.const 2656
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2688
-  i32.store offset=4
   local.get $0
   i32.const 2688
   call $~lib/string/String.__eq
@@ -3598,18 +3445,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2736
-  i32.store offset=8
   i32.const 2736
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2768
-  i32.store offset=4
   local.get $0
   i32.const 2768
   call $~lib/string/String.__eq
@@ -3622,18 +3463,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2928
-  i32.store offset=8
   i32.const 2928
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2960
-  i32.store offset=4
   local.get $0
   i32.const 2960
   call $~lib/string/String.__eq
@@ -3646,18 +3481,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3152
-  i32.store offset=8
   i32.const 3152
   call $~lib/uri/encodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3152
-  i32.store offset=4
   local.get $0
   i32.const 3152
   call $~lib/string/String.__eq
@@ -3670,18 +3499,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=8
   i32.const 1056
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   local.get $0
   i32.const 1056
   call $~lib/string/String.__eq
@@ -3694,18 +3517,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=8
   i32.const 1760
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=4
   local.get $0
   i32.const 1760
   call $~lib/string/String.__eq
@@ -3718,18 +3535,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3648
-  i32.store offset=8
   i32.const 3648
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3680
-  i32.store offset=4
   local.get $0
   i32.const 3680
   call $~lib/string/String.__eq
@@ -3742,18 +3553,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3712
-  i32.store offset=8
   i32.const 3712
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3744
-  i32.store offset=4
   local.get $0
   i32.const 3744
   call $~lib/string/String.__eq
@@ -3766,18 +3571,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3776
-  i32.store offset=8
   i32.const 3776
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3776
-  i32.store offset=4
   local.get $0
   i32.const 3776
   call $~lib/string/String.__eq
@@ -3790,18 +3589,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2736
-  i32.store offset=8
   i32.const 2736
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2736
-  i32.store offset=4
   local.get $0
   i32.const 2736
   call $~lib/string/String.__eq
@@ -3814,18 +3607,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3808
-  i32.store offset=8
   i32.const 3808
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3888
-  i32.store offset=4
   local.get $0
   i32.const 3888
   call $~lib/string/String.__eq
@@ -3838,18 +3625,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3936
-  i32.store offset=8
   i32.const 3936
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3888
-  i32.store offset=4
   local.get $0
   i32.const 3888
   call $~lib/string/String.__eq
@@ -3862,18 +3643,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4016
-  i32.store offset=8
   i32.const 4016
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3152
-  i32.store offset=4
   local.get $0
   i32.const 3152
   call $~lib/string/String.__eq
@@ -3886,18 +3661,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2416
-  i32.store offset=8
   i32.const 2416
   call $~lib/uri/decodeURIComponent
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2384
-  i32.store offset=4
   local.get $0
   i32.const 2384
   call $~lib/string/String.__eq
@@ -3910,18 +3679,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=8
   i32.const 1056
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   local.get $0
   i32.const 1056
   call $~lib/string/String.__eq
@@ -3934,18 +3697,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=8
   i32.const 1760
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=4
   local.get $0
   i32.const 1760
   call $~lib/string/String.__eq
@@ -3958,18 +3715,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3648
-  i32.store offset=8
   i32.const 3648
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3648
-  i32.store offset=4
   local.get $0
   i32.const 3648
   call $~lib/string/String.__eq
@@ -3982,18 +3733,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4144
-  i32.store offset=8
   i32.const 4144
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4176
-  i32.store offset=4
   local.get $0
   i32.const 4176
   call $~lib/string/String.__eq
@@ -4006,18 +3751,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4208
-  i32.store offset=8
   i32.const 4208
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4240
-  i32.store offset=4
   local.get $0
   i32.const 4240
   call $~lib/string/String.__eq
@@ -4030,18 +3769,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3776
-  i32.store offset=8
   i32.const 3776
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3776
-  i32.store offset=4
   local.get $0
   i32.const 3776
   call $~lib/string/String.__eq
@@ -4054,18 +3787,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2736
-  i32.store offset=8
   i32.const 2736
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2736
-  i32.store offset=4
   local.get $0
   i32.const 2736
   call $~lib/string/String.__eq
@@ -4078,18 +3805,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3808
-  i32.store offset=8
   i32.const 3808
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 3808
-  i32.store offset=4
   local.get $0
   i32.const 3808
   call $~lib/string/String.__eq
@@ -4102,18 +3823,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2416
-  i32.store offset=8
   i32.const 2416
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2384
-  i32.store offset=4
   local.get $0
   i32.const 2384
   call $~lib/string/String.__eq
@@ -4126,18 +3841,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4272
-  i32.store offset=8
   i32.const 4272
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4272
-  i32.store offset=4
   local.get $0
   i32.const 4272
   call $~lib/string/String.__eq
@@ -4150,18 +3859,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4320
-  i32.store offset=8
   i32.const 4320
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4320
-  i32.store offset=4
   local.get $0
   i32.const 4320
   call $~lib/string/String.__eq
@@ -4174,18 +3877,12 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4016
-  i32.store offset=8
   i32.const 4016
   call $~lib/uri/decodeURI
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4016
-  i32.store offset=4
   local.get $0
   i32.const 4016
   call $~lib/string/String.__eq
@@ -4234,7 +3931,7 @@
   i32.add
   global.set $~lib/rt/itcms/threshold
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/switch.debug.wat
+++ b/tests/compiler/switch.debug.wat
@@ -2985,16 +2985,13 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   block $case3|0
    block $case2|0
     block $case1|0
@@ -3010,11 +3007,6 @@
       i32.store offset=4
       local.get $2
       i32.const 80
-      local.set $2
-      global.get $~lib/memory/__stack_pointer
-      local.get $2
-      i32.store offset=8
-      local.get $2
       call $~lib/string/String.__eq
       br_if $case0|0
       local.get $1
@@ -3024,11 +3016,6 @@
       i32.store offset=4
       local.get $2
       i32.const 112
-      local.set $2
-      global.get $~lib/memory/__stack_pointer
-      local.get $2
-      i32.store offset=8
-      local.get $2
       call $~lib/string/String.__eq
       br_if $case1|0
       local.get $1
@@ -3038,11 +3025,6 @@
       i32.store offset=4
       local.get $2
       i32.const 144
-      local.set $2
-      global.get $~lib/memory/__stack_pointer
-      local.get $2
-      i32.store offset=8
-      local.get $2
       call $~lib/string/String.__eq
       br_if $case2|0
       br $case3|0
@@ -3050,7 +3032,7 @@
      i32.const 1
      local.set $2
      global.get $~lib/memory/__stack_pointer
-     i32.const 12
+     i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $2
@@ -3059,7 +3041,7 @@
     i32.const 2
     local.set $2
     global.get $~lib/memory/__stack_pointer
-    i32.const 12
+    i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
     local.get $2
@@ -3068,7 +3050,7 @@
    i32.const 3
    local.set $2
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $2
@@ -3077,7 +3059,7 @@
   i32.const 4
   local.set $2
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $2
@@ -3194,16 +3176,13 @@
   (local $1 i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   block $case4|0
    block $case3|0
     block $case2|0
@@ -3229,11 +3208,6 @@
        i32.store offset=4
        local.get $2
        i32.const 80
-       local.set $2
-       global.get $~lib/memory/__stack_pointer
-       local.get $2
-       i32.store offset=8
-       local.get $2
        call $~lib/string/String.__eq
        br_if $case1|0
        local.get $1
@@ -3243,11 +3217,6 @@
        i32.store offset=4
        local.get $2
        i32.const 112
-       local.set $2
-       global.get $~lib/memory/__stack_pointer
-       local.get $2
-       i32.store offset=8
-       local.get $2
        call $~lib/string/String.__eq
        br_if $case2|0
        local.get $1
@@ -3257,11 +3226,6 @@
        i32.store offset=4
        local.get $2
        i32.const 144
-       local.set $2
-       global.get $~lib/memory/__stack_pointer
-       local.get $2
-       i32.store offset=8
-       local.get $2
        call $~lib/string/String.__eq
        br_if $case3|0
        br $case4|0
@@ -3269,7 +3233,7 @@
       i32.const 0
       local.set $2
       global.get $~lib/memory/__stack_pointer
-      i32.const 12
+      i32.const 8
       i32.add
       global.set $~lib/memory/__stack_pointer
       local.get $2
@@ -3278,7 +3242,7 @@
      i32.const 1
      local.set $2
      global.get $~lib/memory/__stack_pointer
-     i32.const 12
+     i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $2
@@ -3287,7 +3251,7 @@
     i32.const 2
     local.set $2
     global.get $~lib/memory/__stack_pointer
-    i32.const 12
+    i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
     local.get $2
@@ -3296,7 +3260,7 @@
    i32.const 3
    local.set $2
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $2
@@ -3305,7 +3269,7 @@
   i32.const 4
   local.set $2
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $2
@@ -3626,14 +3590,16 @@
  (func $start:switch
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 36
+  i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.const 36
-  memory.fill
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
   i32.const 0
   call $switch/doSwitch
   i32.const 0
@@ -4025,11 +3991,6 @@
    unreachable
   end
   i32.const 80
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchString
   i32.const 1
   i32.eq
@@ -4043,11 +4004,6 @@
    unreachable
   end
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchString
   i32.const 2
   i32.eq
@@ -4061,11 +4017,6 @@
    unreachable
   end
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchString
   i32.const 3
   i32.eq
@@ -4079,11 +4030,6 @@
    unreachable
   end
   i32.const 176
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchString
   i32.const 4
   i32.eq
@@ -4114,17 +4060,7 @@
   call $~lib/rt/itcms/initLazy
   global.set $~lib/rt/itcms/fromSpace
   i32.const 208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  local.get $0
   i32.const 240
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=16
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4132,11 +4068,6 @@
   i32.store offset=4
   local.get $0
   i32.const 704
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4156,17 +4087,7 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  local.get $0
   i32.const 768
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=16
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4174,11 +4095,6 @@
   i32.store offset=4
   local.get $0
   i32.const 208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4198,41 +4114,21 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=28
-  local.get $0
   i32.const 800
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=32
-  local.get $0
-  call $~lib/string/String.__concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=20
-  local.get $0
-  i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=24
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=12
   local.get $0
-  i32.const 704
+  i32.const 832
+  call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=8
   local.get $0
+  i32.const 704
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4240,11 +4136,6 @@
   i32.store offset=4
   local.get $0
   i32.const 704
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4264,29 +4155,14 @@
    unreachable
   end
   i32.const 864
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=20
-  local.get $0
   i32.const 208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=24
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   i32.const 896
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=16
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4294,11 +4170,6 @@
   i32.store offset=4
   local.get $0
   i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4331,11 +4202,6 @@
    unreachable
   end
   i32.const 80
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchNullableString
   i32.const 1
   i32.eq
@@ -4349,11 +4215,6 @@
    unreachable
   end
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchNullableString
   i32.const 2
   i32.eq
@@ -4367,11 +4228,6 @@
    unreachable
   end
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchNullableString
   i32.const 3
   i32.eq
@@ -4385,11 +4241,6 @@
    unreachable
   end
   i32.const 176
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   call $switch/doSwitchNullableString
   i32.const 4
   i32.eq
@@ -4403,17 +4254,7 @@
    unreachable
   end
   i32.const 208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  local.get $0
   i32.const 240
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=16
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4421,11 +4262,6 @@
   i32.store offset=4
   local.get $0
   i32.const 704
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4445,17 +4281,7 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  local.get $0
   i32.const 768
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=16
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4463,11 +4289,6 @@
   i32.store offset=4
   local.get $0
   i32.const 208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4487,41 +4308,21 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=28
-  local.get $0
   i32.const 800
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=32
-  local.get $0
-  call $~lib/string/String.__concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=20
-  local.get $0
-  i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=24
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=12
   local.get $0
-  i32.const 704
+  i32.const 832
+  call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=16
+  i32.store offset=8
   local.get $0
+  i32.const 704
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4529,11 +4330,6 @@
   i32.store offset=4
   local.get $0
   i32.const 704
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4553,29 +4349,14 @@
    unreachable
   end
   i32.const 864
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=20
-  local.get $0
   i32.const 208
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=24
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
+  i32.store offset=8
   local.get $0
   i32.const 896
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=16
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -4583,11 +4364,6 @@
   i32.store offset=4
   local.get $0
   i32.const 832
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=8
-  local.get $0
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
@@ -5129,7 +4905,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 36
+  i32.const 16
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/switch.release.wat
+++ b/tests/compiler/switch.release.wat
@@ -1763,7 +1763,7 @@
  )
  (func $switch/doSwitchString (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -1781,17 +1781,11 @@
   i64.const 0
   i64.store
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1104
-  i32.store offset=8
   block $case3|0
    block $case2|0
     block $case1|0
@@ -1803,9 +1797,6 @@
       global.get $~lib/memory/__stack_pointer
       local.get $0
       i32.store offset=4
-      global.get $~lib/memory/__stack_pointer
-      i32.const 1136
-      i32.store offset=8
       local.get $0
       i32.const 1136
       call $~lib/string/String.__eq
@@ -1813,9 +1804,6 @@
       global.get $~lib/memory/__stack_pointer
       local.get $0
       i32.store offset=4
-      global.get $~lib/memory/__stack_pointer
-      i32.const 1168
-      i32.store offset=8
       local.get $0
       i32.const 1168
       call $~lib/string/String.__eq
@@ -1823,28 +1811,28 @@
       br $case3|0
      end
      global.get $~lib/memory/__stack_pointer
-     i32.const 12
+     i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 1
      return
     end
     global.get $~lib/memory/__stack_pointer
-    i32.const 12
+    i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
     i32.const 2
     return
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    i32.const 3
    return
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   i32.const 4
@@ -1954,7 +1942,7 @@
  )
  (func $switch/doSwitchNullableString (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -1971,9 +1959,6 @@
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store
@@ -1992,9 +1977,6 @@
        global.get $~lib/memory/__stack_pointer
        local.get $0
        i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 1104
-       i32.store offset=8
        local.get $0
        i32.const 1104
        call $~lib/string/String.__eq
@@ -2002,9 +1984,6 @@
        global.get $~lib/memory/__stack_pointer
        local.get $0
        i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 1136
-       i32.store offset=8
        local.get $0
        i32.const 1136
        call $~lib/string/String.__eq
@@ -2012,9 +1991,6 @@
        global.get $~lib/memory/__stack_pointer
        local.get $0
        i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 1168
-       i32.store offset=8
        local.get $0
        i32.const 1168
        call $~lib/string/String.__eq
@@ -2022,35 +1998,35 @@
        br $case4|0
       end
       global.get $~lib/memory/__stack_pointer
-      i32.const 12
+      i32.const 8
       i32.add
       global.set $~lib/memory/__stack_pointer
       i32.const 0
       return
      end
      global.get $~lib/memory/__stack_pointer
-     i32.const 12
+     i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 1
      return
     end
     global.get $~lib/memory/__stack_pointer
-    i32.const 12
+    i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
     i32.const 2
     return
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    i32.const 3
    return
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   i32.const 4
@@ -2353,7 +2329,7 @@
  (func $start:switch
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 36
+  i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -2368,12 +2344,11 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.const 36
-  memory.fill
+  i64.const 0
+  i64.store
   global.get $~lib/memory/__stack_pointer
-  i32.const 1104
-  i32.store
+  i64.const 0
+  i64.store offset=8
   i32.const 1104
   call $switch/doSwitchString
   i32.const 1
@@ -2386,9 +2361,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1136
-  i32.store
   i32.const 1136
   call $switch/doSwitchString
   i32.const 2
@@ -2401,9 +2373,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1168
-  i32.store
   i32.const 1168
   call $switch/doSwitchString
   i32.const 3
@@ -2416,9 +2385,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1200
-  i32.store
   i32.const 1200
   call $switch/doSwitchString
   i32.const 4
@@ -2463,12 +2429,6 @@
   i32.store
   i32.const 1616
   global.set $~lib/rt/itcms/fromSpace
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1232
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1264
-  i32.store offset=16
   i32.const 1232
   i32.const 1264
   call $~lib/string/String.__concat
@@ -2476,9 +2436,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1728
-  i32.store offset=8
   local.get $0
   i32.const 1728
   call $~lib/string/String.__concat
@@ -2498,12 +2455,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1792
-  i32.store offset=16
   i32.const 1760
   i32.const 1792
   call $~lib/string/String.__concat
@@ -2511,9 +2462,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1232
-  i32.store offset=8
   local.get $0
   i32.const 1232
   call $~lib/string/String.__concat
@@ -2533,32 +2481,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=28
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1824
-  i32.store offset=32
   i32.const 1760
   i32.const 1824
-  call $~lib/string/String.__concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=24
-  local.get $0
-  i32.const 1856
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=12
+  local.get $0
+  i32.const 1856
+  call $~lib/string/String.__concat
+  local.set $0
   global.get $~lib/memory/__stack_pointer
-  i32.const 1728
-  i32.store offset=16
+  local.get $0
+  i32.store offset=8
   local.get $0
   i32.const 1728
   call $~lib/string/String.__concat
@@ -2566,9 +2502,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1728
-  i32.store offset=8
   local.get $0
   i32.const 1728
   call $~lib/string/String.__concat
@@ -2588,22 +2521,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1888
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1232
-  i32.store offset=24
   i32.const 1888
   i32.const 1232
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1920
-  i32.store offset=16
+  i32.store offset=8
   local.get $0
   i32.const 1920
   call $~lib/string/String.__concat
@@ -2611,9 +2535,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=8
   local.get $0
   i32.const 1856
   call $~lib/string/String.__concat
@@ -2643,9 +2564,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1104
-  i32.store
   i32.const 1104
   call $switch/doSwitchNullableString
   i32.const 1
@@ -2658,9 +2576,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1136
-  i32.store
   i32.const 1136
   call $switch/doSwitchNullableString
   i32.const 2
@@ -2673,9 +2588,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1168
-  i32.store
   i32.const 1168
   call $switch/doSwitchNullableString
   i32.const 3
@@ -2688,9 +2600,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1200
-  i32.store
   i32.const 1200
   call $switch/doSwitchNullableString
   i32.const 4
@@ -2703,12 +2612,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1232
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1264
-  i32.store offset=16
   i32.const 1232
   i32.const 1264
   call $~lib/string/String.__concat
@@ -2716,9 +2619,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1728
-  i32.store offset=8
   local.get $0
   i32.const 1728
   call $~lib/string/String.__concat
@@ -2738,12 +2638,6 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1792
-  i32.store offset=16
   i32.const 1760
   i32.const 1792
   call $~lib/string/String.__concat
@@ -2751,9 +2645,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1232
-  i32.store offset=8
   local.get $0
   i32.const 1232
   call $~lib/string/String.__concat
@@ -2773,32 +2664,20 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1760
-  i32.store offset=28
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1824
-  i32.store offset=32
   i32.const 1760
   i32.const 1824
-  call $~lib/string/String.__concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=24
-  local.get $0
-  i32.const 1856
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=12
+  local.get $0
+  i32.const 1856
+  call $~lib/string/String.__concat
+  local.set $0
   global.get $~lib/memory/__stack_pointer
-  i32.const 1728
-  i32.store offset=16
+  local.get $0
+  i32.store offset=8
   local.get $0
   i32.const 1728
   call $~lib/string/String.__concat
@@ -2806,9 +2685,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1728
-  i32.store offset=8
   local.get $0
   i32.const 1728
   call $~lib/string/String.__concat
@@ -2828,22 +2704,13 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1888
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1232
-  i32.store offset=24
   i32.const 1888
   i32.const 1232
   call $~lib/string/String.__concat
   local.set $0
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1920
-  i32.store offset=16
+  i32.store offset=8
   local.get $0
   i32.const 1920
   call $~lib/string/String.__concat
@@ -2851,9 +2718,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1856
-  i32.store offset=8
   local.get $0
   i32.const 1856
   call $~lib/string/String.__concat
@@ -3048,7 +2912,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 36
+  i32.const 16
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -4975,13 +4975,13 @@
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 32
+  i32.const 28
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 32
+  i32.const 28
   memory.fill
   global.get $~lib/memory/__stack_pointer
   i32.const 32
@@ -4998,11 +4998,6 @@
   i32.store offset=8
   local.get $4
   i32.const 32
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5017,13 +5012,13 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   local.get $b
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=20
+  i32.store offset=16
   local.get $4
   call $~lib/string/String#concat
   local.set $4
@@ -5032,11 +5027,6 @@
   i32.store offset=8
   local.get $4
   i32.const 592
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5050,51 +5040,46 @@
   global.get $~lib/memory/__stack_pointer
   local.get $a
   local.tee $2
-  i32.store offset=24
+  i32.store offset=20
   global.get $~lib/memory/__stack_pointer
   local.get $b
   local.tee $3
-  i32.store offset=28
+  i32.store offset=24
   i32.const 720
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 1
   local.get $2
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=20
+  i32.store offset=16
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 720
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 3
   local.get $3
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=20
+  i32.store offset=16
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 720
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 160
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=20
-  local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -5102,11 +5087,6 @@
   i32.store offset=8
   local.get $4
   i32.const 768
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5118,7 +5098,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 32
+  i32.const 28
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -5129,13 +5109,13 @@
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 24
+  i32.const 20
   memory.fill
   i32.const 1
   local.set $a
@@ -5150,11 +5130,6 @@
   i32.store
   local.get $4
   i32.const 2592
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5171,7 +5146,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   local.get $b
   i32.const 10
@@ -5179,7 +5154,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=12
+  i32.store offset=8
   local.get $4
   call $~lib/string/String#concat
   local.set $4
@@ -5188,11 +5163,6 @@
   i32.store
   local.get $4
   i32.const 2624
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5208,53 +5178,48 @@
   i32.const 10
   call $~lib/number/I32#toString
   local.tee $2
-  i32.store offset=16
+  i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   local.get $b
   i32.const 10
   call $~lib/number/I32#toString
   local.tee $3
-  i32.store offset=20
+  i32.store offset=16
   i32.const 2656
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 1
   local.get $2
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=12
+  i32.store offset=8
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2656
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 3
   local.get $3
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=12
+  i32.store offset=8
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 2656
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 160
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -5262,11 +5227,6 @@
   i32.store
   local.get $4
   i32.const 2704
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5278,7 +5238,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -5289,13 +5249,13 @@
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 24
+  i32.const 20
   memory.fill
   f64.const 1
   local.set $a
@@ -5310,11 +5270,6 @@
   i32.store
   local.get $4
   i32.const 3888
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5331,7 +5286,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   local.get $b
   i32.const 0
@@ -5339,7 +5294,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=12
+  i32.store offset=8
   local.get $4
   call $~lib/string/String#concat
   local.set $4
@@ -5348,11 +5303,6 @@
   i32.store
   local.get $4
   i32.const 3920
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5368,53 +5318,48 @@
   i32.const 0
   call $~lib/number/F64#toString
   local.tee $2
-  i32.store offset=16
+  i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   local.get $b
   i32.const 0
   call $~lib/number/F64#toString
   local.tee $3
-  i32.store offset=20
+  i32.store offset=16
   i32.const 3952
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 1
   local.get $2
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=12
+  i32.store offset=8
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 3952
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 3
   local.get $3
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=12
+  i32.store offset=8
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 3952
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=8
+  i32.store offset=4
   local.get $4
   i32.const 160
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -5422,11 +5367,6 @@
   i32.store
   local.get $4
   i32.const 4000
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5438,7 +5378,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -5447,14 +5387,16 @@
   (local $b i32)
   (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.const 20
-  memory.fill
+  i64.const 0
+  i64.store
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store offset=8
   i32.const 2
   local.set $a
   global.get $~lib/memory/__stack_pointer
@@ -5470,11 +5412,6 @@
   i32.store offset=4
   local.get $2
   i32.const 4048
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=8
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5492,11 +5429,6 @@
   i32.store offset=4
   local.get $2
   i32.const 64
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=8
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5508,18 +5440,13 @@
    unreachable
   end
   i32.const 4080
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   local.get $a
   i32.const 10
   call $~lib/number/I32#toString
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=16
+  i32.store offset=8
   local.get $2
   call $~lib/string/String#concat
   local.set $2
@@ -5528,11 +5455,6 @@
   i32.store offset=4
   local.get $2
   i32.const 4112
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=8
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5544,16 +5466,11 @@
    unreachable
   end
   i32.const 4080
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=12
-  local.get $2
   local.get $b
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=16
+  i32.store offset=8
   local.get $2
   call $~lib/string/String#concat
   local.set $2
@@ -5562,11 +5479,6 @@
   i32.store offset=4
   local.get $2
   i32.const 4144
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=8
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5583,14 +5495,9 @@
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=12
+  i32.store offset=8
   local.get $2
   i32.const 4176
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=16
-  local.get $2
   call $~lib/string/String#concat
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -5598,11 +5505,6 @@
   i32.store offset=4
   local.get $2
   i32.const 4208
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=8
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5617,14 +5519,9 @@
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=12
+  i32.store offset=8
   local.get $2
   i32.const 4176
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=16
-  local.get $2
   call $~lib/string/String#concat
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -5632,11 +5529,6 @@
   i32.store offset=4
   local.get $2
   i32.const 4240
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=8
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5653,13 +5545,13 @@
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=12
+  i32.store offset=8
   local.get $2
   local.get $b
   local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $2
-  i32.store offset=16
+  i32.store offset=12
   local.get $2
   call $~lib/string/String#concat
   local.set $2
@@ -5668,11 +5560,6 @@
   i32.store offset=4
   local.get $2
   i32.const 4272
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=8
-  local.get $2
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5684,7 +5571,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 20
+  i32.const 16
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -5758,27 +5645,19 @@
  (func $templateliteral/Ref#toString (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i64.const 0
   i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
   i32.const 4304
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=8
+  i32.store offset=4
   local.get $1
   call $templateliteral/Ref#get:value
   i32.const 10
@@ -5786,12 +5665,12 @@
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store
   local.get $1
   call $~lib/string/String.__concat
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $1
@@ -5804,13 +5683,13 @@
   (local $3 i32)
   (local $4 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 36
+  i32.const 32
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 36
+  i32.const 32
   memory.fill
   global.get $~lib/memory/__stack_pointer
   i32.const 0
@@ -5828,7 +5707,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   call $templateliteral/Ref#toString
   local.set $4
@@ -5837,11 +5716,6 @@
   i32.store offset=8
   local.get $4
   i32.const 4336
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5856,25 +5730,25 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=24
+  i32.store offset=20
+  local.get $4
+  call $templateliteral/Ref#toString
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.store offset=12
+  local.get $4
+  local.get $b
+  local.set $4
+  global.get $~lib/memory/__stack_pointer
+  local.get $4
+  i32.store offset=20
   local.get $4
   call $templateliteral/Ref#toString
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
   i32.store offset=16
-  local.get $4
-  local.get $b
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=24
-  local.get $4
-  call $templateliteral/Ref#toString
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=20
   local.get $4
   call $~lib/string/String#concat
   local.set $4
@@ -5883,11 +5757,6 @@
   i32.store offset=8
   local.get $4
   i32.const 4368
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5903,61 +5772,56 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   call $templateliteral/Ref#toString
   local.tee $2
-  i32.store offset=28
+  i32.store offset=24
   global.get $~lib/memory/__stack_pointer
   local.get $b
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   call $templateliteral/Ref#toString
   local.tee $3
-  i32.store offset=32
+  i32.store offset=28
   i32.const 4416
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 1
   local.get $2
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=20
+  i32.store offset=16
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4416
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 3
   local.get $3
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=20
+  i32.store offset=16
   local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4416
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=16
+  i32.store offset=12
   local.get $4
   i32.const 160
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=20
-  local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -5965,11 +5829,6 @@
   i32.store offset=8
   local.get $4
   i32.const 4464
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=12
-  local.get $4
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -5981,7 +5840,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 36
+  i32.const 32
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -5993,13 +5852,13 @@
   (local $4 i32)
   (local $5 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 32
+  i32.const 28
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 32
+  i32.const 28
   memory.fill
   global.get $~lib/memory/__stack_pointer
   i32.const 0
@@ -6014,70 +5873,65 @@
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=12
+  i32.store offset=8
   local.get $5
   call $templateliteral/Ref#toString
   local.tee $2
-  i32.store offset=16
+  i32.store offset=12
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
   local.get $d
   local.tee $4
-  i32.store offset=20
+  i32.store offset=16
   local.get $4
   if (result i32)
    local.get $4
    local.set $5
    global.get $~lib/memory/__stack_pointer
    local.get $5
-   i32.store offset=12
+   i32.store offset=8
    local.get $5
    call $templateliteral/Ref#toString
   else
    i32.const 4640
   end
   local.tee $3
-  i32.store offset=24
+  i32.store offset=20
   i32.const 4592
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=12
+  i32.store offset=8
   local.get $5
   i32.const 1
   local.get $2
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=28
+  i32.store offset=24
   local.get $5
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4592
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=12
+  i32.store offset=8
   local.get $5
   i32.const 3
   local.get $3
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=28
+  i32.store offset=24
   local.get $5
   call $~lib/staticarray/StaticArray<~lib/string/String>#__uset
   i32.const 4592
   local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $5
-  i32.store offset=12
+  i32.store offset=8
   local.get $5
   i32.const 160
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=28
-  local.get $5
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $5
   global.get $~lib/memory/__stack_pointer
@@ -6085,11 +5939,6 @@
   i32.store offset=4
   local.get $5
   i32.const 4672
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=8
-  local.get $5
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6101,7 +5950,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 32
+  i32.const 28
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -6259,11 +6108,6 @@
   i32.store
   local.get $4
   i32.const 160
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=16
-  local.get $4
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   local.set $4
   global.get $~lib/memory/__stack_pointer
@@ -6279,78 +6123,58 @@
   (local $a i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 24
+  i32.const 20
   memory.fill
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 4736
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
   i32.const 0
   call $templateliteral/RecursiveObject#constructor
   local.tee $c
-  i32.store offset=4
+  i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 64
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
   local.get $c
   local.set $3
   global.get $~lib/memory/__stack_pointer
   local.get $3
-  i32.store offset=8
+  i32.store offset=4
   local.get $3
   call $templateliteral/RecursiveObject#constructor
   local.tee $b
-  i32.store offset=12
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.const 32
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
   local.get $b
   local.set $3
   global.get $~lib/memory/__stack_pointer
   local.get $3
-  i32.store offset=8
+  i32.store offset=4
   local.get $3
   call $templateliteral/RecursiveObject#constructor
   local.tee $a
-  i32.store offset=16
+  i32.store offset=12
   local.get $a
   local.set $3
   global.get $~lib/memory/__stack_pointer
   local.get $3
-  i32.store offset=20
+  i32.store offset=16
   local.get $3
   call $templateliteral/RecursiveObject#toString
   local.set $3
   global.get $~lib/memory/__stack_pointer
   local.get $3
-  i32.store
+  i32.store offset=4
   local.get $3
   i32.const 4832
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=8
-  local.get $3
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -6362,7 +6186,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 24
+  i32.const 20
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -1,7 +1,7 @@
 (module
  (type $0 (func (param i32 i32) (result i32)))
- (type $1 (func))
- (type $2 (func (param i32) (result i32)))
+ (type $1 (func (param i32) (result i32)))
+ (type $2 (func))
  (type $3 (func (param i32)))
  (type $4 (func (param i32 i32)))
  (type $5 (func (param i32 i32 i32)))
@@ -212,7 +212,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$164
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$165
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -236,7 +236,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$164
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$165
    end
    local.get $0
    i32.load offset=8
@@ -3057,7 +3057,7 @@
   i32.const 1504
   global.set $~lib/rt/itcms/fromSpace
   global.get $~lib/memory/__stack_pointer
-  i32.const 32
+  i32.const 28
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner1
@@ -3067,7 +3067,7 @@
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 32
+   i32.const 28
    memory.fill
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
@@ -3078,9 +3078,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=12
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -3095,10 +3092,10 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 1088
-   i32.store offset=20
+   i32.store offset=16
    i32.const 1056
    i32.const 1088
    call $~lib/string/String#concat
@@ -3106,9 +3103,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1616
-   i32.store offset=12
    local.get $0
    i32.const 1616
    call $~lib/string/String.__eq
@@ -3123,16 +3117,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
-   i32.store offset=24
+   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 1088
-   i32.store offset=28
+   i32.store offset=24
    global.get $~lib/memory/__stack_pointer
    i32.const 1744
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
-   i32.store offset=20
+   i32.store offset=16
    i32.const 1748
    i32.const 1056
    i32.store
@@ -3142,10 +3136,10 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 1744
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 1088
-   i32.store offset=20
+   i32.store offset=16
    i32.const 1756
    i32.const 1088
    i32.store
@@ -3155,19 +3149,13 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 1744
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1184
-   i32.store offset=20
+   i32.store offset=12
    i32.const 1744
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1792
-   i32.store offset=12
    local.get $0
    i32.const 1792
    call $~lib/string/String.__eq
@@ -3181,11 +3169,11 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 32
+   i32.const 28
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -3194,7 +3182,7 @@
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 24
+   i32.const 20
    memory.fill
    i32.const 1
    call $~lib/number/I32#toString
@@ -3202,9 +3190,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3616
-   i32.store offset=4
    local.get $0
    i32.const 3616
    call $~lib/string/String.__eq
@@ -3222,13 +3207,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    i32.const 2
    call $~lib/number/I32#toString
    local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=12
+   i32.store offset=8
    local.get $0
    local.get $1
    call $~lib/string/String#concat
@@ -3236,9 +3221,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3648
-   i32.store offset=4
    local.get $0
    i32.const 3648
    call $~lib/string/String.__eq
@@ -3255,18 +3237,18 @@
    i32.const 1
    call $~lib/number/I32#toString
    local.tee $0
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 2
    call $~lib/number/I32#toString
    local.tee $1
-   i32.store offset=20
+   i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    i32.const 3680
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=12
+   i32.store offset=8
    i32.const 3684
    local.get $0
    i32.store
@@ -3276,10 +3258,10 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 3680
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=12
+   i32.store offset=8
    i32.const 3692
    local.get $1
    i32.store
@@ -3289,19 +3271,13 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 3680
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1184
-   i32.store offset=12
+   i32.store offset=4
    i32.const 3680
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 3728
-   i32.store offset=4
    local.get $0
    i32.const 3728
    call $~lib/string/String.__eq
@@ -3315,11 +3291,11 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -3328,7 +3304,7 @@
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 24
+   i32.const 20
    memory.fill
    f64.const 1
    call $~lib/number/F64#toString
@@ -3336,9 +3312,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4912
-   i32.store offset=4
    local.get $0
    i32.const 4912
    call $~lib/string/String.__eq
@@ -3356,13 +3329,13 @@
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    f64.const 2
    call $~lib/number/F64#toString
    local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=12
+   i32.store offset=8
    local.get $0
    local.get $1
    call $~lib/string/String#concat
@@ -3370,9 +3343,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4944
-   i32.store offset=4
    local.get $0
    i32.const 4944
    call $~lib/string/String.__eq
@@ -3389,18 +3359,18 @@
    f64.const 1
    call $~lib/number/F64#toString
    local.tee $0
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    f64.const 2
    call $~lib/number/F64#toString
    local.tee $1
-   i32.store offset=20
+   i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    i32.const 4976
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=12
+   i32.store offset=8
    i32.const 4980
    local.get $0
    i32.store
@@ -3410,10 +3380,10 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 4976
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=12
+   i32.store offset=8
    i32.const 4988
    local.get $1
    i32.store
@@ -3423,19 +3393,13 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 4976
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1184
-   i32.store offset=12
+   i32.store offset=4
    i32.const 4976
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5024
-   i32.store offset=4
    local.get $0
    i32.const 5024
    call $~lib/string/String.__eq
@@ -3449,12 +3413,187 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.add
    global.set $~lib/memory/__stack_pointer
-   call $templateliteral/test_fast_paths_string
    global.get $~lib/memory/__stack_pointer
-   i32.const 36
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 5904
+   i32.lt_s
+   br_if $folding-inner1
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1088
+   i32.store
+   i32.const 2
+   call $~lib/number/I32#toString
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   i32.const 5072
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 31
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1088
+   i32.store offset=4
+   i32.const 1088
+   i32.const 1088
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 32
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 2
+   call $~lib/number/I32#toString
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 5104
+   local.get $0
+   call $~lib/string/String#concat
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   i32.const 5136
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 33
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1088
+   i32.store offset=8
+   i32.const 5104
+   i32.const 1088
+   call $~lib/string/String#concat
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   i32.const 5168
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 34
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 2
+   call $~lib/number/I32#toString
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.const 5200
+   call $~lib/string/String#concat
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   i32.const 5232
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 35
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1088
+   i32.store offset=8
+   i32.const 1088
+   i32.const 5200
+   call $~lib/string/String#concat
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   i32.const 5264
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 36
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   i32.const 2
+   call $~lib/number/I32#toString
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1088
+   i32.store offset=12
+   local.get $0
+   i32.const 1088
+   call $~lib/string/String#concat
+   local.set $0
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   i32.const 5296
+   call $~lib/string/String.__eq
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 37
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 32
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -3463,7 +3602,7 @@
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 36
+   i32.const 32
    memory.fill
    global.get $~lib/memory/__stack_pointer
    i32.const 1
@@ -3477,16 +3616,13 @@
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=16
+   i32.store offset=12
    local.get $2
    call $templateliteral/Ref#toString
    local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5360
-   i32.store offset=12
    local.get $1
    i32.const 5360
    call $~lib/string/String.__eq
@@ -3501,22 +3637,22 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=24
+   i32.store offset=20
    local.get $2
    call $templateliteral/Ref#toString
    local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=24
+   i32.store offset=20
    local.get $0
    call $templateliteral/Ref#toString
    local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $3
-   i32.store offset=20
+   i32.store offset=16
    local.get $1
    local.get $3
    call $~lib/string/String#concat
@@ -3524,9 +3660,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5392
-   i32.store offset=12
    local.get $1
    i32.const 5392
    call $~lib/string/String.__eq
@@ -3541,26 +3674,26 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    local.get $2
    call $templateliteral/Ref#toString
    local.tee $1
-   i32.store offset=28
+   i32.store offset=24
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    local.get $0
    call $templateliteral/Ref#toString
    local.tee $0
-   i32.store offset=32
+   i32.store offset=28
    global.get $~lib/memory/__stack_pointer
    i32.const 5440
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    local.get $1
-   i32.store offset=20
+   i32.store offset=16
    i32.const 5444
    local.get $1
    i32.store
@@ -3570,10 +3703,10 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 5440
-   i32.store offset=16
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=20
+   i32.store offset=16
    i32.const 5452
    local.get $0
    i32.store
@@ -3583,19 +3716,13 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 5440
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1184
-   i32.store offset=20
+   i32.store offset=12
    i32.const 5440
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5488
-   i32.store offset=12
    local.get $0
    i32.const 5488
    call $~lib/string/String.__eq
@@ -3609,11 +3736,11 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 36
+   i32.const 32
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 32
+   i32.const 28
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -3622,7 +3749,7 @@
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 32
+   i32.const 28
    memory.fill
    global.get $~lib/memory/__stack_pointer
    i32.const 3
@@ -3631,24 +3758,24 @@
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=12
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $0
    call $templateliteral/Ref#toString
    local.tee $0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=20
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5664
-   i32.store offset=24
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5616
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store offset=16
+   global.get $~lib/memory/__stack_pointer
+   i32.const 5664
+   i32.store offset=20
+   global.get $~lib/memory/__stack_pointer
+   i32.const 5616
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=28
+   i32.store offset=24
    i32.const 5620
    local.get $0
    i32.store
@@ -3658,10 +3785,10 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 5616
-   i32.store offset=12
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 5664
-   i32.store offset=28
+   i32.store offset=24
    i32.const 5628
    i32.const 5664
    i32.store
@@ -3671,19 +3798,13 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 5616
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1184
-   i32.store offset=28
+   i32.store offset=8
    i32.const 5616
    call $~lib/staticarray/StaticArray<~lib/string/String>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5696
-   i32.store offset=8
    local.get $0
    i32.const 5696
    call $~lib/string/String.__eq
@@ -3697,11 +3818,11 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 32
+   i32.const 28
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -3710,53 +3831,41 @@
    br_if $folding-inner1
    global.get $~lib/memory/__stack_pointer
    i32.const 0
-   i32.const 24
+   i32.const 20
    memory.fill
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5760
-   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 5760
    i32.const 0
    call $templateliteral/RecursiveObject#constructor
    local.tee $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1088
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 1088
+   local.get $0
+   call $templateliteral/RecursiveObject#constructor
+   local.tee $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1056
    local.get $0
    call $templateliteral/RecursiveObject#constructor
    local.tee $0
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   local.get $0
-   call $templateliteral/RecursiveObject#constructor
-   local.tee $0
    i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=20
    local.get $0
    call $templateliteral/RecursiveObject#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5856
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.const 5856
    call $~lib/string/String.__eq
@@ -3770,7 +3879,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 24
+   i32.const 20
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
@@ -3972,7 +4081,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$90
+   block $__inlined_func$~lib/util/string/compareImpl$91
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -3992,7 +4101,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$90
+      br_if $__inlined_func$~lib/util/string/compareImpl$91
       local.get $2
       i32.const 2
       i32.add
@@ -4354,223 +4463,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $templateliteral/test_fast_paths_string
-  (local $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 20
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5904
-  i32.lt_s
-  if
-   i32.const 38704
-   i32.const 38752
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.const 20
-  memory.fill
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1088
-  i32.store
-  i32.const 2
-  call $~lib/number/I32#toString
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5072
-  i32.store offset=8
-  local.get $0
-  i32.const 5072
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 31
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1088
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1088
-  i32.store offset=8
-  i32.const 1088
-  i32.const 1088
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 32
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5104
-  i32.store offset=12
-  i32.const 2
-  call $~lib/number/I32#toString
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=16
-  i32.const 5104
-  local.get $0
-  call $~lib/string/String#concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5136
-  i32.store offset=8
-  local.get $0
-  i32.const 5136
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 33
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5104
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1088
-  i32.store offset=16
-  i32.const 5104
-  i32.const 1088
-  call $~lib/string/String#concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5168
-  i32.store offset=8
-  local.get $0
-  i32.const 5168
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 34
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 2
-  call $~lib/number/I32#toString
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5200
-  i32.store offset=16
-  local.get $0
-  i32.const 5200
-  call $~lib/string/String#concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5232
-  i32.store offset=8
-  local.get $0
-  i32.const 5232
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 35
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1088
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5200
-  i32.store offset=16
-  i32.const 1088
-  i32.const 5200
-  call $~lib/string/String#concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5264
-  i32.store offset=8
-  local.get $0
-  i32.const 5264
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 36
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  i32.const 2
-  call $~lib/number/I32#toString
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1088
-  i32.store offset=16
-  local.get $0
-  i32.const 1088
-  call $~lib/string/String#concat
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5296
-  i32.store offset=8
-  local.get $0
-  i32.const 5296
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1120
-   i32.const 37
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 20
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
  (func $templateliteral/Ref#constructor (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -4611,7 +4503,7 @@
  )
  (func $templateliteral/Ref#toString (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -4623,21 +4515,15 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 5328
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
    local.get $0
    i32.load
    call $~lib/number/I32#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -4663,7 +4549,7 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 12
+   i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    return
@@ -4824,9 +4710,6 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 5824
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1184
-  i32.store offset=16
   i32.const 5824
   call $~lib/staticarray/StaticArray<~lib/string/String>#join
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/typealias.debug.wat
+++ b/tests/compiler/typealias.debug.wat
@@ -140,6 +140,64 @@
   i32.const 0
   return
  )
+ (func $typealias/outer_function~inner_function
+  (local $alias f64)
+  f64.const 1
+  local.set $alias
+  i32.const 112
+  i32.const 112
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 17
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $typealias/outer_function
+  (local $alias i64)
+  (local $inner_function i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  i64.const 1
+  local.set $alias
+  i32.const 32
+  i32.const 32
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 64
+   i32.const 13
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 144
+  local.tee $inner_function
+  i32.store
+  local.get $inner_function
+  drop
+  i32.const 0
+  global.set $~argumentsLength
+  local.get $inner_function
+  i32.load
+  call_indirect (type $0)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
  (func $typealias/generic_type_alias
   i32.const 5
   i32.const 5
@@ -272,100 +330,5 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
   return
- )
- (func $typealias/outer_function~inner_function
-  (local $alias f64)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  f64.const 1
-  local.set $alias
-  i32.const 112
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 112
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 17
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
- )
- (func $typealias/outer_function
-  (local $alias i64)
-  (local $inner_function i32)
-  (local $2 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store offset=8
-  i64.const 1
-  local.set $alias
-  i32.const 32
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store
-  local.get $2
-  i32.const 32
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 64
-   i32.const 13
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 144
-  local.tee $inner_function
-  i32.store offset=8
-  local.get $inner_function
-  drop
-  i32.const 0
-  global.set $~argumentsLength
-  local.get $inner_function
-  i32.load
-  call_indirect (type $0)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
 )

--- a/tests/compiler/typealias.release.wat
+++ b/tests/compiler/typealias.release.wat
@@ -19,12 +19,26 @@
  (export "alias" (func $typealias/alias))
  (export "memory" (memory $0))
  (start $~start)
+ (func $typealias/outer_function~inner_function
+  i32.const 1136
+  i32.const 1136
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1088
+   i32.const 17
+   i32.const 5
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
  (func $typealias/alias (param $0 i32) (result i32)
   local.get $0
  )
  (func $~start
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -39,17 +53,8 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1056
-  i32.store offset=4
   i32.const 1056
   i32.const 1056
   call $~lib/string/String.__eq
@@ -64,12 +69,12 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 1168
-  i32.store offset=8
+  i32.store
   i32.const 1168
   i32.load
   call_indirect (type $0)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
@@ -234,47 +239,5 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   i32.const 0
- )
- (func $typealias/outer_function~inner_function
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1180
-  i32.lt_s
-  if
-   i32.const 33968
-   i32.const 34016
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1136
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  i32.const 1136
-  i32.store offset=4
-  i32.const 1136
-  i32.const 1136
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1088
-   i32.const 17
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
 )

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -2621,27 +2621,17 @@
  (func $start:typeof
   (local $0 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   i32.const 1
   drop
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2653,17 +2643,7 @@
    unreachable
   end
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2675,17 +2655,7 @@
    unreachable
   end
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2697,17 +2667,7 @@
    unreachable
   end
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2719,17 +2679,7 @@
    unreachable
   end
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2741,17 +2691,7 @@
    unreachable
   end
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2765,17 +2705,7 @@
   i32.const 1
   drop
   i32.const 192
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 192
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2787,17 +2717,7 @@
    unreachable
   end
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2811,17 +2731,7 @@
   i32.const 1
   drop
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2835,17 +2745,7 @@
   f64.const 1
   drop
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2859,17 +2759,7 @@
   i64.const 1
   drop
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2883,17 +2773,7 @@
   i32.const 240
   drop
   i32.const 272
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 272
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2913,11 +2793,6 @@
   i32.store
   local.get $0
   i32.const 192
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2937,11 +2812,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2961,11 +2831,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -2985,11 +2850,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3009,11 +2869,6 @@
   i32.store
   local.get $0
   i32.const 32
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3033,11 +2888,6 @@
   i32.store
   local.get $0
   i32.const 272
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3057,11 +2907,6 @@
   i32.store
   local.get $0
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3101,11 +2946,6 @@
   i32.store
   local.get $0
   i32.const 112
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3117,17 +2957,7 @@
    unreachable
   end
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 144
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3139,17 +2969,7 @@
    unreachable
   end
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3169,11 +2989,6 @@
   i32.store
   local.get $0
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3193,11 +3008,6 @@
   i32.store
   local.get $0
   i32.const 736
-  local.set $0
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -3209,7 +3019,7 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -1629,7 +1629,7 @@
   (local $0 i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   block $folding-inner0
@@ -1638,14 +1638,8 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
+   i32.const 0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1658,12 +1652,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store offset=4
    i32.const 1136
    i32.const 1136
    call $~lib/string/String.__eq
@@ -1676,12 +1664,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store offset=4
    i32.const 1136
    i32.const 1136
    call $~lib/string/String.__eq
@@ -1694,12 +1676,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store offset=4
    i32.const 1136
    i32.const 1136
    call $~lib/string/String.__eq
@@ -1712,12 +1688,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store offset=4
    i32.const 1168
    i32.const 1168
    call $~lib/string/String.__eq
@@ -1730,12 +1700,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store offset=4
    i32.const 1168
    i32.const 1168
    call $~lib/string/String.__eq
@@ -1748,12 +1712,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1216
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1216
-   i32.store offset=4
    i32.const 1216
    i32.const 1216
    call $~lib/string/String.__eq
@@ -1766,12 +1724,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store offset=4
    i32.const 1136
    i32.const 1136
    call $~lib/string/String.__eq
@@ -1784,12 +1736,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1802,12 +1748,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1820,12 +1760,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1838,12 +1772,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1296
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1296
-   i32.store offset=4
    i32.const 1296
    i32.const 1296
    call $~lib/string/String.__eq
@@ -1859,9 +1787,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1216
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1216
-   i32.store offset=4
    i32.const 1216
    i32.const 1216
    call $~lib/string/String.__eq
@@ -1877,9 +1802,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1895,9 +1817,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1913,9 +1832,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1931,9 +1847,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1056
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1056
-   i32.store offset=4
    i32.const 1056
    i32.const 1056
    call $~lib/string/String.__eq
@@ -1949,9 +1862,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1296
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1296
-   i32.store offset=4
    i32.const 1296
    i32.const 1296
    call $~lib/string/String.__eq
@@ -1967,9 +1877,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1168
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store offset=4
    i32.const 1168
    i32.const 1168
    call $~lib/string/String.__eq
@@ -2069,9 +1976,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1136
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1136
-   i32.store offset=4
    i32.const 1136
    i32.const 1136
    call $~lib/string/String.__eq
@@ -2084,12 +1988,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1168
-   i32.store offset=4
    i32.const 1168
    i32.const 1168
    call $~lib/string/String.__eq
@@ -2102,12 +2000,6 @@
     call $~lib/builtins/abort
     unreachable
    end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1760
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1760
-   i32.store offset=4
    i32.const 1760
    i32.const 1760
    call $~lib/string/String.__eq
@@ -2123,9 +2015,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1760
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1760
-   i32.store offset=4
    i32.const 1760
    i32.const 1760
    call $~lib/string/String.__eq
@@ -2141,9 +2030,6 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1760
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1760
-   i32.store offset=4
    i32.const 1760
    i32.const 1760
    call $~lib/string/String.__eq
@@ -2157,7 +2043,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    return


### PR DESCRIPTION
String literals are widely used static data, and our GC algorithm does not recycle them (see https://github.com/AssemblyScript/assemblyscript/blob/7e2a62d9615d2ae02b593af87ee4920a3c57b0bd/std/assembly/rt/itcms.ts#L244). Recording the addresses of all string literals and preventing the emission of tostack code can effectively improve performance