### PR TITLE
chore: refactor unary postfix code emitter to reduce nested tostack

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -48,7 +48,6 @@ import {
   getBlockChildCount,
   getBlockChildAt,
   getBlockName,
-  getLocalSetValue,
   getGlobalGetName,
   isGlobalMutable,
   getSideEffects,
@@ -9231,11 +9230,12 @@ export class Compiler extends DiagnosticEmitter {
     let flow = this.currentFlow;
 
     // make a getter for the expression (also obtains the type)
-    let getValue = this.compileExpression( // reports
+    const getValueOrigin = this.compileExpression( // reports
       expression.operand,
       contextualType.exceptVoid,
       Constraints.None
     );
+    let getValue: ExpressionRef;
 
     // if the value isn't dropped, a temp. local is required to remember the original value,
     // except if a static overload is found, which reverses the use of a temp. (see below)
@@ -9244,16 +9244,17 @@ export class Compiler extends DiagnosticEmitter {
       tempLocal = flow.getTempLocal(this.currentType);
       getValue = module.local_tee(
         tempLocal.index,
-        getValue,
+        getValueOrigin,
         this.currentType.isManaged
       );
+    } else {
+      getValue = getValueOrigin;
     }
 
     let expr: ExpressionRef;
 
     switch (expression.operator) {
       case Token.Plus_Plus: {
-
         // check operator overload
         let classReference = this.currentType.getClassOrWrapper(this.program);
         if (classReference) {
@@ -9261,7 +9262,7 @@ export class Compiler extends DiagnosticEmitter {
           if (overload) {
             let isInstance = overload.is(CommonFlags.Instance);
             if (tempLocal && !isInstance) { // revert: static overload simply returns
-              getValue = getLocalSetValue(getValue);
+              getValue = getValueOrigin;
               tempLocal = null;
             }
             expr = this.compileUnaryOverload(overload, expression.operand, getValue, expression);
@@ -9337,7 +9338,6 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       case Token.Minus_Minus: {
-
         // check operator overload
         let classReference = this.currentType.getClassOrWrapper(this.program);
         if (classReference) {
@@ -9345,11 +9345,11 @@ export class Compiler extends DiagnosticEmitter {
           if (overload) {
             let isInstance = overload.is(CommonFlags.Instance);
             if (tempLocal && !isInstance) { // revert: static overload simply returns
-              getValue = getLocalSetValue(getValue);
+              getValue = getValueOrigin;
               tempLocal = null;
             }
             expr = this.compileUnaryOverload(overload, expression.operand, getValue, expression);
-            if (overload.is(CommonFlags.Instance)) break;
+            if (isInstance) break;
             return expr; // here
           }
         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -9230,7 +9230,7 @@ export class Compiler extends DiagnosticEmitter {
     let flow = this.currentFlow;
 
     // make a getter for the expression (also obtains the type)
-    const getValueOrigin = this.compileExpression( // reports
+    const getValueOriginal = this.compileExpression( // reports
       expression.operand,
       contextualType.exceptVoid,
       Constraints.None
@@ -9244,11 +9244,11 @@ export class Compiler extends DiagnosticEmitter {
       tempLocal = flow.getTempLocal(this.currentType);
       getValue = module.local_tee(
         tempLocal.index,
-        getValueOrigin,
+        getValueOriginal,
         this.currentType.isManaged
       );
     } else {
-      getValue = getValueOrigin;
+      getValue = getValueOriginal;
     }
 
     let expr: ExpressionRef;
@@ -9262,7 +9262,7 @@ export class Compiler extends DiagnosticEmitter {
           if (overload) {
             let isInstance = overload.is(CommonFlags.Instance);
             if (tempLocal && !isInstance) { // revert: static overload simply returns
-              getValue = getValueOrigin;
+              getValue = getValueOriginal;
               tempLocal = null;
             }
             expr = this.compileUnaryOverload(overload, expression.operand, getValue, expression);
@@ -9345,7 +9345,7 @@ export class Compiler extends DiagnosticEmitter {
           if (overload) {
             let isInstance = overload.is(CommonFlags.Instance);
             if (tempLocal && !isInstance) { // revert: static overload simply returns
-              getValue = getValueOrigin;
+              getValue = getValueOriginal;
               tempLocal = null;
             }
             expr = this.compileUnaryOverload(overload, expression.operand, getValue, expression);

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -6190,11 +6190,6 @@
   block $std/operator-overloading/TesterInlineStatic.postInc|inlined.0 (result i32)
    global.get $~lib/memory/__stack_pointer
    global.get $std/operator-overloading/ais1
-   local.set $9
-   global.get $~lib/memory/__stack_pointer
-   local.get $9
-   i32.store
-   local.get $9
    local.tee $3
    i32.store offset=16
    i32.const 0

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -4550,9 +4550,6 @@
    global.get $~lib/memory/__stack_pointer
    global.get $std/operator-overloading/ais1
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    local.get $0


### PR DESCRIPTION
In original code, `getLocalSetValue` cannot get the original expression accurately. For managed objects, the original expression will be wrapped in a layer of `tostack`, and will be wrapped in another layer of `tostack` when called. Although the subsequent nested `tostack` can be eliminated, this brings some readability issues.