### PR TITLE
fix: check native source correctly

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -18,7 +18,6 @@ import {
   CommonFlags,
   PATH_DELIMITER,
   LIBRARY_PREFIX,
-  LIBRARY_SUBST
 } from "./common";
 
 import {


### PR DESCRIPTION
native code's internal path is ~lib/native.ts instead of ~lib.
However, it is more easier to check current source is same as static
_native field.

<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes # .

Changes proposed in this pull request:
⯈
⯈
⯈

- [ ] I've read the contributing guidelines
- [ ] I've added my name and email to the NOTICE file
