### PR TITLE
chore: remove baseUrl from std/assembly.json

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -61,6 +61,7 @@ under the licensing terms detailed in LICENSE:
 * Jonas Minnberg <sasq64@gmail.com>
 * Kam Chehresa <kaz.che@gmail.com>
 * Mopsgamer <79159094+Mopsgamer@users.noreply.github.com>
+* EDM115 <github@edm115.dev>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/std/assembly.json
+++ b/std/assembly.json
@@ -7,7 +7,6 @@
     "allowJs": false,
     "typeRoots": [ "types" ],
     "types": [ "assembly" ],
-    "baseUrl": ".",
     "paths": {
       "*": [
         "./assembly/*"


### PR DESCRIPTION
Fixes a crash of tsgolint when used in a project where AssemblyScript is present.

When #637 was introduced it also brought the `baseUrl` option to enable `paths` to work. However this option will be deprecated in TS 6 and removed in TS 7, so projects that already use TS 7 like [oxc-project/tsgolint](https://github.com/oxc-project/tsgolint) will crash when said option is set in any of the `tsconfig` files in a project (cf oxc-project/tsgolint#351).

According to https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259 it is safe to remove the option, and since the path *already* included it (`./`) it won't break any existing behavior (see also https://github.com/andrewbranch/ts5to6#overview).

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
