### PR TITLE
fix: compound assignment with side-effect in lhs miscompiles

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -424,6 +424,37 @@ export const runtimeFunctions = [ "__new", "__pin", "__unpin", "__collect" ];
 /** Globals to export if `--exportRuntime` is set. */
 export const runtimeGlobals = [ "__rtti_base" ];
 
+class CompoundAssignmentCacheContext {
+  target: Element;
+  leftExpr: ExpressionRef;
+  leftType: Type;
+  assignmentThisExpression: Expression | null;
+  assignmentElementExpression: Expression | null;
+  assignmentThisExpr: ExpressionRef;
+  assignmentElementExpr: ExpressionRef;
+  setupPrefixExprs: ExpressionRef[] | null;
+
+  constructor(
+    target: Element,
+    leftExpr: ExpressionRef,
+    leftType: Type,
+    assignmentThisExpression: Expression | null,
+    assignmentElementExpression: Expression | null,
+    assignmentThisExpr: ExpressionRef,
+    assignmentElementExpr: ExpressionRef,
+    setupPrefixExprs: ExpressionRef[] | null
+  ) {
+    this.target = target;
+    this.leftExpr = leftExpr;
+    this.leftType = leftType;
+    this.assignmentThisExpression = assignmentThisExpression;
+    this.assignmentElementExpression = assignmentElementExpression;
+    this.assignmentThisExpr = assignmentThisExpr;
+    this.assignmentElementExpr = assignmentElementExpr;
+    this.setupPrefixExprs = setupPrefixExprs;
+  }
+}
+
 /** Compiler interface. */
 export class Compiler extends DiagnosticEmitter {
 
@@ -476,8 +507,6 @@ export class Compiler extends DiagnosticEmitter {
   hasCustomFunctionExports: bool = false;
   /** Whether the module would use the exported runtime to lift/lower. */
   desiresExportRuntime: bool = false;
-  /** Unique suffix for synthesized scoped locals used by compound assignments. */
-  private compoundAssignmentTempId: i32 = 0;
 
   /** Compiles a {@link Program} to a {@link Module} using the specified options. */
   static compile(program: Program): Module {
@@ -4476,104 +4505,69 @@ export class Compiler extends DiagnosticEmitter {
         break;
       }
       case Token.Bar_Equals: {
-        compound = true;
-        let assignmentLeft = left;
-        let setupExprs: ExpressionRef[] | null = null;
+        let cacheContext: CompoundAssignmentCacheContext | null = null;
         let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
         if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(left)) {
-          let flow = this.currentFlow;
-          let rewrittenTarget: Expression;
-          if (cacheTarget.kind == NodeKind.PropertyAccess) {
-            let access = <PropertyAccessExpression>cacheTarget;
-            let receiverExpression = access.expression;
-            if (this.expressionHasSideEffects(receiverExpression)) {
-              let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
-              let receiverType = this.currentType;
-              let receiverTemp = flow.getTempLocal(receiverType);
-              let receiverName = this.makeCompoundAssignmentTempName(flow);
-              flow.addScopedAlias(receiverName, receiverType, receiverTemp.index);
-              flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
-              setupExprs = [ module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged) ];
-              rewrittenTarget = Node.createPropertyAccessExpression(
-                Node.createIdentifierExpression(receiverName, receiverExpression.range),
-                access.property,
-                access.range
-              );
-            } else {
-              rewrittenTarget = cacheTarget;
-            }
-          } else {
-            let access = <ElementAccessExpression>cacheTarget;
-            let receiverExpression = access.expression;
-            let elementExpression = access.elementExpression;
-            let receiverName: string | null = null;
-            let elementName: string | null = null;
-
-            if (this.expressionHasSideEffects(receiverExpression)) {
-              let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
-              let receiverType = this.currentType;
-              let receiverTemp = flow.getTempLocal(receiverType);
-              receiverName = this.makeCompoundAssignmentTempName(flow);
-              flow.addScopedAlias(receiverName, receiverType, receiverTemp.index);
-              flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
-              if (!setupExprs) setupExprs = [];
-              setupExprs.push(module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged));
-            }
-
-            if (this.expressionHasSideEffects(elementExpression)) {
-              let elementExpr = this.compileExpression(elementExpression, Type.auto);
-              let elementType = this.currentType;
-              let elementTemp = flow.getTempLocal(elementType);
-              elementName = this.makeCompoundAssignmentTempName(flow);
-              flow.addScopedAlias(elementName, elementType, elementTemp.index);
-              flow.setLocalFlag(elementTemp.index, LocalFlags.Initialized);
-              if (!setupExprs) setupExprs = [];
-              setupExprs.push(module.local_set(elementTemp.index, elementExpr, elementType.isManaged));
-            }
-
-            rewrittenTarget = Node.createElementAccessExpression(
-              receiverName
-                ? Node.createIdentifierExpression(receiverName, receiverExpression.range)
-                : receiverExpression,
-              elementName
-                ? Node.createIdentifierExpression(elementName, elementExpression.range)
-                : elementExpression,
-              access.range
-            );
-          }
-          assignmentLeft = this.replaceCompoundAssignmentSideEffectCacheTarget(
-            left,
-            this.wrapCompoundAssignmentCacheSetup(setupExprs, rewrittenTarget)
-          );
+          cacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
+          if (!cacheContext) return module.unreachable();
+          leftExpr = cacheContext.leftExpr;
+          leftType = cacheContext.leftType;
+        } else {
+          leftExpr = this.compileExpression(left, contextualType.intType);
+          leftType = this.currentType;
         }
-
-        leftExpr = this.compileExpression(assignmentLeft, contextualType.intType);
-        leftType = this.currentType;
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
         if (classReference) {
           let overload = classReference.lookupOverload(OperatorKind.BitwiseOr);
           if (overload) {
-            expr = this.compileBinaryOverload(overload, assignmentLeft, leftExpr, leftType, right, expression);
-            break;
+            expr = this.compileBinaryOverload(overload, left, leftExpr, leftType, right, expression);
+          } else {
+            if (!leftType.isIntegerValue) {
+              this.error(
+                DiagnosticCode.The_0_operator_cannot_be_applied_to_type_1,
+                expression.range, "|", leftType.toString()
+              );
+              return module.unreachable();
+            }
+            rightExpr = this.compileExpression(right, leftType, Constraints.ConvImplicit);
+            rightType = commonType = this.currentType;
+            expr = this.makeOr(leftExpr, rightExpr, commonType);
           }
+        } else {
+          if (!leftType.isIntegerValue) {
+            this.error(
+              DiagnosticCode.The_0_operator_cannot_be_applied_to_type_1,
+              expression.range, "|", leftType.toString()
+            );
+            return module.unreachable();
+          }
+          rightExpr = this.compileExpression(right, leftType, Constraints.ConvImplicit);
+          rightType = commonType = this.currentType;
+          expr = this.makeOr(leftExpr, rightExpr, commonType);
         }
-
-        if (!leftType.isIntegerValue) {
-          this.error(
-            DiagnosticCode.The_0_operator_cannot_be_applied_to_type_1,
-            expression.range, "|", leftType.toString()
-          );
-          return module.unreachable();
-        }
-        rightExpr = this.compileExpression(right, leftType, Constraints.ConvImplicit);
-        rightType = commonType = this.currentType;
-        expr = this.makeOr(leftExpr, rightExpr, commonType);
 
         let resolver = this.resolver;
-        let target = resolver.lookupExpression(assignmentLeft, this.currentFlow);
-        if (!target) return module.unreachable();
+        let target: Element | null;
+        let thisExpression: Expression | null;
+        let elementExpression: Expression | null;
+        let thisExpr: ExpressionRef = 0;
+        let indexExpr: ExpressionRef = 0;
+        if (cacheContext) {
+          target = cacheContext.target;
+          thisExpression = cacheContext.assignmentThisExpression;
+          elementExpression = cacheContext.assignmentElementExpression;
+          thisExpr = cacheContext.assignmentThisExpr;
+          indexExpr = cacheContext.assignmentElementExpr;
+        } else {
+          target = resolver.lookupExpression(left, this.currentFlow);
+          if (!target) return module.unreachable();
+          thisExpression = resolver.currentThisExpression;
+          elementExpression = resolver.currentElementExpression;
+        }
+
+        target = assert(target);
         let targetType = resolver.getTypeOfElement(target);
         if (!targetType) targetType = Type.void;
         if (!this.currentType.isStrictlyAssignableTo(targetType)) {
@@ -4583,15 +4577,21 @@ export class Compiler extends DiagnosticEmitter {
           );
           return module.unreachable();
         }
-        return this.makeAssignment(
+
+        let assignmentExpr = this.makeAssignment(
           target,
           expr,
           this.currentType,
           right,
-          resolver.currentThisExpression,
-          resolver.currentElementExpression,
-          contextualType != Type.void
+          thisExpression,
+          elementExpression,
+          contextualType != Type.void,
+          thisExpr,
+          indexExpr
         );
+        return cacheContext
+          ? this.prependSetupPrefixExpressions(cacheContext.setupPrefixExprs, assignmentExpr, contextualType != Type.void)
+          : assignmentExpr;
       }
       case Token.Bar: {
         leftExpr = this.compileExpression(left, contextualType.intType);
@@ -4607,33 +4607,22 @@ export class Compiler extends DiagnosticEmitter {
           }
         }
 
-        if (compound) {
-          if (!leftType.isIntegerValue) {
-            this.error(
-              DiagnosticCode.The_0_operator_cannot_be_applied_to_type_1,
-              expression.range, "|", leftType.toString()
-            );
-            return module.unreachable();
-          }
-          rightExpr = this.compileExpression(right, leftType, Constraints.ConvImplicit);
-          rightType = commonType = this.currentType;
-        } else {
-          rightExpr = this.compileExpression(right, leftType);
-          rightType = this.currentType;
-          commonType = Type.commonType(leftType, rightType, contextualType);
-          if (!commonType || !commonType.isIntegerValue) {
-            this.error(
-              DiagnosticCode.Operator_0_cannot_be_applied_to_types_1_and_2,
-              expression.range, "|", leftType.toString(), rightType.toString()
-            );
-            this.currentType = contextualType;
-            return module.unreachable();
-          }
-          leftExpr = this.convertExpression(leftExpr, leftType, commonType, false, left);
-          leftType = commonType;
-          rightExpr = this.convertExpression(rightExpr, rightType, commonType, false, right);
-          rightType = commonType;
+        rightExpr = this.compileExpression(right, leftType);
+        rightType = this.currentType;
+        commonType = Type.commonType(leftType, rightType, contextualType);
+        if (!commonType || !commonType.isIntegerValue) {
+          this.error(
+            DiagnosticCode.Operator_0_cannot_be_applied_to_types_1_and_2,
+            expression.range, "|", leftType.toString(), rightType.toString()
+          );
+          this.currentType = contextualType;
+          return module.unreachable();
         }
+        leftExpr = this.convertExpression(leftExpr, leftType, commonType, false, left);
+        leftType = commonType;
+        rightExpr = this.convertExpression(rightExpr, rightType, commonType, false, right);
+        rightType = commonType;
+
         expr = this.makeOr(leftExpr, rightExpr, commonType);
         break;
       }
@@ -4905,17 +4894,182 @@ export class Compiler extends DiagnosticEmitter {
       right,
       resolver.currentThisExpression,
       resolver.currentElementExpression,
-      contextualType != Type.void
+      contextualType != Type.void,
+      0,
+      0
     );
   }
 
-  private makeCompoundAssignmentTempName(flow: Flow): string {
-    let name: string;
-    do {
-      let id = this.compoundAssignmentTempId++;
-      name = "__as_or_assign_tmp" + id.toString();
-    } while (flow.lookup(name));
-    return name;
+  private prepareCompoundAssignmentCache(
+    cacheTarget: Expression,
+    contextualType: Type
+  ): CompoundAssignmentCacheContext | null {
+    let module = this.module;
+    let flow = this.currentFlow;
+    let resolver = this.resolver;
+    let target = resolver.lookupExpression(cacheTarget, flow);
+    if (!target) return null;
+
+    let setupPrefixExprs: ExpressionRef[] | null = null;
+    let assignmentThisExpression: Expression | null = null;
+    let assignmentElementExpression: Expression | null = null;
+    let assignmentThisExpr: ExpressionRef = 0;
+    let assignmentElementExpr: ExpressionRef = 0;
+    let readThisExpression: Expression | null = null;
+    let readElementExpression: Expression | null = null;
+
+    if (cacheTarget.kind == NodeKind.PropertyAccess) {
+      let access = <PropertyAccessExpression>cacheTarget;
+      let receiverExpression = access.expression;
+      let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
+      let receiverType = this.currentType;
+      let receiverTemp = flow.getTempLocal(receiverType);
+      flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
+      setupPrefixExprs = [ module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged) ];
+      let receiverCachedExpression = Node.createCompiledExpression(
+        module.local_get(receiverTemp.index, receiverType.toRef()),
+        receiverType,
+        receiverExpression.range
+      );
+      readThisExpression = receiverCachedExpression;
+      assignmentThisExpression = receiverCachedExpression;
+    } else {
+      let access = <ElementAccessExpression>cacheTarget;
+      let receiverExpression = access.expression;
+      let elementExpression = access.elementExpression;
+      let receiverForRead: Expression = receiverExpression;
+      let elementForRead: Expression = elementExpression;
+
+      assignmentThisExpression = receiverExpression;
+      assignmentElementExpression = elementExpression;
+
+      if (this.expressionHasSideEffects(receiverExpression)) {
+        let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
+        let receiverType = this.currentType;
+        let receiverTemp = flow.getTempLocal(receiverType);
+        flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
+        if (!setupPrefixExprs) setupPrefixExprs = [];
+        setupPrefixExprs.push(module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged));
+        let receiverCachedExpression = Node.createCompiledExpression(
+          module.local_get(receiverTemp.index, receiverType.toRef()),
+          receiverType,
+          receiverExpression.range
+        );
+        receiverForRead = receiverCachedExpression;
+        assignmentThisExpression = receiverCachedExpression;
+      }
+
+      if (this.expressionHasSideEffects(elementExpression)) {
+        let elementExpr = this.compileExpression(elementExpression, Type.auto);
+        let elementType = this.currentType;
+        let elementTemp = flow.getTempLocal(elementType);
+        flow.setLocalFlag(elementTemp.index, LocalFlags.Initialized);
+        if (!setupPrefixExprs) setupPrefixExprs = [];
+        setupPrefixExprs.push(module.local_set(elementTemp.index, elementExpr, elementType.isManaged));
+        let elementCachedExpression = Node.createCompiledExpression(
+          module.local_get(elementTemp.index, elementType.toRef()),
+          elementType,
+          elementExpression.range
+        );
+        elementForRead = elementCachedExpression;
+        assignmentElementExpression = elementCachedExpression;
+      }
+
+      readThisExpression = receiverForRead;
+      readElementExpression = elementForRead;
+    }
+
+    let leftExpr: ExpressionRef;
+    let leftType: Type;
+    switch (target.kind) {
+      case ElementKind.PropertyPrototype: {
+        let propertyInstance = resolver.resolveProperty(<PropertyPrototype>target);
+        if (!propertyInstance) return null;
+        target = propertyInstance;
+        // fall-through
+      }
+      case ElementKind.Property: {
+        let getterInstance = (<Property>target).getterInstance;
+        if (!getterInstance) return null;
+        if (getterInstance.is(CommonFlags.Instance)) {
+          let thisArg = this.compileExpression(
+            assert(readThisExpression),
+            assert(getterInstance.signature.thisType),
+            Constraints.ConvImplicit | Constraints.IsThis
+          );
+          assignmentThisExpr = thisArg;
+          leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget, thisArg);
+        } else {
+          leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget);
+        }
+        leftType = this.currentType;
+        break;
+      }
+      case ElementKind.IndexSignature: {
+        let parent = (<IndexSignature>target).parent;
+        assert(parent.kind == ElementKind.Class);
+        let classInstance = <Class>parent;
+        let isUnchecked = flow.is(FlowFlags.UncheckedContext);
+        let getterInstance = classInstance.lookupOverload(OperatorKind.IndexedGet, isUnchecked);
+        if (!getterInstance) {
+          this.error(
+            DiagnosticCode.Index_signature_is_missing_in_type_0,
+            cacheTarget.range,
+            classInstance.internalName
+          );
+          return null;
+        }
+        let thisArg = this.compileExpression(
+          assert(readThisExpression),
+          classInstance.type,
+          Constraints.ConvImplicit | Constraints.IsThis
+        );
+        let indexArg = this.compileExpression(
+          assert(readElementExpression),
+          getterInstance.signature.parameterTypes[0],
+          Constraints.ConvImplicit
+        );
+        assignmentThisExpr = thisArg;
+        assignmentElementExpr = indexArg;
+        leftExpr = this.makeCallDirect(getterInstance, [ thisArg, indexArg ], cacheTarget);
+        leftType = this.currentType;
+        break;
+      }
+      default: {
+        leftExpr = this.compileExpression(cacheTarget, contextualType);
+        leftType = this.currentType;
+        break;
+      }
+    }
+
+    return new CompoundAssignmentCacheContext(
+      target,
+      leftExpr,
+      leftType,
+      assignmentThisExpression,
+      assignmentElementExpression,
+      assignmentThisExpr,
+      assignmentElementExpr,
+      setupPrefixExprs
+    );
+  }
+
+  private prependSetupPrefixExpressions(
+    setupPrefixExprs: ExpressionRef[] | null,
+    expr: ExpressionRef,
+    tee: bool
+  ): ExpressionRef {
+    if (!setupPrefixExprs || !setupPrefixExprs.length) return expr;
+    let setupAndExpr = new Array<ExpressionRef>(setupPrefixExprs.length + 1);
+    for (let i = 0, k = setupPrefixExprs.length; i < k; ++i) {
+      setupAndExpr[i] = unchecked(setupPrefixExprs[i]);
+    }
+    setupAndExpr[setupPrefixExprs.length] = expr;
+    return this.module.block(
+      null,
+      setupAndExpr,
+      tee ? this.currentType.toRef() : TypeRef.None
+    );
   }
 
   private needsCompoundAssignmentSideEffectCache(target: Expression): bool {
@@ -4956,122 +5110,11 @@ export class Compiler extends DiagnosticEmitter {
     }
   }
 
-  private replaceCompoundAssignmentSideEffectCacheTarget(target: Expression, replacement: Expression): Expression {
-    while (target.kind == NodeKind.Parenthesized) {
-      target = (<ParenthesizedExpression>target).expression;
-      replacement = Node.createParenthesizedExpression(replacement, target.range);
-    }
-    switch (target.kind) {
-      case NodeKind.PropertyAccess:
-      case NodeKind.ElementAccess:
-        return replacement;
-      case NodeKind.Assertion: {
-        let assertion = <AssertionExpression>target;
-        if (assertion.assertionKind == AssertionKind.NonNull) {
-          return Node.createAssertionExpression(
-            AssertionKind.NonNull,
-            this.replaceCompoundAssignmentSideEffectCacheTarget(assertion.expression, replacement),
-            null,
-            assertion.range
-          );
-        }
-        return target;
-      }
-      case NodeKind.Comma: {
-        let comma = <CommaExpression>target;
-        let expressions = comma.expressions;
-        let cloned = new Array<Expression>(expressions.length);
-        for (let i = 0, k = expressions.length - 1; i < k; ++i) {
-          cloned[i] = unchecked(expressions[i]);
-        }
-        cloned[assert(expressions.length) - 1] = this.replaceCompoundAssignmentSideEffectCacheTarget(
-          expressions[assert(expressions.length) - 1],
-          replacement
-        );
-        return Node.createCommaExpression(cloned, comma.range);
-      }
-      default:
-        return target;
-    }
-  }
-
-  private wrapCompoundAssignmentCacheSetup(setupExprs: ExpressionRef[] | null, target: Expression): Expression {
-    if (!setupExprs || !setupExprs.length) return target;
-    let range = target.range;
-    let expressions = new Array<Expression>(setupExprs.length + 1);
-    for (let i = 0, k = setupExprs.length; i < k; ++i) {
-      expressions[i] = Node.createCompiledExpression(unchecked(setupExprs[i]), Type.void, range);
-    }
-    expressions[setupExprs.length] = target;
-    return Node.createCommaExpression(expressions, range);
-  }
-
   private expressionHasSideEffects(expression: Expression): bool {
     while (expression.kind == NodeKind.Parenthesized) {
       expression = (<ParenthesizedExpression>expression).expression;
     }
-    switch (expression.kind) {
-      case NodeKind.Call:
-      case NodeKind.New:
-      case NodeKind.UnaryPostfix:
-      case NodeKind.Class:
-      case NodeKind.Function:
-      case NodeKind.Compiled:
-        return true;
-      case NodeKind.UnaryPrefix: {
-        let unary = <UnaryPrefixExpression>expression;
-        if (unary.operator == Token.Plus_Plus || unary.operator == Token.Minus_Minus) {
-          return true;
-        }
-        return this.expressionHasSideEffects(unary.operand);
-      }
-      case NodeKind.Binary: {
-        let binary = <BinaryExpression>expression;
-        switch (binary.operator) {
-          case Token.Equals:
-          case Token.Plus_Equals:
-          case Token.Minus_Equals:
-          case Token.Asterisk_Equals:
-          case Token.Asterisk_Asterisk_Equals:
-          case Token.Slash_Equals:
-          case Token.Percent_Equals:
-          case Token.LessThan_LessThan_Equals:
-          case Token.GreaterThan_GreaterThan_Equals:
-          case Token.GreaterThan_GreaterThan_GreaterThan_Equals:
-          case Token.Ampersand_Equals:
-          case Token.Bar_Equals:
-          case Token.Caret_Equals:
-            return true;
-          default:
-            return this.expressionHasSideEffects(binary.left)
-                || this.expressionHasSideEffects(binary.right);
-        }
-      }
-      case NodeKind.Assertion:
-        return this.expressionHasSideEffects((<AssertionExpression>expression).expression);
-      case NodeKind.Comma: {
-        let expressions = (<CommaExpression>expression).expressions;
-        for (let i = 0, k = expressions.length; i < k; ++i) {
-          if (this.expressionHasSideEffects(unchecked(expressions[i]))) return true;
-        }
-        return false;
-      }
-      case NodeKind.ElementAccess: {
-        let access = <ElementAccessExpression>expression;
-        return this.expressionHasSideEffects(access.expression)
-            || this.expressionHasSideEffects(access.elementExpression);
-      }
-      case NodeKind.PropertyAccess:
-        return this.expressionHasSideEffects((<PropertyAccessExpression>expression).expression);
-      case NodeKind.Ternary: {
-        let ternary = <TernaryExpression>expression;
-        return this.expressionHasSideEffects(ternary.condition)
-            || this.expressionHasSideEffects(ternary.ifThen)
-            || this.expressionHasSideEffects(ternary.ifElse);
-      }
-      default:
-        return false;
-    }
+    return expression.kind != NodeKind.Identifier;
   }
 
   makeLt(leftExpr: ExpressionRef, rightExpr: ExpressionRef, type: Type): ExpressionRef {
@@ -6068,7 +6111,9 @@ export class Compiler extends DiagnosticEmitter {
       valueExpression,
       thisExpression,
       elementExpression,
-      contextualType != Type.void
+      contextualType != Type.void,
+      0,
+      0
     );
   }
 
@@ -6087,7 +6132,11 @@ export class Compiler extends DiagnosticEmitter {
     /** Index expression reference if an indexed set. */
     indexExpression: Expression | null,
     /** Whether to tee the value. */
-    tee: bool
+    tee: bool,
+    /** Precompiled `this` expression reference if available. */
+    thisExpr: ExpressionRef,
+    /** Precompiled index expression reference if available. */
+    indexExpr: ExpressionRef,
   ): ExpressionRef {
     let module = this.module;
     let flow = this.currentFlow;
@@ -6160,11 +6209,13 @@ export class Compiler extends DiagnosticEmitter {
         assert(setterInstance.signature.returnType == Type.void);
         if (propertyInstance.is(CommonFlags.Instance)) {
           let thisType = assert(setterInstance.signature.thisType);
-          let thisExpr = this.compileExpression(
-            assert(thisExpression),
-            thisType,
-            Constraints.ConvImplicit | Constraints.IsThis
-          );
+          if (!thisExpr) {
+            thisExpr = this.compileExpression(
+              assert(thisExpression),
+              thisType,
+              Constraints.ConvImplicit | Constraints.IsThis
+            );
+          }
           if (!tee) return this.makeCallDirect(setterInstance, [ thisExpr, valueExpr ], valueExpression);
           let tempLocal = flow.getTempLocal(valueType);
           let valueTypeRef = valueType.toRef();
@@ -6217,11 +6268,13 @@ export class Compiler extends DiagnosticEmitter {
         }
         assert(setterInstance.signature.parameterTypes.length == 2);
         let thisType = classInstance.type;
-        let thisExpr = this.compileExpression(
-          assert(thisExpression),
-          thisType,
-          Constraints.ConvImplicit | Constraints.IsThis
-        );
+        if (!thisExpr) {
+          thisExpr = this.compileExpression(
+            assert(thisExpression),
+            thisType,
+            Constraints.ConvImplicit | Constraints.IsThis
+          );
+        }
         let setterIndexType = setterInstance.signature.parameterTypes[0];
         let getterIndexType = getterInstance.signature.parameterTypes[0];
         if (!setterIndexType.equals(getterIndexType)) {
@@ -6234,8 +6287,15 @@ export class Compiler extends DiagnosticEmitter {
           this.currentType = tee ? getterInstance.signature.returnType : Type.void;
           return module.unreachable();
         }
-        let elementExpr = this.compileExpression(assert(indexExpression), setterIndexType, Constraints.ConvImplicit);
-        let elementType = this.currentType;
+        let elementExpr: ExpressionRef;
+        let elementType: Type;
+        if (indexExpr) {
+          elementExpr = indexExpr;
+          elementType = getterIndexType;
+        } else {
+          elementExpr = this.compileExpression(assert(indexExpression), setterIndexType, Constraints.ConvImplicit);
+          elementType = this.currentType;
+        }
         if (tee) {
           let tempTarget = flow.getTempLocal(thisType);
           let tempElement = flow.getTempLocal(elementType);
@@ -9778,7 +9838,9 @@ export class Compiler extends DiagnosticEmitter {
         expression.operand,
         resolver.currentThisExpression,
         resolver.currentElementExpression,
-        false
+        false,
+        0,
+        0
       );
     }
 
@@ -9790,7 +9852,9 @@ export class Compiler extends DiagnosticEmitter {
       expression.operand,
       resolver.currentThisExpression,
       resolver.currentElementExpression,
-      false
+      false,
+      0,
+      0
     );
 
     this.currentType = tempLocal.type;
@@ -10154,7 +10218,9 @@ export class Compiler extends DiagnosticEmitter {
       expression.operand,
       resolver.currentThisExpression,
       resolver.currentElementExpression,
-      contextualType != Type.void
+      contextualType != Type.void,
+      0,
+      0
     );
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5280,16 +5280,13 @@ export class Compiler extends DiagnosticEmitter {
         return true;
       case NodeKind.UnaryPrefix: {
         let unaryPrefix = <UnaryPrefixExpression>expression;
-        switch (unaryPrefix.operator) {
-          case Token.Plus_Plus:
-          case Token.Minus_Minus:
-          case Token.Delete:
-          case Token.Await:
-          case Token.Yield:
-            return true;
-          default:
-            return this.expressionHasSideEffects(unaryPrefix.operand);
-        }
+        let operator = unaryPrefix.operator;
+        return operator == Token.Plus_Plus
+            || operator == Token.Minus_Minus
+            || operator == Token.Delete
+            || operator == Token.Await
+            || operator == Token.Yield
+            || this.expressionHasSideEffects(unaryPrefix.operand);
       }
       case NodeKind.Assertion:
         return this.expressionHasSideEffects((<AssertionExpression>expression).expression);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4090,6 +4090,7 @@ export class Compiler extends DiagnosticEmitter {
 
     let expr: ExpressionRef;
     let compound = false;
+    let compoundAssignmentCacheContext: CompoundAssignmentCacheContext | null = null;
 
     let operator = expression.operator;
     switch (operator) {
@@ -4110,8 +4111,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Plus_Equals: compound = true;
       case Token.Plus: {
-        leftExpr = this.compileExpression(left, contextualType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4154,8 +4168,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Minus_Equals: compound = true;
       case Token.Minus: {
-        leftExpr = this.compileExpression(left, contextualType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4199,8 +4226,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Asterisk_Equals: compound = true;
       case Token.Asterisk: {
-        leftExpr = this.compileExpression(left, contextualType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4244,8 +4284,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Asterisk_Asterisk_Equals: compound = true;
       case Token.Asterisk_Asterisk: {
-        leftExpr = this.compileExpression(left, contextualType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4289,8 +4342,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Slash_Equals: compound = true;
       case Token.Slash: {
-        leftExpr = this.compileExpression(left, contextualType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4334,8 +4400,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Percent_Equals: compound = true;
       case Token.Percent: {
-        leftExpr = this.compileExpression(left, contextualType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4379,8 +4458,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.LessThan_LessThan_Equals: compound = true;
       case Token.LessThan_LessThan: {
-        leftExpr = this.compileExpression(left, contextualType.intType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType.intType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType.intType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4406,8 +4498,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.GreaterThan_GreaterThan_Equals: compound = true;
       case Token.GreaterThan_GreaterThan: {
-        leftExpr = this.compileExpression(left, contextualType.intType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType.intType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType.intType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4434,8 +4539,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.GreaterThan_GreaterThan_GreaterThan_Equals: compound = true;
       case Token.GreaterThan_GreaterThan_GreaterThan: {
-        leftExpr = this.compileExpression(left, contextualType.intType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType.intType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType.intType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4461,8 +4579,21 @@ export class Compiler extends DiagnosticEmitter {
       }
       case Token.Ampersand_Equals: compound = true;
       case Token.Ampersand: {
-        leftExpr = this.compileExpression(left, contextualType.intType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType.intType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType.intType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4504,14 +4635,19 @@ export class Compiler extends DiagnosticEmitter {
         expr = this.makeAnd(leftExpr, rightExpr, commonType);
         break;
       }
-      case Token.Bar_Equals: {
-        let cacheContext: CompoundAssignmentCacheContext | null = null;
-        let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
-        if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
-          cacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
-          if (!cacheContext) return module.unreachable();
-          leftExpr = cacheContext.leftExpr;
-          leftType = cacheContext.leftType;
+      case Token.Bar_Equals: compound = true;
+      case Token.Bar: {
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType.intType);
+            leftType = this.currentType;
+          }
         } else {
           leftExpr = this.compileExpression(left, contextualType.intType);
           leftType = this.currentType;
@@ -4523,19 +4659,11 @@ export class Compiler extends DiagnosticEmitter {
           let overload = classReference.lookupOverload(OperatorKind.BitwiseOr);
           if (overload) {
             expr = this.compileBinaryOverload(overload, left, leftExpr, leftType, right, expression);
-          } else {
-            if (!leftType.isIntegerValue) {
-              this.error(
-                DiagnosticCode.The_0_operator_cannot_be_applied_to_type_1,
-                expression.range, "|", leftType.toString()
-              );
-              return module.unreachable();
-            }
-            rightExpr = this.compileExpression(right, leftType, Constraints.ConvImplicit);
-            rightType = commonType = this.currentType;
-            expr = this.makeOr(leftExpr, rightExpr, commonType);
+            break;
           }
-        } else {
+        }
+
+        if (compound) {
           if (!leftType.isIntegerValue) {
             this.error(
               DiagnosticCode.The_0_operator_cannot_be_applied_to_type_1,
@@ -4545,91 +4673,44 @@ export class Compiler extends DiagnosticEmitter {
           }
           rightExpr = this.compileExpression(right, leftType, Constraints.ConvImplicit);
           rightType = commonType = this.currentType;
-          expr = this.makeOr(leftExpr, rightExpr, commonType);
-        }
-
-        let resolver = this.resolver;
-        let target: Element | null;
-        let thisExpression: Expression | null;
-        let elementExpression: Expression | null;
-        let thisExpr: ExpressionRef = 0;
-        let indexExpr: ExpressionRef = 0;
-        if (cacheContext) {
-          target = cacheContext.target;
-          thisExpression = cacheContext.assignmentThisExpression;
-          elementExpression = cacheContext.assignmentElementExpression;
-          thisExpr = cacheContext.assignmentThisExpr;
-          indexExpr = cacheContext.assignmentElementExpr;
         } else {
-          target = resolver.lookupExpression(left, this.currentFlow);
-          if (!target) return module.unreachable();
-          thisExpression = resolver.currentThisExpression;
-          elementExpression = resolver.currentElementExpression;
-        }
-
-        target = assert(target);
-        let targetType = resolver.getTypeOfElement(target);
-        if (!targetType) targetType = Type.void;
-        if (!this.currentType.isStrictlyAssignableTo(targetType)) {
-          this.error(
-            DiagnosticCode.Type_0_is_not_assignable_to_type_1,
-            expression.range, this.currentType.toString(), targetType.toString()
-          );
-          return module.unreachable();
-        }
-
-        let assignmentExpr = this.makeAssignment(
-          target,
-          expr,
-          this.currentType,
-          right,
-          thisExpression,
-          elementExpression,
-          contextualType != Type.void,
-          thisExpr,
-          indexExpr
-        );
-        return cacheContext
-          ? this.prependSetupPrefixExpressions(cacheContext.setupPrefixExprs, assignmentExpr, contextualType != Type.void)
-          : assignmentExpr;
-      }
-      case Token.Bar: {
-        leftExpr = this.compileExpression(left, contextualType.intType);
-        leftType = this.currentType;
-
-        // check operator overload
-        let classReference = leftType.getClassOrWrapper(this.program);
-        if (classReference) {
-          let overload = classReference.lookupOverload(OperatorKind.BitwiseOr);
-          if (overload) {
-            expr = this.compileBinaryOverload(overload, left, leftExpr, leftType, right, expression);
-            break;
+          rightExpr = this.compileExpression(right, leftType);
+          rightType = this.currentType;
+          commonType = Type.commonType(leftType, rightType, contextualType);
+          if (!commonType || !commonType.isIntegerValue) {
+            this.error(
+              DiagnosticCode.Operator_0_cannot_be_applied_to_types_1_and_2,
+              expression.range, "|", leftType.toString(), rightType.toString()
+            );
+            this.currentType = contextualType;
+            return module.unreachable();
           }
+          leftExpr = this.convertExpression(leftExpr, leftType, commonType, false, left);
+          leftType = commonType;
+          rightExpr = this.convertExpression(rightExpr, rightType, commonType, false, right);
+          rightType = commonType;
         }
-
-        rightExpr = this.compileExpression(right, leftType);
-        rightType = this.currentType;
-        commonType = Type.commonType(leftType, rightType, contextualType);
-        if (!commonType || !commonType.isIntegerValue) {
-          this.error(
-            DiagnosticCode.Operator_0_cannot_be_applied_to_types_1_and_2,
-            expression.range, "|", leftType.toString(), rightType.toString()
-          );
-          this.currentType = contextualType;
-          return module.unreachable();
-        }
-        leftExpr = this.convertExpression(leftExpr, leftType, commonType, false, left);
-        leftType = commonType;
-        rightExpr = this.convertExpression(rightExpr, rightType, commonType, false, right);
-        rightType = commonType;
 
         expr = this.makeOr(leftExpr, rightExpr, commonType);
         break;
       }
       case Token.Caret_Equals: compound = true;
       case Token.Caret: {
-        leftExpr = this.compileExpression(left, contextualType.intType);
-        leftType = this.currentType;
+        if (compound) {
+          let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+          if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
+            compoundAssignmentCacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
+            if (!compoundAssignmentCacheContext) return module.unreachable();
+            leftExpr = compoundAssignmentCacheContext.leftExpr;
+            leftType = compoundAssignmentCacheContext.leftType;
+          } else {
+            leftExpr = this.compileExpression(left, contextualType.intType);
+            leftType = this.currentType;
+          }
+        } else {
+          leftExpr = this.compileExpression(left, contextualType.intType);
+          leftType = this.currentType;
+        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4876,8 +4957,24 @@ export class Compiler extends DiagnosticEmitter {
     }
     if (!compound) return expr;
     let resolver = this.resolver;
-    let target = resolver.lookupExpression(left, this.currentFlow);
-    if (!target) return module.unreachable();
+    let target: Element | null;
+    let thisExpression: Expression | null;
+    let elementExpression: Expression | null;
+    let thisExpr: ExpressionRef = 0;
+    let indexExpr: ExpressionRef = 0;
+    if (compoundAssignmentCacheContext) {
+      target = compoundAssignmentCacheContext.target;
+      thisExpression = compoundAssignmentCacheContext.assignmentThisExpression;
+      elementExpression = compoundAssignmentCacheContext.assignmentElementExpression;
+      thisExpr = compoundAssignmentCacheContext.assignmentThisExpr;
+      indexExpr = compoundAssignmentCacheContext.assignmentElementExpr;
+    } else {
+      target = resolver.lookupExpression(left, this.currentFlow);
+      if (!target) return module.unreachable();
+      thisExpression = resolver.currentThisExpression;
+      elementExpression = resolver.currentElementExpression;
+    }
+    target = assert(target);
     let targetType = resolver.getTypeOfElement(target);
     if (!targetType) targetType = Type.void;
     if (!this.currentType.isStrictlyAssignableTo(targetType)) {
@@ -4887,17 +4984,20 @@ export class Compiler extends DiagnosticEmitter {
       );
       return module.unreachable();
     }
-    return this.makeAssignment(
+    let assignmentExpr = this.makeAssignment(
       target,
       expr,
       this.currentType,
       right,
-      resolver.currentThisExpression,
-      resolver.currentElementExpression,
+      thisExpression,
+      elementExpression,
       contextualType != Type.void,
-      0,
-      0
+      thisExpr,
+      indexExpr
     );
+    return compoundAssignmentCacheContext
+      ? this.prependSetupPrefixExpressions(compoundAssignmentCacheContext.setupPrefixExprs, assignmentExpr, contextualType != Type.void)
+      : assignmentExpr;
   }
 
   private prepareCompoundAssignmentCache(

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4479,10 +4479,12 @@ export class Compiler extends DiagnosticEmitter {
         compound = true;
         let assignmentLeft = left;
         let setupExprs: ExpressionRef[] | null = null;
-        if (this.needsCompoundAssignmentSideEffectCache(left)) {
+        let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
+        if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(left)) {
           let flow = this.currentFlow;
-          if (left.kind == NodeKind.PropertyAccess) {
-            let access = <PropertyAccessExpression>left;
+          let rewrittenTarget: Expression;
+          if (cacheTarget.kind == NodeKind.PropertyAccess) {
+            let access = <PropertyAccessExpression>cacheTarget;
             let receiverExpression = access.expression;
             if (this.expressionHasSideEffects(receiverExpression)) {
               let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
@@ -4492,14 +4494,16 @@ export class Compiler extends DiagnosticEmitter {
               flow.addScopedAlias(receiverName, receiverType, receiverTemp.index);
               flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
               setupExprs = [ module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged) ];
-              assignmentLeft = Node.createPropertyAccessExpression(
+              rewrittenTarget = Node.createPropertyAccessExpression(
                 Node.createIdentifierExpression(receiverName, receiverExpression.range),
                 access.property,
                 access.range
               );
+            } else {
+              rewrittenTarget = cacheTarget;
             }
           } else {
-            let access = <ElementAccessExpression>left;
+            let access = <ElementAccessExpression>cacheTarget;
             let receiverExpression = access.expression;
             let elementExpression = access.elementExpression;
             let receiverName: string | null = null;
@@ -4527,7 +4531,7 @@ export class Compiler extends DiagnosticEmitter {
               setupExprs.push(module.local_set(elementTemp.index, elementExpr, elementType.isManaged));
             }
 
-            assignmentLeft = Node.createElementAccessExpression(
+            rewrittenTarget = Node.createElementAccessExpression(
               receiverName
                 ? Node.createIdentifierExpression(receiverName, receiverExpression.range)
                 : receiverExpression,
@@ -4537,15 +4541,14 @@ export class Compiler extends DiagnosticEmitter {
               access.range
             );
           }
+          assignmentLeft = this.replaceCompoundAssignmentSideEffectCacheTarget(
+            left,
+            this.wrapCompoundAssignmentCacheSetup(setupExprs, rewrittenTarget)
+          );
         }
 
         leftExpr = this.compileExpression(assignmentLeft, contextualType.intType);
         leftType = this.currentType;
-        if (setupExprs) {
-          let wrappedExprs = setupExprs;
-          wrappedExprs.push(leftExpr);
-          leftExpr = module.block(null, wrappedExprs, leftType.toRef());
-        }
 
         // check operator overload
         let classReference = leftType.getClassOrWrapper(this.program);
@@ -4916,15 +4919,91 @@ export class Compiler extends DiagnosticEmitter {
   }
 
   private needsCompoundAssignmentSideEffectCache(target: Expression): bool {
-    if (target.kind == NodeKind.PropertyAccess) {
-      return this.expressionHasSideEffects((<PropertyAccessExpression>target).expression);
+    let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(target);
+    if (!cacheTarget) return false;
+    if (cacheTarget.kind == NodeKind.PropertyAccess) {
+      return this.expressionHasSideEffects((<PropertyAccessExpression>cacheTarget).expression);
     }
-    if (target.kind == NodeKind.ElementAccess) {
-      let access = <ElementAccessExpression>target;
+    if (cacheTarget.kind == NodeKind.ElementAccess) {
+      let access = <ElementAccessExpression>cacheTarget;
       return this.expressionHasSideEffects(access.expression)
           || this.expressionHasSideEffects(access.elementExpression);
     }
     return false;
+  }
+
+  private getCompoundAssignmentSideEffectCacheTarget(target: Expression): Expression | null {
+    while (target.kind == NodeKind.Parenthesized) {
+      target = (<ParenthesizedExpression>target).expression;
+    }
+    switch (target.kind) {
+      case NodeKind.PropertyAccess:
+      case NodeKind.ElementAccess:
+        return target;
+      case NodeKind.Assertion: {
+        let assertion = <AssertionExpression>target;
+        if (assertion.assertionKind == AssertionKind.NonNull) {
+          return this.getCompoundAssignmentSideEffectCacheTarget(assertion.expression);
+        }
+        return null;
+      }
+      case NodeKind.Comma: {
+        let expressions = (<CommaExpression>target).expressions;
+        return this.getCompoundAssignmentSideEffectCacheTarget(expressions[assert(expressions.length) - 1]);
+      }
+      default:
+        return null;
+    }
+  }
+
+  private replaceCompoundAssignmentSideEffectCacheTarget(target: Expression, replacement: Expression): Expression {
+    while (target.kind == NodeKind.Parenthesized) {
+      target = (<ParenthesizedExpression>target).expression;
+      replacement = Node.createParenthesizedExpression(replacement, target.range);
+    }
+    switch (target.kind) {
+      case NodeKind.PropertyAccess:
+      case NodeKind.ElementAccess:
+        return replacement;
+      case NodeKind.Assertion: {
+        let assertion = <AssertionExpression>target;
+        if (assertion.assertionKind == AssertionKind.NonNull) {
+          return Node.createAssertionExpression(
+            AssertionKind.NonNull,
+            this.replaceCompoundAssignmentSideEffectCacheTarget(assertion.expression, replacement),
+            null,
+            assertion.range
+          );
+        }
+        return target;
+      }
+      case NodeKind.Comma: {
+        let comma = <CommaExpression>target;
+        let expressions = comma.expressions;
+        let cloned = new Array<Expression>(expressions.length);
+        for (let i = 0, k = expressions.length - 1; i < k; ++i) {
+          cloned[i] = unchecked(expressions[i]);
+        }
+        cloned[assert(expressions.length) - 1] = this.replaceCompoundAssignmentSideEffectCacheTarget(
+          expressions[assert(expressions.length) - 1],
+          replacement
+        );
+        return Node.createCommaExpression(cloned, comma.range);
+      }
+      default:
+        return target;
+    }
+  }
+
+  private wrapCompoundAssignmentCacheSetup(setupExprs: ExpressionRef[] | null, target: Expression): Expression {
+    if (!setupExprs || !setupExprs.length) return target;
+    let range = target.range;
+    let expressions = new Array<Expression>(setupExprs.length + 1);
+    for (let i = 0, k = setupExprs.length; i < k; ++i) {
+      expressions[i] = Node.createCompiledExpression(unchecked(setupExprs[i]), Type.void, range);
+    }
+    expressions[setupExprs.length] = target;
+    return Node.createCommaExpression(expressions, range);
   }
 
   private expressionHasSideEffects(expression: Expression): bool {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -5273,7 +5273,71 @@ export class Compiler extends DiagnosticEmitter {
     while (expression.kind == NodeKind.Parenthesized) {
       expression = (<ParenthesizedExpression>expression).expression;
     }
-    return expression.kind != NodeKind.Identifier;
+    switch (expression.kind) {
+      case NodeKind.Call:
+      case NodeKind.New:
+      case NodeKind.UnaryPostfix:
+        return true;
+      case NodeKind.UnaryPrefix: {
+        let unaryPrefix = <UnaryPrefixExpression>expression;
+        switch (unaryPrefix.operator) {
+          case Token.Plus_Plus:
+          case Token.Minus_Minus:
+          case Token.Delete:
+          case Token.Await:
+          case Token.Yield:
+            return true;
+          default:
+            return this.expressionHasSideEffects(unaryPrefix.operand);
+        }
+      }
+      case NodeKind.Assertion:
+        return this.expressionHasSideEffects((<AssertionExpression>expression).expression);
+      case NodeKind.PropertyAccess:
+        return this.expressionHasSideEffects((<PropertyAccessExpression>expression).expression);
+      case NodeKind.ElementAccess: {
+        let access = <ElementAccessExpression>expression;
+        return this.expressionHasSideEffects(access.expression)
+            || this.expressionHasSideEffects(access.elementExpression);
+      }
+      case NodeKind.Comma: {
+        let expressions = (<CommaExpression>expression).expressions;
+        for (let i = 0, k = expressions.length; i < k; ++i) {
+          if (this.expressionHasSideEffects(unchecked(expressions[i]))) return true;
+        }
+        return false;
+      }
+      case NodeKind.Ternary: {
+        let ternary = <TernaryExpression>expression;
+        return this.expressionHasSideEffects(ternary.condition)
+            || this.expressionHasSideEffects(ternary.ifThen)
+            || this.expressionHasSideEffects(ternary.ifElse);
+      }
+      case NodeKind.Binary: {
+        let binary = <BinaryExpression>expression;
+        switch (binary.operator) {
+          case Token.Equals:
+          case Token.Plus_Equals:
+          case Token.Minus_Equals:
+          case Token.Asterisk_Equals:
+          case Token.Asterisk_Asterisk_Equals:
+          case Token.Slash_Equals:
+          case Token.Percent_Equals:
+          case Token.LessThan_LessThan_Equals:
+          case Token.GreaterThan_GreaterThan_Equals:
+          case Token.GreaterThan_GreaterThan_GreaterThan_Equals:
+          case Token.Ampersand_Equals:
+          case Token.Bar_Equals:
+          case Token.Caret_Equals:
+            return true;
+          default:
+            return this.expressionHasSideEffects(binary.left)
+                || this.expressionHasSideEffects(binary.right);
+        }
+      }
+      default:
+        return false;
+    }
   }
 
   makeLt(leftExpr: ExpressionRef, rightExpr: ExpressionRef, type: Type): ExpressionRef {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -476,6 +476,8 @@ export class Compiler extends DiagnosticEmitter {
   hasCustomFunctionExports: bool = false;
   /** Whether the module would use the exported runtime to lift/lower. */
   desiresExportRuntime: bool = false;
+  /** Unique suffix for synthesized scoped locals used by compound assignments. */
+  private compoundAssignmentTempId: i32 = 0;
 
   /** Compiles a {@link Program} to a {@link Module} using the specified options. */
   static compile(program: Program): Module {
@@ -4473,7 +4475,121 @@ export class Compiler extends DiagnosticEmitter {
         expr = this.makeAnd(leftExpr, rightExpr, commonType);
         break;
       }
-      case Token.Bar_Equals: compound = true;
+      case Token.Bar_Equals: {
+        compound = true;
+        let assignmentLeft = left;
+        let setupExprs: ExpressionRef[] | null = null;
+        if (this.needsCompoundAssignmentSideEffectCache(left)) {
+          let flow = this.currentFlow;
+          if (left.kind == NodeKind.PropertyAccess) {
+            let access = <PropertyAccessExpression>left;
+            let receiverExpression = access.expression;
+            if (this.expressionHasSideEffects(receiverExpression)) {
+              let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
+              let receiverType = this.currentType;
+              let receiverTemp = flow.getTempLocal(receiverType);
+              let receiverName = this.makeCompoundAssignmentTempName(flow);
+              flow.addScopedAlias(receiverName, receiverType, receiverTemp.index);
+              flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
+              setupExprs = [ module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged) ];
+              assignmentLeft = Node.createPropertyAccessExpression(
+                Node.createIdentifierExpression(receiverName, receiverExpression.range),
+                access.property,
+                access.range
+              );
+            }
+          } else {
+            let access = <ElementAccessExpression>left;
+            let receiverExpression = access.expression;
+            let elementExpression = access.elementExpression;
+            let receiverName: string | null = null;
+            let elementName: string | null = null;
+
+            if (this.expressionHasSideEffects(receiverExpression)) {
+              let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
+              let receiverType = this.currentType;
+              let receiverTemp = flow.getTempLocal(receiverType);
+              receiverName = this.makeCompoundAssignmentTempName(flow);
+              flow.addScopedAlias(receiverName, receiverType, receiverTemp.index);
+              flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
+              if (!setupExprs) setupExprs = [];
+              setupExprs.push(module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged));
+            }
+
+            if (this.expressionHasSideEffects(elementExpression)) {
+              let elementExpr = this.compileExpression(elementExpression, Type.auto);
+              let elementType = this.currentType;
+              let elementTemp = flow.getTempLocal(elementType);
+              elementName = this.makeCompoundAssignmentTempName(flow);
+              flow.addScopedAlias(elementName, elementType, elementTemp.index);
+              flow.setLocalFlag(elementTemp.index, LocalFlags.Initialized);
+              if (!setupExprs) setupExprs = [];
+              setupExprs.push(module.local_set(elementTemp.index, elementExpr, elementType.isManaged));
+            }
+
+            assignmentLeft = Node.createElementAccessExpression(
+              receiverName
+                ? Node.createIdentifierExpression(receiverName, receiverExpression.range)
+                : receiverExpression,
+              elementName
+                ? Node.createIdentifierExpression(elementName, elementExpression.range)
+                : elementExpression,
+              access.range
+            );
+          }
+        }
+
+        leftExpr = this.compileExpression(assignmentLeft, contextualType.intType);
+        leftType = this.currentType;
+        if (setupExprs) {
+          let wrappedExprs = setupExprs;
+          wrappedExprs.push(leftExpr);
+          leftExpr = module.block(null, wrappedExprs, leftType.toRef());
+        }
+
+        // check operator overload
+        let classReference = leftType.getClassOrWrapper(this.program);
+        if (classReference) {
+          let overload = classReference.lookupOverload(OperatorKind.BitwiseOr);
+          if (overload) {
+            expr = this.compileBinaryOverload(overload, assignmentLeft, leftExpr, leftType, right, expression);
+            break;
+          }
+        }
+
+        if (!leftType.isIntegerValue) {
+          this.error(
+            DiagnosticCode.The_0_operator_cannot_be_applied_to_type_1,
+            expression.range, "|", leftType.toString()
+          );
+          return module.unreachable();
+        }
+        rightExpr = this.compileExpression(right, leftType, Constraints.ConvImplicit);
+        rightType = commonType = this.currentType;
+        expr = this.makeOr(leftExpr, rightExpr, commonType);
+
+        let resolver = this.resolver;
+        let target = resolver.lookupExpression(assignmentLeft, this.currentFlow);
+        if (!target) return module.unreachable();
+        let targetType = resolver.getTypeOfElement(target);
+        if (!targetType) targetType = Type.void;
+        if (!this.currentType.isStrictlyAssignableTo(targetType)) {
+          this.error(
+            DiagnosticCode.Type_0_is_not_assignable_to_type_1,
+            expression.range, this.currentType.toString(), targetType.toString()
+          );
+          return module.unreachable();
+        }
+        return this.makeAssignment(
+          target,
+          expr,
+          this.currentType,
+          right,
+          resolver.currentThisExpression,
+          resolver.currentElementExpression,
+          contextualType != Type.void
+        );
+      }
       case Token.Bar: {
         leftExpr = this.compileExpression(left, contextualType.intType);
         leftType = this.currentType;
@@ -4788,6 +4904,95 @@ export class Compiler extends DiagnosticEmitter {
       resolver.currentElementExpression,
       contextualType != Type.void
     );
+  }
+
+  private makeCompoundAssignmentTempName(flow: Flow): string {
+    let name: string;
+    do {
+      let id = this.compoundAssignmentTempId++;
+      name = "__as_or_assign_tmp" + id.toString();
+    } while (flow.lookup(name));
+    return name;
+  }
+
+  private needsCompoundAssignmentSideEffectCache(target: Expression): bool {
+    if (target.kind == NodeKind.PropertyAccess) {
+      return this.expressionHasSideEffects((<PropertyAccessExpression>target).expression);
+    }
+    if (target.kind == NodeKind.ElementAccess) {
+      let access = <ElementAccessExpression>target;
+      return this.expressionHasSideEffects(access.expression)
+          || this.expressionHasSideEffects(access.elementExpression);
+    }
+    return false;
+  }
+
+  private expressionHasSideEffects(expression: Expression): bool {
+    while (expression.kind == NodeKind.Parenthesized) {
+      expression = (<ParenthesizedExpression>expression).expression;
+    }
+    switch (expression.kind) {
+      case NodeKind.Call:
+      case NodeKind.New:
+      case NodeKind.UnaryPostfix:
+      case NodeKind.Class:
+      case NodeKind.Function:
+      case NodeKind.Compiled:
+        return true;
+      case NodeKind.UnaryPrefix: {
+        let unary = <UnaryPrefixExpression>expression;
+        if (unary.operator == Token.Plus_Plus || unary.operator == Token.Minus_Minus) {
+          return true;
+        }
+        return this.expressionHasSideEffects(unary.operand);
+      }
+      case NodeKind.Binary: {
+        let binary = <BinaryExpression>expression;
+        switch (binary.operator) {
+          case Token.Equals:
+          case Token.Plus_Equals:
+          case Token.Minus_Equals:
+          case Token.Asterisk_Equals:
+          case Token.Asterisk_Asterisk_Equals:
+          case Token.Slash_Equals:
+          case Token.Percent_Equals:
+          case Token.LessThan_LessThan_Equals:
+          case Token.GreaterThan_GreaterThan_Equals:
+          case Token.GreaterThan_GreaterThan_GreaterThan_Equals:
+          case Token.Ampersand_Equals:
+          case Token.Bar_Equals:
+          case Token.Caret_Equals:
+            return true;
+          default:
+            return this.expressionHasSideEffects(binary.left)
+                || this.expressionHasSideEffects(binary.right);
+        }
+      }
+      case NodeKind.Assertion:
+        return this.expressionHasSideEffects((<AssertionExpression>expression).expression);
+      case NodeKind.Comma: {
+        let expressions = (<CommaExpression>expression).expressions;
+        for (let i = 0, k = expressions.length; i < k; ++i) {
+          if (this.expressionHasSideEffects(unchecked(expressions[i]))) return true;
+        }
+        return false;
+      }
+      case NodeKind.ElementAccess: {
+        let access = <ElementAccessExpression>expression;
+        return this.expressionHasSideEffects(access.expression)
+            || this.expressionHasSideEffects(access.elementExpression);
+      }
+      case NodeKind.PropertyAccess:
+        return this.expressionHasSideEffects((<PropertyAccessExpression>expression).expression);
+      case NodeKind.Ternary: {
+        let ternary = <TernaryExpression>expression;
+        return this.expressionHasSideEffects(ternary.condition)
+            || this.expressionHasSideEffects(ternary.ifThen)
+            || this.expressionHasSideEffects(ternary.ifElse);
+      }
+      default:
+        return false;
+    }
   }
 
   makeLt(leftExpr: ExpressionRef, rightExpr: ExpressionRef, type: Type): ExpressionRef {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -428,30 +428,60 @@ class CompoundAssignmentCacheContext {
   target: Element;
   leftExpr: ExpressionRef;
   leftType: Type;
-  assignmentThisExpression: Expression | null;
-  assignmentElementExpression: Expression | null;
-  assignmentThisExpr: ExpressionRef;
-  assignmentElementExpr: ExpressionRef;
+  assignmentAccessContext: AssignmentAccessContext;
   setupPrefixExprs: ExpressionRef[] | null;
 
   constructor(
     target: Element,
     leftExpr: ExpressionRef,
     leftType: Type,
-    assignmentThisExpression: Expression | null,
-    assignmentElementExpression: Expression | null,
-    assignmentThisExpr: ExpressionRef,
-    assignmentElementExpr: ExpressionRef,
+    assignmentAccessContext: AssignmentAccessContext,
     setupPrefixExprs: ExpressionRef[] | null
   ) {
     this.target = target;
     this.leftExpr = leftExpr;
     this.leftType = leftType;
-    this.assignmentThisExpression = assignmentThisExpression;
-    this.assignmentElementExpression = assignmentElementExpression;
-    this.assignmentThisExpr = assignmentThisExpr;
-    this.assignmentElementExpr = assignmentElementExpr;
+    this.assignmentAccessContext = assignmentAccessContext;
     this.setupPrefixExprs = setupPrefixExprs;
+  }
+}
+
+class AssignmentAccessContext {
+  thisExpression: Expression | null;
+  indexExpression: Expression | null;
+  thisExpr: ExpressionRef;
+  indexExpr: ExpressionRef;
+
+  constructor(
+    thisExpression: Expression | null,
+    indexExpression: Expression | null,
+    thisExpr: ExpressionRef = 0,
+    indexExpr: ExpressionRef = 0
+  ) {
+    this.thisExpression = thisExpression;
+    this.indexExpression = indexExpression;
+    this.thisExpr = thisExpr;
+    this.indexExpr = indexExpr;
+  }
+
+  resolveThisExpr(compiler: Compiler, targetType: Type): ExpressionRef {
+    if (this.thisExpr) return this.thisExpr;
+    let thisExpression = this.thisExpression;
+    if (!thisExpression) return 0;
+    this.thisExpr = compiler.compileExpression(
+      thisExpression,
+      targetType,
+      Constraints.ConvImplicit | Constraints.IsThis
+    );
+    return this.thisExpr;
+  }
+
+  resolveIndexExpr(compiler: Compiler, targetType: Type): ExpressionRef {
+    if (this.indexExpr) return this.indexExpr;
+    let indexExpression = this.indexExpression;
+    if (!indexExpression) return 0;
+    this.indexExpr = compiler.compileExpression(indexExpression, targetType, Constraints.ConvImplicit);
+    return this.indexExpr;
   }
 }
 
@@ -4958,21 +4988,17 @@ export class Compiler extends DiagnosticEmitter {
     if (!compound) return expr;
     let resolver = this.resolver;
     let target: Element | null;
-    let thisExpression: Expression | null;
-    let elementExpression: Expression | null;
-    let thisExpr: ExpressionRef = 0;
-    let indexExpr: ExpressionRef = 0;
+    let assignmentAccessContext: AssignmentAccessContext;
     if (compoundAssignmentCacheContext) {
       target = compoundAssignmentCacheContext.target;
-      thisExpression = compoundAssignmentCacheContext.assignmentThisExpression;
-      elementExpression = compoundAssignmentCacheContext.assignmentElementExpression;
-      thisExpr = compoundAssignmentCacheContext.assignmentThisExpr;
-      indexExpr = compoundAssignmentCacheContext.assignmentElementExpr;
+      assignmentAccessContext = compoundAssignmentCacheContext.assignmentAccessContext;
     } else {
       target = resolver.lookupExpression(left, this.currentFlow);
       if (!target) return module.unreachable();
-      thisExpression = resolver.currentThisExpression;
-      elementExpression = resolver.currentElementExpression;
+      assignmentAccessContext = new AssignmentAccessContext(
+        resolver.currentThisExpression,
+        resolver.currentElementExpression
+      );
     }
     target = assert(target);
     let targetType = resolver.getTypeOfElement(target);
@@ -4980,7 +5006,9 @@ export class Compiler extends DiagnosticEmitter {
     if (!this.currentType.isStrictlyAssignableTo(targetType)) {
       this.error(
         DiagnosticCode.Type_0_is_not_assignable_to_type_1,
-        expression.range, this.currentType.toString(), targetType.toString()
+        expression.range,
+        this.currentType.toString(),
+        targetType.toString()
       );
       return module.unreachable();
     }
@@ -4989,19 +5017,33 @@ export class Compiler extends DiagnosticEmitter {
       expr,
       this.currentType,
       right,
-      thisExpression,
-      elementExpression,
-      contextualType != Type.void,
-      thisExpr,
-      indexExpr
+      assignmentAccessContext,
+      contextualType != Type.void
     );
     return compoundAssignmentCacheContext
-      ? this.prependSetupPrefixExpressions(compoundAssignmentCacheContext.setupPrefixExprs, assignmentExpr, contextualType != Type.void)
+      ? this.prependSetupPrefixExpressions(
+          compoundAssignmentCacheContext.setupPrefixExprs,
+          assignmentExpr,
+          contextualType != Type.void
+        )
       : assignmentExpr;
   }
 
   private prepareCompoundAssignmentCache(
     cacheTarget: Expression,
+    contextualType: Type
+  ): CompoundAssignmentCacheContext | null {
+    if (cacheTarget.kind == NodeKind.PropertyAccess) {
+      return this.prepareCompoundAssignmentPropertyAccessCache(<PropertyAccessExpression>cacheTarget, contextualType);
+    }
+    if (cacheTarget.kind == NodeKind.ElementAccess) {
+      return this.prepareCompoundAssignmentElementAccessCache(<ElementAccessExpression>cacheTarget, contextualType);
+    }
+    return null;
+  }
+
+  private prepareCompoundAssignmentPropertyAccessCache(
+    cacheTarget: PropertyAccessExpression,
     contextualType: Type
   ): CompoundAssignmentCacheContext | null {
     let module = this.module;
@@ -5011,60 +5053,14 @@ export class Compiler extends DiagnosticEmitter {
     if (!target) return null;
 
     let setupPrefixExprs: ExpressionRef[] | null = null;
-    let assignmentThisExpression: Expression | null = null;
-    let assignmentElementExpression: Expression | null = null;
+    let thisExpression: Expression = cacheTarget.expression;
     let assignmentThisExpr: ExpressionRef = 0;
-    let assignmentElementExpr: ExpressionRef = 0;
-    let cachedThisLocal: Local | null = null;
-    let cachedThisType: Type = Type.void;
-    let cachedElementLocal: Local | null = null;
-    let cachedElementType: Type = Type.void;
-    let readThisExpression: Expression | null = null;
-    let readElementExpression: Expression | null = null;
-
-    if (cacheTarget.kind == NodeKind.PropertyAccess) {
-      let access = <PropertyAccessExpression>cacheTarget;
-      let receiverExpression = access.expression;
-      assignmentThisExpression = receiverExpression;
-      let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
-      let receiverType = this.currentType;
-      let receiverTemp = flow.getTempLocal(receiverType);
-      cachedThisLocal = receiverTemp;
-      cachedThisType = receiverType;
-      flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
-      setupPrefixExprs = [ module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged) ];
-    } else {
-      let access = <ElementAccessExpression>cacheTarget;
-      let receiverExpression = access.expression;
-      let elementExpression = access.elementExpression;
-
-      readThisExpression = receiverExpression;
-      readElementExpression = elementExpression;
-      assignmentThisExpression = receiverExpression;
-      assignmentElementExpression = elementExpression;
-
-      if (this.expressionHasSideEffects(receiverExpression)) {
-        let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
-        let receiverType = this.currentType;
-        let receiverTemp = flow.getTempLocal(receiverType);
-        cachedThisLocal = receiverTemp;
-        cachedThisType = receiverType;
-        flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
-        if (!setupPrefixExprs) setupPrefixExprs = [];
-        setupPrefixExprs.push(module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged));
-      }
-
-      if (this.expressionHasSideEffects(elementExpression)) {
-        let elementExpr = this.compileExpression(elementExpression, Type.auto);
-        let elementType = this.currentType;
-        let elementTemp = flow.getTempLocal(elementType);
-        cachedElementLocal = elementTemp;
-        cachedElementType = elementType;
-        flow.setLocalFlag(elementTemp.index, LocalFlags.Initialized);
-        if (!setupPrefixExprs) setupPrefixExprs = [];
-        setupPrefixExprs.push(module.local_set(elementTemp.index, elementExpr, elementType.isManaged));
-      }
-    }
+    let receiverExpr = this.compileExpression(thisExpression, Type.auto);
+    let receiverType = this.currentType;
+    let cachedThisLocal = flow.getTempLocal(receiverType);
+    let cachedThisType = receiverType;
+    flow.setLocalFlag(cachedThisLocal.index, LocalFlags.Initialized);
+    setupPrefixExprs = [module.local_set(cachedThisLocal.index, receiverExpr, receiverType.isManaged)];
 
     let leftExpr: ExpressionRef;
     let leftType: Type;
@@ -5073,49 +5069,88 @@ export class Compiler extends DiagnosticEmitter {
         let propertyInstance = resolver.resolveProperty(<PropertyPrototype>target);
         if (!propertyInstance) return null;
         target = propertyInstance;
-        // fall-through
       }
+      // falls through
       case ElementKind.Property: {
         let getterInstance = (<Property>target).getterInstance;
         if (!getterInstance) return null;
         if (getterInstance.is(CommonFlags.Instance)) {
           let thisType = assert(getterInstance.signature.thisType);
-          if (cachedThisLocal) {
-            let thisRef = cachedThisType.toRef();
-            let thisArg = this.convertExpression(
-              module.local_get(cachedThisLocal.index, thisRef),
-              cachedThisType,
-              thisType,
-              false,
-              cacheTarget
-            );
-            assignmentThisExpr = this.convertExpression(
-              module.local_get(cachedThisLocal.index, thisRef),
-              cachedThisType,
-              thisType,
-              false,
-              cacheTarget
-            );
-            leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget, thisArg);
-          } else {
-            let thisArg = this.compileExpression(
-              assert(readThisExpression),
-              thisType,
-              Constraints.ConvImplicit | Constraints.IsThis
-            );
-            assignmentThisExpr = this.compileExpression(
-              assert(assignmentThisExpression),
-              thisType,
-              Constraints.ConvImplicit | Constraints.IsThis
-            );
-            leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget, thisArg);
-          }
+          let thisRef = cachedThisType.toRef();
+          let thisArg = this.convertExpression(
+            module.local_get(cachedThisLocal.index, thisRef),
+            cachedThisType,
+            thisType,
+            false,
+            cacheTarget
+          );
+          assignmentThisExpr = this.convertExpression(
+            module.local_get(cachedThisLocal.index, thisRef),
+            cachedThisType,
+            thisType,
+            false,
+            cacheTarget
+          );
+          leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget, thisArg);
         } else {
           leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget);
         }
         leftType = this.currentType;
         break;
       }
+      default:
+        return null;
+    }
+
+    let assignmentAccessContext = new AssignmentAccessContext(thisExpression, null, assignmentThisExpr, 0);
+    return new CompoundAssignmentCacheContext(target, leftExpr, leftType, assignmentAccessContext, setupPrefixExprs);
+  }
+
+  private prepareCompoundAssignmentElementAccessCache(
+    cacheTarget: ElementAccessExpression,
+    contextualType: Type
+  ): CompoundAssignmentCacheContext | null {
+    let module = this.module;
+    let flow = this.currentFlow;
+    let resolver = this.resolver;
+    let target = resolver.lookupExpression(cacheTarget, flow);
+    if (!target) return null;
+
+    let setupPrefixExprs: ExpressionRef[] | null = null;
+    let thisExpression: Expression = cacheTarget.expression;
+    let indexExpression: Expression = cacheTarget.elementExpression;
+    let assignmentThisExpr: ExpressionRef = 0;
+    let assignmentElementExpr: ExpressionRef = 0;
+    let cachedThisLocal: Local | null = null;
+    let cachedThisType: Type = Type.void;
+    let cachedElementLocal: Local | null = null;
+    let cachedElementType: Type = Type.void;
+
+    if (this.expressionHasSideEffects(thisExpression)) {
+      let receiverExpr = this.compileExpression(thisExpression, Type.auto);
+      let receiverType = this.currentType;
+      let receiverTemp = flow.getTempLocal(receiverType);
+      cachedThisLocal = receiverTemp;
+      cachedThisType = receiverType;
+      flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
+      if (!setupPrefixExprs) setupPrefixExprs = [];
+      setupPrefixExprs.push(module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged));
+    }
+
+    if (this.expressionHasSideEffects(indexExpression)) {
+      let elementExpr = this.compileExpression(indexExpression, Type.auto);
+      let elementType = this.currentType;
+      let elementTemp = flow.getTempLocal(elementType);
+      cachedElementLocal = elementTemp;
+      cachedElementType = elementType;
+      flow.setLocalFlag(elementTemp.index, LocalFlags.Initialized);
+      if (!setupPrefixExprs) setupPrefixExprs = [];
+      setupPrefixExprs.push(module.local_set(elementTemp.index, elementExpr, elementType.isManaged));
+    }
+
+    let leftExpr: ExpressionRef;
+    let leftType: Type;
+    switch (target.kind) {
       case ElementKind.IndexSignature: {
         let parent = (<IndexSignature>target).parent;
         assert(parent.kind == ElementKind.Class);
@@ -5150,12 +5185,12 @@ export class Compiler extends DiagnosticEmitter {
           );
         } else {
           thisArg = this.compileExpression(
-            assert(readThisExpression),
+            assert(thisExpression),
             thisType,
             Constraints.ConvImplicit | Constraints.IsThis
           );
           assignmentThisExpr = this.compileExpression(
-            assert(assignmentThisExpression),
+            assert(thisExpression),
             thisType,
             Constraints.ConvImplicit | Constraints.IsThis
           );
@@ -5179,38 +5214,25 @@ export class Compiler extends DiagnosticEmitter {
             cacheTarget
           );
         } else {
-          indexArg = this.compileExpression(
-            assert(readElementExpression),
-            indexType,
-            Constraints.ConvImplicit
-          );
-          assignmentElementExpr = this.compileExpression(
-            assert(assignmentElementExpression),
-            indexType,
-            Constraints.ConvImplicit
-          );
+          indexArg = this.compileExpression(assert(indexExpression), indexType, Constraints.ConvImplicit);
+          assignmentElementExpr = this.compileExpression(assert(indexExpression), indexType, Constraints.ConvImplicit);
         }
-        leftExpr = this.makeCallDirect(getterInstance, [ thisArg, indexArg ], cacheTarget);
+        leftExpr = this.makeCallDirect(getterInstance, [thisArg, indexArg], cacheTarget);
         leftType = this.currentType;
         break;
       }
-      default: {
-        leftExpr = this.compileExpression(cacheTarget, contextualType);
-        leftType = this.currentType;
-        break;
-      }
+      default:
+        return null;
     }
 
-    return new CompoundAssignmentCacheContext(
-      target,
-      leftExpr,
-      leftType,
-      assignmentThisExpression,
-      assignmentElementExpression,
+    let assignmentAccessContext = new AssignmentAccessContext(
+      thisExpression,
+      indexExpression,
       assignmentThisExpr,
-      assignmentElementExpr,
-      setupPrefixExprs
+      assignmentElementExpr
     );
+
+    return new CompoundAssignmentCacheContext(target, leftExpr, leftType, assignmentAccessContext, setupPrefixExprs);
   }
 
   private prependSetupPrefixExpressions(
@@ -5232,15 +5254,14 @@ export class Compiler extends DiagnosticEmitter {
   }
 
   private needsCompoundAssignmentSideEffectCache(target: Expression): bool {
-    let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(target);
-    if (!cacheTarget) return false;
-    if (cacheTarget.kind == NodeKind.PropertyAccess) {
-      return this.expressionHasSideEffects((<PropertyAccessExpression>cacheTarget).expression);
+    if (target.kind == NodeKind.PropertyAccess) {
+      return this.expressionHasSideEffects((<PropertyAccessExpression>target).expression);
     }
-    if (cacheTarget.kind == NodeKind.ElementAccess) {
-      let access = <ElementAccessExpression>cacheTarget;
-      return this.expressionHasSideEffects(access.expression)
-          || this.expressionHasSideEffects(access.elementExpression);
+    if (target.kind == NodeKind.ElementAccess) {
+      let access = <ElementAccessExpression>target;
+      return (
+        this.expressionHasSideEffects(access.expression) || this.expressionHasSideEffects(access.elementExpression)
+      );
     }
     return false;
   }
@@ -5269,6 +5290,12 @@ export class Compiler extends DiagnosticEmitter {
     }
   }
 
+  /**
+   * Returns whether evaluating an expression has observable effects beyond producing a value.
+   *
+   * In this context, a side effect means behavior that must not be duplicated when lowering
+   * compound assignments, such as state mutation (e.g. ++, --, assignment), calls/allocation.
+   */
   private expressionHasSideEffects(expression: Expression): bool {
     while (expression.kind == NodeKind.Parenthesized) {
       expression = (<ParenthesizedExpression>expression).expression;
@@ -6329,11 +6356,8 @@ export class Compiler extends DiagnosticEmitter {
       this.convertExpression(valueExpr, valueType, targetType, false, valueExpression),
       targetType,
       valueExpression,
-      thisExpression,
-      elementExpression,
-      contextualType != Type.void,
-      0,
-      0
+      new AssignmentAccessContext(thisExpression, elementExpression),
+      contextualType != Type.void
     );
   }
 
@@ -6347,16 +6371,10 @@ export class Compiler extends DiagnosticEmitter {
     valueType: Type,
     /** Expression reference. Has already been compiled to `valueExpr`. */
     valueExpression: Expression,
-    /** `this` expression reference if a field or property set. */
-    thisExpression: Expression | null,
-    /** Index expression reference if an indexed set. */
-    indexExpression: Expression | null,
+    /** Assignment access context for property/index targets. */
+    accessContext: AssignmentAccessContext,
     /** Whether to tee the value. */
-    tee: bool,
-    /** Precompiled `this` expression reference if available. */
-    thisExpr: ExpressionRef,
-    /** Precompiled index expression reference if available. */
-    indexExpr: ExpressionRef,
+    tee: bool
   ): ExpressionRef {
     let module = this.module;
     let flow = this.currentFlow;
@@ -6412,6 +6430,7 @@ export class Compiler extends DiagnosticEmitter {
             }
           }
           // Mark initialized fields in constructors
+          let thisExpression = accessContext.thisExpression;
           thisExpression = assert(thisExpression);
           if (isConstructor && thisExpression.kind == NodeKind.This) {
             flow.setThisFieldFlag(propertyInstance, FieldFlags.Initialized);
@@ -6429,13 +6448,7 @@ export class Compiler extends DiagnosticEmitter {
         assert(setterInstance.signature.returnType == Type.void);
         if (propertyInstance.is(CommonFlags.Instance)) {
           let thisType = assert(setterInstance.signature.thisType);
-          if (!thisExpr) {
-            thisExpr = this.compileExpression(
-              assert(thisExpression),
-              thisType,
-              Constraints.ConvImplicit | Constraints.IsThis
-            );
-          }
+          let thisExpr = accessContext.resolveThisExpr(this, thisType);
           if (!tee) return this.makeCallDirect(setterInstance, [ thisExpr, valueExpr ], valueExpression);
           let tempLocal = flow.getTempLocal(valueType);
           let valueTypeRef = valueType.toRef();
@@ -6488,13 +6501,7 @@ export class Compiler extends DiagnosticEmitter {
         }
         assert(setterInstance.signature.parameterTypes.length == 2);
         let thisType = classInstance.type;
-        if (!thisExpr) {
-          thisExpr = this.compileExpression(
-            assert(thisExpression),
-            thisType,
-            Constraints.ConvImplicit | Constraints.IsThis
-          );
-        }
+        let thisExpr = accessContext.resolveThisExpr(this, thisType);
         let setterIndexType = setterInstance.signature.parameterTypes[0];
         let getterIndexType = getterInstance.signature.parameterTypes[0];
         if (!setterIndexType.equals(getterIndexType)) {
@@ -6507,15 +6514,8 @@ export class Compiler extends DiagnosticEmitter {
           this.currentType = tee ? getterInstance.signature.returnType : Type.void;
           return module.unreachable();
         }
-        let elementExpr: ExpressionRef;
-        let elementType: Type;
-        if (indexExpr) {
-          elementExpr = indexExpr;
-          elementType = getterIndexType;
-        } else {
-          elementExpr = this.compileExpression(assert(indexExpression), setterIndexType, Constraints.ConvImplicit);
-          elementType = this.currentType;
-        }
+        let elementExpr = accessContext.resolveIndexExpr(this, setterIndexType);
+        let elementType = this.currentType;
         if (tee) {
           let tempTarget = flow.getTempLocal(thisType);
           let tempElement = flow.getTempLocal(elementType);
@@ -10056,11 +10056,8 @@ export class Compiler extends DiagnosticEmitter {
         expr,
         this.currentType,
         expression.operand,
-        resolver.currentThisExpression,
-        resolver.currentElementExpression,
-        false,
-        0,
-        0
+        new AssignmentAccessContext(resolver.currentThisExpression, resolver.currentElementExpression),
+        false
       );
     }
 
@@ -10070,11 +10067,8 @@ export class Compiler extends DiagnosticEmitter {
       expr, // includes a tee of getValue to tempLocal
       this.currentType,
       expression.operand,
-      resolver.currentThisExpression,
-      resolver.currentElementExpression,
-      false,
-      0,
-      0
+      new AssignmentAccessContext(resolver.currentThisExpression, resolver.currentElementExpression),
+      false
     );
 
     this.currentType = tempLocal.type;
@@ -10436,11 +10430,8 @@ export class Compiler extends DiagnosticEmitter {
       expr,
       this.currentType,
       expression.operand,
-      resolver.currentThisExpression,
-      resolver.currentElementExpression,
-      contextualType != Type.void,
-      0,
-      0
+      new AssignmentAccessContext(resolver.currentThisExpression, resolver.currentElementExpression),
+      contextualType != Type.void
     );
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -4507,7 +4507,7 @@ export class Compiler extends DiagnosticEmitter {
       case Token.Bar_Equals: {
         let cacheContext: CompoundAssignmentCacheContext | null = null;
         let cacheTarget = this.getCompoundAssignmentSideEffectCacheTarget(left);
-        if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(left)) {
+        if (cacheTarget && this.needsCompoundAssignmentSideEffectCache(cacheTarget)) {
           cacheContext = this.prepareCompoundAssignmentCache(cacheTarget, contextualType.intType);
           if (!cacheContext) return module.unreachable();
           leftExpr = cacheContext.leftExpr;
@@ -4915,31 +4915,31 @@ export class Compiler extends DiagnosticEmitter {
     let assignmentElementExpression: Expression | null = null;
     let assignmentThisExpr: ExpressionRef = 0;
     let assignmentElementExpr: ExpressionRef = 0;
+    let cachedThisLocal: Local | null = null;
+    let cachedThisType: Type = Type.void;
+    let cachedElementLocal: Local | null = null;
+    let cachedElementType: Type = Type.void;
     let readThisExpression: Expression | null = null;
     let readElementExpression: Expression | null = null;
 
     if (cacheTarget.kind == NodeKind.PropertyAccess) {
       let access = <PropertyAccessExpression>cacheTarget;
       let receiverExpression = access.expression;
+      assignmentThisExpression = receiverExpression;
       let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
       let receiverType = this.currentType;
       let receiverTemp = flow.getTempLocal(receiverType);
+      cachedThisLocal = receiverTemp;
+      cachedThisType = receiverType;
       flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
       setupPrefixExprs = [ module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged) ];
-      let receiverCachedExpression = Node.createCompiledExpression(
-        module.local_get(receiverTemp.index, receiverType.toRef()),
-        receiverType,
-        receiverExpression.range
-      );
-      readThisExpression = receiverCachedExpression;
-      assignmentThisExpression = receiverCachedExpression;
     } else {
       let access = <ElementAccessExpression>cacheTarget;
       let receiverExpression = access.expression;
       let elementExpression = access.elementExpression;
-      let receiverForRead: Expression = receiverExpression;
-      let elementForRead: Expression = elementExpression;
 
+      readThisExpression = receiverExpression;
+      readElementExpression = elementExpression;
       assignmentThisExpression = receiverExpression;
       assignmentElementExpression = elementExpression;
 
@@ -4947,36 +4947,23 @@ export class Compiler extends DiagnosticEmitter {
         let receiverExpr = this.compileExpression(receiverExpression, Type.auto);
         let receiverType = this.currentType;
         let receiverTemp = flow.getTempLocal(receiverType);
+        cachedThisLocal = receiverTemp;
+        cachedThisType = receiverType;
         flow.setLocalFlag(receiverTemp.index, LocalFlags.Initialized);
         if (!setupPrefixExprs) setupPrefixExprs = [];
         setupPrefixExprs.push(module.local_set(receiverTemp.index, receiverExpr, receiverType.isManaged));
-        let receiverCachedExpression = Node.createCompiledExpression(
-          module.local_get(receiverTemp.index, receiverType.toRef()),
-          receiverType,
-          receiverExpression.range
-        );
-        receiverForRead = receiverCachedExpression;
-        assignmentThisExpression = receiverCachedExpression;
       }
 
       if (this.expressionHasSideEffects(elementExpression)) {
         let elementExpr = this.compileExpression(elementExpression, Type.auto);
         let elementType = this.currentType;
         let elementTemp = flow.getTempLocal(elementType);
+        cachedElementLocal = elementTemp;
+        cachedElementType = elementType;
         flow.setLocalFlag(elementTemp.index, LocalFlags.Initialized);
         if (!setupPrefixExprs) setupPrefixExprs = [];
         setupPrefixExprs.push(module.local_set(elementTemp.index, elementExpr, elementType.isManaged));
-        let elementCachedExpression = Node.createCompiledExpression(
-          module.local_get(elementTemp.index, elementType.toRef()),
-          elementType,
-          elementExpression.range
-        );
-        elementForRead = elementCachedExpression;
-        assignmentElementExpression = elementCachedExpression;
       }
-
-      readThisExpression = receiverForRead;
-      readElementExpression = elementForRead;
     }
 
     let leftExpr: ExpressionRef;
@@ -4992,13 +4979,37 @@ export class Compiler extends DiagnosticEmitter {
         let getterInstance = (<Property>target).getterInstance;
         if (!getterInstance) return null;
         if (getterInstance.is(CommonFlags.Instance)) {
-          let thisArg = this.compileExpression(
-            assert(readThisExpression),
-            assert(getterInstance.signature.thisType),
-            Constraints.ConvImplicit | Constraints.IsThis
-          );
-          assignmentThisExpr = thisArg;
-          leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget, thisArg);
+          let thisType = assert(getterInstance.signature.thisType);
+          if (cachedThisLocal) {
+            let thisRef = cachedThisType.toRef();
+            let thisArg = this.convertExpression(
+              module.local_get(cachedThisLocal.index, thisRef),
+              cachedThisType,
+              thisType,
+              false,
+              cacheTarget
+            );
+            assignmentThisExpr = this.convertExpression(
+              module.local_get(cachedThisLocal.index, thisRef),
+              cachedThisType,
+              thisType,
+              false,
+              cacheTarget
+            );
+            leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget, thisArg);
+          } else {
+            let thisArg = this.compileExpression(
+              assert(readThisExpression),
+              thisType,
+              Constraints.ConvImplicit | Constraints.IsThis
+            );
+            assignmentThisExpr = this.compileExpression(
+              assert(assignmentThisExpression),
+              thisType,
+              Constraints.ConvImplicit | Constraints.IsThis
+            );
+            leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget, thisArg);
+          }
         } else {
           leftExpr = this.compileCallDirect(getterInstance, [], cacheTarget);
         }
@@ -5019,18 +5030,66 @@ export class Compiler extends DiagnosticEmitter {
           );
           return null;
         }
-        let thisArg = this.compileExpression(
-          assert(readThisExpression),
-          classInstance.type,
-          Constraints.ConvImplicit | Constraints.IsThis
-        );
-        let indexArg = this.compileExpression(
-          assert(readElementExpression),
-          getterInstance.signature.parameterTypes[0],
-          Constraints.ConvImplicit
-        );
-        assignmentThisExpr = thisArg;
-        assignmentElementExpr = indexArg;
+        let thisType = classInstance.type;
+        let thisArg: ExpressionRef;
+        if (cachedThisLocal) {
+          let thisRef = cachedThisType.toRef();
+          thisArg = this.convertExpression(
+            module.local_get(cachedThisLocal.index, thisRef),
+            cachedThisType,
+            thisType,
+            false,
+            cacheTarget
+          );
+          assignmentThisExpr = this.convertExpression(
+            module.local_get(cachedThisLocal.index, thisRef),
+            cachedThisType,
+            thisType,
+            false,
+            cacheTarget
+          );
+        } else {
+          thisArg = this.compileExpression(
+            assert(readThisExpression),
+            thisType,
+            Constraints.ConvImplicit | Constraints.IsThis
+          );
+          assignmentThisExpr = this.compileExpression(
+            assert(assignmentThisExpression),
+            thisType,
+            Constraints.ConvImplicit | Constraints.IsThis
+          );
+        }
+        let indexType = getterInstance.signature.parameterTypes[0];
+        let indexArg: ExpressionRef;
+        if (cachedElementLocal) {
+          let elementRef = cachedElementType.toRef();
+          indexArg = this.convertExpression(
+            module.local_get(cachedElementLocal.index, elementRef),
+            cachedElementType,
+            indexType,
+            false,
+            cacheTarget
+          );
+          assignmentElementExpr = this.convertExpression(
+            module.local_get(cachedElementLocal.index, elementRef),
+            cachedElementType,
+            indexType,
+            false,
+            cacheTarget
+          );
+        } else {
+          indexArg = this.compileExpression(
+            assert(readElementExpression),
+            indexType,
+            Constraints.ConvImplicit
+          );
+          assignmentElementExpr = this.compileExpression(
+            assert(assignmentElementExpression),
+            indexType,
+            Constraints.ConvImplicit
+          );
+        }
         leftExpr = this.makeCallDirect(getterInstance, [ thisArg, indexArg ], cacheTarget);
         leftType = this.currentType;
         break;

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -2009,7 +2009,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2075,21 +2075,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2105,6 +2090,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -122,7 +122,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$129
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$128
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -146,7 +146,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$129
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$128
     end
     local.get $1
     i32.load offset=8
@@ -1231,7 +1231,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1248,7 +1248,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -2135,7 +2135,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2201,21 +2201,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2231,6 +2216,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -1351,7 +1351,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1368,7 +1368,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -2160,7 +2160,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$284
+   block $__inlined_func$~lib/string/String#concat$283
     local.get $1
     i32.const 20
     i32.sub
@@ -2179,7 +2179,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$284
+     br $__inlined_func$~lib/string/String#concat$283
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2893,7 +2893,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$269
+   block $__inlined_func$~lib/rt/itcms/__renew$268
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2936,7 +2936,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$269
+     br $__inlined_func$~lib/rt/itcms/__renew$268
     end
     local.get $3
     local.get $4

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -2030,7 +2030,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2096,21 +2096,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2126,6 +2111,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -156,7 +156,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$132
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$131
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -180,7 +180,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$132
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$131
    end
    local.get $0
    i32.load offset=8
@@ -1284,7 +1284,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1301,7 +1301,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -2138,7 +2138,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2204,21 +2204,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2234,6 +2219,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -1351,7 +1351,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$71
+   block $__inlined_func$~lib/rt/itcms/interrupt$70
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1368,7 +1368,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$71
+      br $__inlined_func$~lib/rt/itcms/interrupt$70
      end
      local.get $2
      i32.const 0
@@ -2160,7 +2160,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$285
+   block $__inlined_func$~lib/string/String#concat$284
     local.get $1
     i32.const 20
     i32.sub
@@ -2179,7 +2179,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$285
+     br $__inlined_func$~lib/string/String#concat$284
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2893,7 +2893,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$270
+   block $__inlined_func$~lib/rt/itcms/__renew$269
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2936,7 +2936,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$270
+     br $__inlined_func$~lib/rt/itcms/__renew$269
     end
     local.get $3
     local.get $4

--- a/tests/compiler/call-inferred.debug.wat
+++ b/tests/compiler/call-inferred.debug.wat
@@ -2035,7 +2035,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2101,21 +2101,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2131,6 +2116,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/call-inferred.release.wat
+++ b/tests/compiler/call-inferred.release.wat
@@ -118,7 +118,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$125
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$124
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -142,7 +142,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$125
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$124
     end
     local.get $1
     i32.load offset=8
@@ -1227,7 +1227,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1244,7 +1244,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/call-rest.debug.wat
+++ b/tests/compiler/call-rest.debug.wat
@@ -2032,7 +2032,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2098,21 +2098,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2128,6 +2113,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/call-rest.release.wat
+++ b/tests/compiler/call-rest.release.wat
@@ -147,7 +147,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$160
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$159
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -171,7 +171,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$160
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$159
    end
    local.get $0
    i32.load offset=8
@@ -1275,7 +1275,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1292,7 +1292,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2024,7 +2024,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$154
+   block $__inlined_func$~lib/rt/itcms/__renew$153
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2067,7 +2067,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$154
+     br $__inlined_func$~lib/rt/itcms/__renew$153
     end
     local.get $3
     local.get $4

--- a/tests/compiler/call-super.debug.wat
+++ b/tests/compiler/call-super.debug.wat
@@ -2005,7 +2005,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2071,21 +2071,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2101,6 +2086,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/call-super.release.wat
+++ b/tests/compiler/call-super.release.wat
@@ -118,7 +118,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$158
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$157
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -142,7 +142,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$158
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$157
     end
     local.get $1
     i32.load offset=8
@@ -1227,7 +1227,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1244,7 +1244,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/class-implements.debug.wat
+++ b/tests/compiler/class-implements.debug.wat
@@ -2008,7 +2008,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2074,21 +2074,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2104,6 +2089,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/class-implements.release.wat
+++ b/tests/compiler/class-implements.release.wat
@@ -167,7 +167,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$174
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$173
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -191,7 +191,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$174
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$173
     end
     local.get $1
     i32.load offset=8
@@ -1276,7 +1276,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1293,7 +1293,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2167,7 +2167,7 @@
    i32.const 0
    call $class-implements/D#constructor
    global.set $class-implements/d
-   block $__inlined_func$class-implements/D#foo@override$163 (result i32)
+   block $__inlined_func$class-implements/D#foo@override$162 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-implements/d
     local.tee $0
@@ -2179,7 +2179,7 @@
     i32.load
     i32.const 11
     i32.eq
-    br_if $__inlined_func$class-implements/D#foo@override$163
+    br_if $__inlined_func$class-implements/D#foo@override$162
     drop
     i32.const 3
    end
@@ -2224,7 +2224,7 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    global.set $class-implements/e
-   block $__inlined_func$class-implements/D#foo@override$165 (result i32)
+   block $__inlined_func$class-implements/D#foo@override$164 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-implements/e
     local.tee $0
@@ -2236,7 +2236,7 @@
     i32.load
     i32.const 11
     i32.eq
-    br_if $__inlined_func$class-implements/D#foo@override$165
+    br_if $__inlined_func$class-implements/D#foo@override$164
     drop
     i32.const 3
    end
@@ -2257,7 +2257,7 @@
    i32.store
    call $class-implements/F#constructor
    global.set $class-implements/g
-   block $__inlined_func$class-implements/D#foo@override$166 (result i32)
+   block $__inlined_func$class-implements/D#foo@override$165 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-implements/g
     local.tee $0
@@ -2269,7 +2269,7 @@
     i32.load
     i32.const 11
     i32.eq
-    br_if $__inlined_func$class-implements/D#foo@override$166
+    br_if $__inlined_func$class-implements/D#foo@override$165
     drop
     i32.const 3
    end
@@ -2289,7 +2289,7 @@
    global.get $class-implements/h
    local.tee $0
    i32.store
-   block $__inlined_func$class-implements/I#foo@override$167
+   block $__inlined_func$class-implements/I#foo@override$166
     block $default12
      block $case3
       block $case2
@@ -2305,19 +2305,19 @@
         end
         i32.const 4
         local.set $0
-        br $__inlined_func$class-implements/I#foo@override$167
+        br $__inlined_func$class-implements/I#foo@override$166
        end
        i32.const 1
        local.set $0
-       br $__inlined_func$class-implements/I#foo@override$167
+       br $__inlined_func$class-implements/I#foo@override$166
       end
       i32.const 2
       local.set $0
-      br $__inlined_func$class-implements/I#foo@override$167
+      br $__inlined_func$class-implements/I#foo@override$166
      end
      i32.const 3
      local.set $0
-     br $__inlined_func$class-implements/I#foo@override$167
+     br $__inlined_func$class-implements/I#foo@override$166
     end
     unreachable
    end
@@ -2364,7 +2364,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$class-implements/J#foo@override$169
+   block $__inlined_func$class-implements/J#foo@override$168
     block $default14
      block $case315
       block $case216
@@ -2382,15 +2382,15 @@
        end
        i32.const 4
        local.set $0
-       br $__inlined_func$class-implements/J#foo@override$169
+       br $__inlined_func$class-implements/J#foo@override$168
       end
       i32.const 3
       local.set $0
-      br $__inlined_func$class-implements/J#foo@override$169
+      br $__inlined_func$class-implements/J#foo@override$168
      end
      i32.const 1
      local.set $0
-     br $__inlined_func$class-implements/J#foo@override$169
+     br $__inlined_func$class-implements/J#foo@override$168
     end
     unreachable
    end

--- a/tests/compiler/class-overloading-cast.debug.wat
+++ b/tests/compiler/class-overloading-cast.debug.wat
@@ -2014,7 +2014,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2080,21 +2080,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2110,6 +2095,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/class-overloading-cast.release.wat
+++ b/tests/compiler/class-overloading-cast.release.wat
@@ -155,7 +155,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$141
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$140
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -179,7 +179,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$141
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$140
     end
     local.get $1
     i32.load offset=8
@@ -1181,7 +1181,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1198,7 +1198,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0
@@ -1620,7 +1620,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$87
+   block $__inlined_func$~lib/util/string/compareImpl$86
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1640,7 +1640,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$87
+      br_if $__inlined_func$~lib/util/string/compareImpl$86
       local.get $2
       i32.const 2
       i32.add
@@ -1838,7 +1838,7 @@
    local.get $0
    global.set $class-overloading-cast/v3
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$class-overloading-cast/A<i32>#foo@override$136 (result i32)
+   block $__inlined_func$class-overloading-cast/A<i32>#foo@override$135 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-overloading-cast/v
     local.tee $0
@@ -1860,10 +1860,10 @@
        br $default
       end
       i32.const 1488
-      br $__inlined_func$class-overloading-cast/A<i32>#foo@override$136
+      br $__inlined_func$class-overloading-cast/A<i32>#foo@override$135
      end
      i32.const 1488
-     br $__inlined_func$class-overloading-cast/A<i32>#foo@override$136
+     br $__inlined_func$class-overloading-cast/A<i32>#foo@override$135
     end
     i32.const 1456
    end
@@ -1900,7 +1900,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$class-overloading-cast/A<f64>#foo@override$137 (result i32)
+   block $__inlined_func$class-overloading-cast/A<f64>#foo@override$136 (result i32)
     global.get $~lib/memory/__stack_pointer
     global.get $class-overloading-cast/v3
     local.tee $0
@@ -1912,7 +1912,7 @@
     i32.load
     i32.const 7
     i32.eq
-    br_if $__inlined_func$class-overloading-cast/A<f64>#foo@override$137
+    br_if $__inlined_func$class-overloading-cast/A<f64>#foo@override$136
     drop
     i32.const 1456
    end

--- a/tests/compiler/class-overloading.debug.wat
+++ b/tests/compiler/class-overloading.debug.wat
@@ -2018,7 +2018,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2084,21 +2084,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2114,6 +2099,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/class-overloading.release.wat
+++ b/tests/compiler/class-overloading.release.wat
@@ -177,7 +177,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$171
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$170
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -201,7 +201,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$171
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$170
     end
     local.get $1
     i32.load offset=8
@@ -1203,7 +1203,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1220,7 +1220,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0
@@ -1715,7 +1715,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$95
+   block $__inlined_func$~lib/util/string/compareImpl$94
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1735,7 +1735,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$95
+      br_if $__inlined_func$~lib/util/string/compareImpl$94
       local.get $2
       i32.const 2
       i32.add
@@ -1972,7 +1972,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$153
+   block $__inlined_func$class-overloading/A#b@override$152
     block $default
      block $case2
       block $case1
@@ -1987,15 +1987,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$153
+       br $__inlined_func$class-overloading/A#b@override$152
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$153
+      br $__inlined_func$class-overloading/A#b@override$152
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$153
+     br $__inlined_func$class-overloading/A#b@override$152
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2022,7 +2022,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$154
+   block $__inlined_func$class-overloading/A#get:c@override$153
     block $default4
      block $case25
       block $case16
@@ -2037,15 +2037,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$154
+       br $__inlined_func$class-overloading/A#get:c@override$153
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$154
+      br $__inlined_func$class-overloading/A#get:c@override$153
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$154
+     br $__inlined_func$class-overloading/A#get:c@override$153
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2072,7 +2072,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$155
+   block $__inlined_func$class-overloading/A#b@override$154
     block $default8
      block $case29
       block $case110
@@ -2087,15 +2087,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$155
+       br $__inlined_func$class-overloading/A#b@override$154
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$155
+      br $__inlined_func$class-overloading/A#b@override$154
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$155
+     br $__inlined_func$class-overloading/A#b@override$154
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2267,7 +2267,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$157
+   block $__inlined_func$class-overloading/A#b@override$156
     block $default16
      block $case217
       block $case118
@@ -2282,15 +2282,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$157
+       br $__inlined_func$class-overloading/A#b@override$156
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$157
+      br $__inlined_func$class-overloading/A#b@override$156
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$157
+     br $__inlined_func$class-overloading/A#b@override$156
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2317,7 +2317,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$158
+   block $__inlined_func$class-overloading/A#get:c@override$157
     block $default24
      block $case225
       block $case126
@@ -2332,15 +2332,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$158
+       br $__inlined_func$class-overloading/A#get:c@override$157
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$158
+      br $__inlined_func$class-overloading/A#get:c@override$157
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$158
+     br $__inlined_func$class-overloading/A#get:c@override$157
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2365,7 +2365,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$159
+   block $__inlined_func$class-overloading/A#b@override$158
     block $default32
      block $case233
       block $case134
@@ -2380,15 +2380,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$159
+       br $__inlined_func$class-overloading/A#b@override$158
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$159
+      br $__inlined_func$class-overloading/A#b@override$158
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$159
+     br $__inlined_func$class-overloading/A#b@override$158
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2442,7 +2442,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$160
+   block $__inlined_func$class-overloading/A#b@override$159
     block $default40
      block $case241
       block $case142
@@ -2457,15 +2457,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$160
+       br $__inlined_func$class-overloading/A#b@override$159
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$160
+      br $__inlined_func$class-overloading/A#b@override$159
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$160
+     br $__inlined_func$class-overloading/A#b@override$159
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2492,7 +2492,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$161
+   block $__inlined_func$class-overloading/A#get:c@override$160
     block $default48
      block $case249
       block $case150
@@ -2507,15 +2507,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$161
+       br $__inlined_func$class-overloading/A#get:c@override$160
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$161
+      br $__inlined_func$class-overloading/A#get:c@override$160
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$161
+     br $__inlined_func$class-overloading/A#get:c@override$160
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2540,7 +2540,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$162
+   block $__inlined_func$class-overloading/A#b@override$161
     block $default56
      block $case257
       block $case158
@@ -2555,15 +2555,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$162
+       br $__inlined_func$class-overloading/A#b@override$161
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$162
+      br $__inlined_func$class-overloading/A#b@override$161
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$162
+     br $__inlined_func$class-overloading/A#b@override$161
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2644,7 +2644,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$164
+   block $__inlined_func$class-overloading/A#b@override$163
     block $default64
      block $case265
       block $case166
@@ -2659,15 +2659,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$164
+       br $__inlined_func$class-overloading/A#b@override$163
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$164
+      br $__inlined_func$class-overloading/A#b@override$163
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$164
+     br $__inlined_func$class-overloading/A#b@override$163
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2694,7 +2694,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#get:c@override$165
+   block $__inlined_func$class-overloading/A#get:c@override$164
     block $default72
      block $case273
       block $case174
@@ -2709,15 +2709,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#get:c@override$165
+       br $__inlined_func$class-overloading/A#get:c@override$164
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#get:c@override$165
+      br $__inlined_func$class-overloading/A#get:c@override$164
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#get:c@override$165
+     br $__inlined_func$class-overloading/A#get:c@override$164
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2744,7 +2744,7 @@
    global.get $class-overloading/a
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/A#b@override$166
+   block $__inlined_func$class-overloading/A#b@override$165
     block $default80
      block $case281
       block $case182
@@ -2759,15 +2759,15 @@
        end
        i32.const 1520
        global.set $class-overloading/which
-       br $__inlined_func$class-overloading/A#b@override$166
+       br $__inlined_func$class-overloading/A#b@override$165
       end
       i32.const 1616
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/A#b@override$166
+      br $__inlined_func$class-overloading/A#b@override$165
      end
      i32.const 1648
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/A#b@override$166
+     br $__inlined_func$class-overloading/A#b@override$165
     end
     i32.const 1488
     global.set $class-overloading/which
@@ -2824,7 +2824,7 @@
    global.get $class-overloading/ia
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/IA#foo@override$168
+   block $__inlined_func$class-overloading/IA#foo@override$167
     block $default88
      block $case189
       local.get $0
@@ -2843,11 +2843,11 @@
       end
       i32.const 1680
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/IA#foo@override$168
+      br $__inlined_func$class-overloading/IA#foo@override$167
      end
      i32.const 1712
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/IA#foo@override$168
+     br $__inlined_func$class-overloading/IA#foo@override$167
     end
     unreachable
    end
@@ -2903,7 +2903,7 @@
    global.get $class-overloading/ic
    local.tee $0
    i32.store
-   block $__inlined_func$class-overloading/IA#foo@override$170
+   block $__inlined_func$class-overloading/IA#foo@override$169
     block $default91
      block $case192
       local.get $0
@@ -2922,11 +2922,11 @@
       end
       i32.const 1680
       global.set $class-overloading/which
-      br $__inlined_func$class-overloading/IA#foo@override$170
+      br $__inlined_func$class-overloading/IA#foo@override$169
      end
      i32.const 1712
      global.set $class-overloading/which
-     br $__inlined_func$class-overloading/IA#foo@override$170
+     br $__inlined_func$class-overloading/IA#foo@override$169
     end
     unreachable
    end

--- a/tests/compiler/class-override.debug.wat
+++ b/tests/compiler/class-override.debug.wat
@@ -2003,7 +2003,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2069,21 +2069,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2099,6 +2084,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/class-override.release.wat
+++ b/tests/compiler/class-override.release.wat
@@ -126,7 +126,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$120
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -150,7 +150,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$120
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
     end
     local.get $1
     i32.load offset=8
@@ -1152,7 +1152,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1169,7 +1169,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0
@@ -1631,7 +1631,7 @@
    global.get $class-override/x
    local.tee $1
    i32.store
-   block $__inlined_func$class-override/A#f@override$126
+   block $__inlined_func$class-override/A#f@override$125
     block $default
      block $case1
       block $case0
@@ -1647,7 +1647,7 @@
       local.get $0
       call $class-override/B#f
       local.set $0
-      br $__inlined_func$class-override/A#f@override$126
+      br $__inlined_func$class-override/A#f@override$125
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -1673,7 +1673,7 @@
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$class-override/A#f@override$126
+     br $__inlined_func$class-override/A#f@override$125
     end
     local.get $0
     i32.const 1

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -2086,7 +2086,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2152,21 +2152,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2182,6 +2167,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -109,7 +109,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$138
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -133,7 +133,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$138
    end
    local.get $0
    i32.load offset=8
@@ -1237,7 +1237,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$71
+   block $__inlined_func$~lib/rt/itcms/interrupt$70
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1254,7 +1254,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$71
+      br $__inlined_func$~lib/rt/itcms/interrupt$70
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -2014,7 +2014,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2080,21 +2080,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2110,6 +2095,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -181,7 +181,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$153
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$152
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -205,7 +205,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$153
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$152
     end
     local.get $1
     i32.load offset=8
@@ -1290,7 +1290,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1307,7 +1307,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/do.debug.wat
+++ b/tests/compiler/do.debug.wat
@@ -2408,7 +2408,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2474,21 +2474,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2504,6 +2489,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/do.release.wat
+++ b/tests/compiler/do.release.wat
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$125
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$124
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$125
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$124
     end
     local.get $1
     i32.load offset=8
@@ -1143,7 +1143,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1160,7 +1160,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -2008,7 +2008,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2074,21 +2074,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2104,6 +2089,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -116,7 +116,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$138
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -140,7 +140,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$138
    end
    local.get $0
    i32.load offset=8
@@ -1244,7 +1244,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1261,7 +1261,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/empty-exportruntime.debug.wat
+++ b/tests/compiler/empty-exportruntime.debug.wat
@@ -2007,7 +2007,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2073,21 +2073,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2103,6 +2088,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/empty-exportruntime.release.wat
+++ b/tests/compiler/empty-exportruntime.release.wat
@@ -1245,7 +1245,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1262,7 +1262,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/empty-new.debug.wat
+++ b/tests/compiler/empty-new.debug.wat
@@ -2000,7 +2000,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2066,21 +2066,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2096,6 +2081,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/empty-new.release.wat
+++ b/tests/compiler/empty-new.release.wat
@@ -114,7 +114,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$107
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$106
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -138,7 +138,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$107
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$106
     end
     local.get $1
     i32.load offset=8
@@ -1140,7 +1140,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $0
     loop $do-loop|0
@@ -1157,7 +1157,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $0
      i32.const 0

--- a/tests/compiler/exportstar-rereexport.debug.wat
+++ b/tests/compiler/exportstar-rereexport.debug.wat
@@ -2040,7 +2040,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2106,21 +2106,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2136,6 +2121,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/exportstar-rereexport.release.wat
+++ b/tests/compiler/exportstar-rereexport.release.wat
@@ -148,7 +148,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$120
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -172,7 +172,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$120
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
     end
     local.get $1
     i32.load offset=8
@@ -1174,7 +1174,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $0
     loop $do-loop|0
@@ -1191,7 +1191,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $0
      i32.const 0

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -2010,7 +2010,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2076,21 +2076,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2106,6 +2091,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -120,7 +120,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$142
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$141
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -144,7 +144,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$142
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$141
    end
    local.get $0
    i32.load offset=8
@@ -1248,7 +1248,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1265,7 +1265,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -1933,7 +1933,7 @@
     global.get $~lib/memory/__stack_pointer
     i32.const 1168
     i32.store
-    block $__inlined_func$~lib/rt/itcms/__renew$141
+    block $__inlined_func$~lib/rt/itcms/__renew$140
      i32.const 1073741820
      local.get $0
      i32.const 1
@@ -1976,7 +1976,7 @@
       i32.store offset=16
       local.get $0
       local.set $1
-      br $__inlined_func$~lib/rt/itcms/__renew$141
+      br $__inlined_func$~lib/rt/itcms/__renew$140
      end
      local.get $3
      local.get $2

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -2000,7 +2000,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2066,21 +2066,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2096,6 +2081,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -115,7 +115,7 @@
     local.get $1
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$115
     local.get $0
     i32.load offset=4
     i32.const -4
@@ -139,7 +139,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$115
     end
     local.get $0
     i32.load offset=8
@@ -1224,7 +1224,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1241,7 +1241,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -2011,7 +2011,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2077,21 +2077,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2107,6 +2092,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -120,7 +120,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$241
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$240
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -144,7 +144,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$241
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$240
    end
    local.get $0
    i32.load offset=8
@@ -1248,7 +1248,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1265,7 +1265,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -1883,7 +1883,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$118
+   block $__inlined_func$~lib/util/string/compareImpl$117
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1903,7 +1903,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$118
+      br_if $__inlined_func$~lib/util/string/compareImpl$117
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/field.debug.wat
+++ b/tests/compiler/field.debug.wat
@@ -2003,7 +2003,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2069,21 +2069,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2099,6 +2084,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/field.release.wat
+++ b/tests/compiler/field.release.wat
@@ -103,7 +103,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$127
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$126
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -127,7 +127,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$127
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$126
    end
    local.get $0
    i32.load offset=8
@@ -1231,7 +1231,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1248,7 +1248,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/for.debug.wat
+++ b/tests/compiler/for.debug.wat
@@ -2389,7 +2389,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2455,21 +2455,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2485,6 +2470,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/for.release.wat
+++ b/tests/compiler/for.release.wat
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$128
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$127
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$128
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$127
     end
     local.get $1
     i32.load offset=8
@@ -1143,7 +1143,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1160,7 +1160,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/function-call.debug.wat
+++ b/tests/compiler/function-call.debug.wat
@@ -2037,7 +2037,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2103,21 +2103,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2133,6 +2118,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/function-call.release.wat
+++ b/tests/compiler/function-call.release.wat
@@ -155,7 +155,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$115
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$114
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -179,7 +179,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$115
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$114
     end
     local.get $1
     i32.load offset=8
@@ -1181,7 +1181,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1198,7 +1198,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/function-expression.debug.wat
+++ b/tests/compiler/function-expression.debug.wat
@@ -2195,7 +2195,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2261,21 +2261,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2291,6 +2276,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/function-expression.release.wat
+++ b/tests/compiler/function-expression.release.wat
@@ -166,7 +166,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$133
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$132
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -190,7 +190,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$133
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$132
    end
    local.get $0
    i32.load offset=8
@@ -1211,7 +1211,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$71
+   block $__inlined_func$~lib/rt/itcms/interrupt$70
     i32.const 2048
     local.set $0
     loop $do-loop|0
@@ -1228,7 +1228,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$71
+      br $__inlined_func$~lib/rt/itcms/interrupt$70
      end
      local.get $0
      i32.const 0

--- a/tests/compiler/getter-call.debug.wat
+++ b/tests/compiler/getter-call.debug.wat
@@ -2003,7 +2003,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2069,21 +2069,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2099,6 +2084,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/getter-call.release.wat
+++ b/tests/compiler/getter-call.release.wat
@@ -120,7 +120,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$115
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$114
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -144,7 +144,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$115
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$114
     end
     local.get $1
     i32.load offset=8
@@ -1146,7 +1146,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1163,7 +1163,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/heap.debug.wat
+++ b/tests/compiler/heap.debug.wat
@@ -1315,7 +1315,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -1381,21 +1381,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -1411,6 +1396,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1
@@ -1617,7 +1605,7 @@
    local.get $block
    return
   end
-  block $~lib/rt/tlsf/GETRIGHT|inlined.4 (result i32)
+  block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
    local.get $block
    local.set $block|6
    local.get $block|6
@@ -1630,7 +1618,7 @@
    i32.xor
    i32.and
    i32.add
-   br $~lib/rt/tlsf/GETRIGHT|inlined.4
+   br $~lib/rt/tlsf/GETRIGHT|inlined.3
   end
   local.set $right
   local.get $right

--- a/tests/compiler/heap.release.wat
+++ b/tests/compiler/heap.release.wat
@@ -1044,7 +1044,7 @@
    call $~lib/rt/tlsf/moveBlock
    local.set $0
   else
-   block $__inlined_func$~lib/rt/tlsf/reallocateBlock$53
+   block $__inlined_func$~lib/rt/tlsf/reallocateBlock$52
     global.get $~lib/rt/tlsf/ROOT
     local.set $3
     local.get $0
@@ -1065,7 +1065,7 @@
      local.get $0
      local.get $5
      call $~lib/rt/tlsf/prepareBlock
-     br $__inlined_func$~lib/rt/tlsf/reallocateBlock$53
+     br $__inlined_func$~lib/rt/tlsf/reallocateBlock$52
     end
     local.get $0
     i32.const 4
@@ -1106,7 +1106,7 @@
       local.get $0
       local.get $5
       call $~lib/rt/tlsf/prepareBlock
-      br $__inlined_func$~lib/rt/tlsf/reallocateBlock$53
+      br $__inlined_func$~lib/rt/tlsf/reallocateBlock$52
      end
     end
     local.get $3

--- a/tests/compiler/incremental-gc/call-indirect.debug.wat
+++ b/tests/compiler/incremental-gc/call-indirect.debug.wat
@@ -2049,7 +2049,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2115,21 +2115,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2145,6 +2130,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/incremental-gc/call-indirect.release.wat
+++ b/tests/compiler/incremental-gc/call-indirect.release.wat
@@ -123,7 +123,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$123
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$122
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -147,7 +147,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$123
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$122
     end
     local.get $1
     i32.load offset=8
@@ -1232,7 +1232,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1249,7 +1249,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/infer-array.debug.wat
+++ b/tests/compiler/infer-array.debug.wat
@@ -2022,7 +2022,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2088,21 +2088,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2118,6 +2103,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/infer-array.release.wat
+++ b/tests/compiler/infer-array.release.wat
@@ -142,7 +142,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$154
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$153
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -166,7 +166,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$154
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$153
    end
    local.get $0
    i32.load offset=8
@@ -1270,7 +1270,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1287,7 +1287,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2079,7 +2079,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
-     block $__inlined_func$~lib/rt/itcms/__renew$149
+     block $__inlined_func$~lib/rt/itcms/__renew$148
       i32.const 1073741820
       local.get $4
       i32.const 1
@@ -2122,7 +2122,7 @@
        i32.store offset=16
        local.get $4
        local.set $3
-       br $__inlined_func$~lib/rt/itcms/__renew$149
+       br $__inlined_func$~lib/rt/itcms/__renew$148
       end
       local.get $5
       local.get $7

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -2049,7 +2049,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2115,21 +2115,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2145,6 +2130,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -144,7 +144,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$138
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$137
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -168,7 +168,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$138
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$137
     end
     local.get $1
     i32.load offset=8
@@ -1253,7 +1253,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1270,7 +1270,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -2272,7 +2272,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2338,21 +2338,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2368,6 +2353,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -134,7 +134,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$125
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$124
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -158,7 +158,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$125
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$124
     end
     local.get $1
     i32.load offset=8
@@ -1243,7 +1243,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1260,7 +1260,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/instanceof.debug.wat
+++ b/tests/compiler/instanceof.debug.wat
@@ -2024,7 +2024,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2090,21 +2090,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2120,6 +2105,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/instanceof.release.wat
+++ b/tests/compiler/instanceof.release.wat
@@ -222,7 +222,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$241
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$240
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -246,7 +246,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$241
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$240
     end
     local.get $1
     i32.load offset=8
@@ -1248,7 +1248,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1265,7 +1265,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0
@@ -1492,7 +1492,7 @@
   i32.store
   local.get $0
   if (result i32)
-   block $__inlined_func$~instanceof|instanceof/X$76 (result i32)
+   block $__inlined_func$~instanceof|instanceof/X$75 (result i32)
     block $is_instance
      block $tablify|0
       local.get $0
@@ -1504,7 +1504,7 @@
       br_table $is_instance $tablify|0 $tablify|0 $is_instance $tablify|0 $tablify|0 $is_instance $tablify|0
      end
      i32.const 0
-     br $__inlined_func$~instanceof|instanceof/X$76
+     br $__inlined_func$~instanceof|instanceof/X$75
     end
     i32.const 1
    end
@@ -1549,7 +1549,7 @@
   i32.store
   local.get $0
   if (result i32)
-   block $__inlined_func$~instanceof|instanceof/Y$78 (result i32)
+   block $__inlined_func$~instanceof|instanceof/Y$77 (result i32)
     block $is_instance
      local.get $0
      i32.const 8
@@ -1564,7 +1564,7 @@
      i32.eq
      br_if $is_instance
      i32.const 0
-     br $__inlined_func$~instanceof|instanceof/Y$78
+     br $__inlined_func$~instanceof|instanceof/Y$77
     end
     i32.const 1
    end
@@ -1656,7 +1656,7 @@
   i32.store
   local.get $0
   if (result i32)
-   block $__inlined_func$~instanceof|instanceof/Y$82 (result i32)
+   block $__inlined_func$~instanceof|instanceof/Y$81 (result i32)
     block $is_instance
      local.get $0
      i32.const 8
@@ -1671,7 +1671,7 @@
      i32.eq
      br_if $is_instance
      i32.const 0
-     br $__inlined_func$~instanceof|instanceof/Y$82
+     br $__inlined_func$~instanceof|instanceof/Y$81
     end
     i32.const 1
    end
@@ -2405,7 +2405,7 @@
    i32.store offset=12
    local.get $0
    if (result i32)
-    block $__inlined_func$~anyinstanceof|instanceof/Child$110 (result i32)
+    block $__inlined_func$~anyinstanceof|instanceof/Child$109 (result i32)
      block $is_instance1
       local.get $0
       i32.const 8
@@ -2420,7 +2420,7 @@
       i32.eq
       br_if $is_instance1
       i32.const 0
-      br $__inlined_func$~anyinstanceof|instanceof/Child$110
+      br $__inlined_func$~anyinstanceof|instanceof/Child$109
      end
      i32.const 1
     end
@@ -2450,7 +2450,7 @@
    i32.store offset=16
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$111 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$110 (result i32)
      block $is_instance2
       local.get $0
       i32.const 8
@@ -2465,7 +2465,7 @@
       i32.eq
       br_if $is_instance2
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$111
+      br $__inlined_func$~instanceof|instanceof/Cat$110
      end
      i32.const 1
     end
@@ -2509,7 +2509,7 @@
    i32.store offset=24
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$113 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$112 (result i32)
      block $is_instance4
       local.get $0
       i32.const 8
@@ -2524,7 +2524,7 @@
       i32.eq
       br_if $is_instance4
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$113
+      br $__inlined_func$~instanceof|instanceof/Cat$112
      end
      i32.const 1
     end
@@ -2569,7 +2569,7 @@
    i32.store offset=32
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$115 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$114 (result i32)
      block $is_instance6
       local.get $0
       i32.const 8
@@ -2584,7 +2584,7 @@
       i32.eq
       br_if $is_instance6
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$115
+      br $__inlined_func$~instanceof|instanceof/Cat$114
      end
      i32.const 1
     end
@@ -2648,7 +2648,7 @@
    i32.store offset=40
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$117 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$116 (result i32)
      block $is_instance8
       local.get $0
       i32.const 8
@@ -2663,7 +2663,7 @@
       i32.eq
       br_if $is_instance8
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$117
+      br $__inlined_func$~instanceof|instanceof/Cat$116
      end
      i32.const 1
     end
@@ -2717,7 +2717,7 @@
    i32.store offset=48
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$119 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$118 (result i32)
      block $is_instance10
       local.get $0
       i32.const 8
@@ -2732,7 +2732,7 @@
       i32.eq
       br_if $is_instance10
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$119
+      br $__inlined_func$~instanceof|instanceof/Cat$118
      end
      i32.const 1
     end
@@ -2787,7 +2787,7 @@
    i32.store offset=56
    local.get $0
    if (result i32)
-    block $__inlined_func$~instanceof|instanceof/Cat$121 (result i32)
+    block $__inlined_func$~instanceof|instanceof/Cat$120 (result i32)
      block $is_instance12
       local.get $0
       i32.const 8
@@ -2802,7 +2802,7 @@
       i32.eq
       br_if $is_instance12
       i32.const 0
-      br $__inlined_func$~instanceof|instanceof/Cat$121
+      br $__inlined_func$~instanceof|instanceof/Cat$120
      end
      i32.const 1
     end

--- a/tests/compiler/issues/1095.debug.wat
+++ b/tests/compiler/issues/1095.debug.wat
@@ -2003,7 +2003,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2069,21 +2069,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2099,6 +2084,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/1095.release.wat
+++ b/tests/compiler/issues/1095.release.wat
@@ -106,7 +106,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$117
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$116
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -130,7 +130,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$117
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$116
    end
    local.get $0
    i32.load offset=8
@@ -1234,7 +1234,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1251,7 +1251,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -2018,7 +2018,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2084,21 +2084,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2114,6 +2099,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -126,7 +126,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$118
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -150,7 +150,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$118
     end
     local.get $1
     i32.load offset=8
@@ -1152,7 +1152,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $0
     loop $do-loop|0
@@ -1169,7 +1169,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $0
      i32.const 0

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -2005,7 +2005,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2071,21 +2071,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2101,6 +2086,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -113,7 +113,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$146
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$145
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -137,7 +137,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$146
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$145
    end
    local.get $0
    i32.load offset=8
@@ -1241,7 +1241,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1258,7 +1258,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2129,7 +2129,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
-     block $__inlined_func$~lib/rt/itcms/__renew$145
+     block $__inlined_func$~lib/rt/itcms/__renew$144
       i32.const 1073741820
       local.get $4
       i32.const 1
@@ -2172,7 +2172,7 @@
        i32.store offset=16
        local.get $4
        local.set $3
-       br $__inlined_func$~lib/rt/itcms/__renew$145
+       br $__inlined_func$~lib/rt/itcms/__renew$144
       end
       local.get $5
       local.get $7

--- a/tests/compiler/issues/2166.debug.wat
+++ b/tests/compiler/issues/2166.debug.wat
@@ -2007,7 +2007,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2073,21 +2073,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2103,6 +2088,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/2166.release.wat
+++ b/tests/compiler/issues/2166.release.wat
@@ -126,7 +126,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$122
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$121
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -150,7 +150,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$122
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$121
     end
     local.get $1
     i32.load offset=8
@@ -1152,7 +1152,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1169,7 +1169,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0
@@ -1719,7 +1719,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$79
+   block $__inlined_func$~lib/util/string/compareImpl$78
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1739,7 +1739,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$79
+      br_if $__inlined_func$~lib/util/string/compareImpl$78
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -2001,7 +2001,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2067,21 +2067,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2097,6 +2082,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -116,7 +116,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -140,7 +140,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
     end
     local.get $1
     i32.load offset=8
@@ -1225,7 +1225,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1242,7 +1242,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/issues/2622.debug.wat
+++ b/tests/compiler/issues/2622.debug.wat
@@ -2004,7 +2004,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2070,21 +2070,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2100,6 +2085,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/2622.release.wat
+++ b/tests/compiler/issues/2622.release.wat
@@ -155,7 +155,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$110
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -179,7 +179,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$110
     end
     local.get $1
     i32.load offset=8
@@ -1181,7 +1181,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1198,7 +1198,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/issues/2707.debug.wat
+++ b/tests/compiler/issues/2707.debug.wat
@@ -2010,7 +2010,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2076,21 +2076,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2106,6 +2091,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/2707.release.wat
+++ b/tests/compiler/issues/2707.release.wat
@@ -109,7 +109,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$118
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -133,7 +133,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$118
    end
    local.get $0
    i32.load offset=8
@@ -1154,7 +1154,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1171,7 +1171,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/issues/2730.debug.wat
+++ b/tests/compiler/issues/2730.debug.wat
@@ -2,18 +2,13 @@
  (type $0 (func (param i32) (result i32)))
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
- (type $3 (func (param i32 i32) (result i32)))
- (type $4 (func))
+ (type $3 (func))
+ (type $4 (func (param i32 i32) (result i32)))
  (type $5 (func (param i32 i32 i32)))
  (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
  (type $8 (func (param i32 i32 i64) (result i32)))
- (type $9 (func (param i32 i64 i32)))
- (type $10 (func (param i64 i32) (result i32)))
- (type $11 (func (param i32 i64 i32 i32)))
- (type $12 (func (param i32 i32 i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
- (global $resolve-propertyaccess/Namespace.member i32 (i32.const 1))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/state (mut i32) (i32.const 0))
@@ -28,107 +23,35 @@
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
  (global $~lib/native/ASC_LOW_MEMORY_LIMIT i32 (i32.const 0))
+ (global $issues/2730/box (mut i32) (i32.const 0))
+ (global $issues/2730/boxCalls (mut i32) (i32.const 0))
+ (global $issues/2730/arr (mut i32) (i32.const 464))
+ (global $issues/2730/idxCalls (mut i32) (i32.const 0))
  (global $~lib/native/ASC_SHRINK_LEVEL i32 (i32.const 0))
- (global $resolve-propertyaccess/Namespace.lazyMember i32 (i32.const 11))
- (global $resolve-propertyaccess/MergedNamespace.member i32 (i32.const 2))
- (global $resolve-propertyaccess/MergedNamespace.lazyMember i32 (i32.const 22))
- (global $resolve-propertyaccess/TypedNamespace.member i32 (i32.const 3))
- (global $resolve-propertyaccess/TypedNamespace.lazyMember i32 (i32.const 33))
- (global $resolve-propertyaccess/Enum.VALUE i32 (i32.const 4))
- (global $resolve-propertyaccess/Class.staticField (mut i32) (i32.const 5))
- (global $resolve-propertyaccess/Class.lazyStaticField (mut i32) (i32.const 55))
- (global $~lib/rt/__rtti_base i32 (i32.const 2656))
- (global $~lib/memory/__data_end i32 (i32.const 2680))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 35448))
- (global $~lib/memory/__heap_base i32 (i32.const 35448))
+ (global $~lib/native/ASC_RUNTIME i32 (i32.const 2))
+ (global $~lib/rt/__rtti_base i32 (i32.const 640))
+ (global $~lib/memory/__data_end i32 (i32.const 668))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 33436))
+ (global $~lib/memory/__heap_base i32 (i32.const 33436))
  (memory $0 1)
- (data $0 (i32.const 12) "|\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00d\00\00\00t\00o\00S\00t\00r\00i\00n\00g\00(\00)\00 \00r\00a\00d\00i\00x\00 \00a\00r\00g\00u\00m\00e\00n\00t\00 \00m\00u\00s\00t\00 \00b\00e\00 \00b\00e\00t\00w\00e\00e\00n\00 \002\00 \00a\00n\00d\00 \003\006\00\00\00\00\00\00\00\00\00")
- (data $1 (i32.const 140) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00&\00\00\00~\00l\00i\00b\00/\00u\00t\00i\00l\00/\00n\00u\00m\00b\00e\00r\00.\00t\00s\00\00\00\00\00\00\00")
- (data $2 (i32.const 204) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\000\00\00\00\00\00\00\00\00\00\00\00")
- (data $3 (i32.const 236) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
- (data $4 (i32.const 300) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $5 (i32.const 368) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $6 (i32.const 400) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $7 (i32.const 428) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
- (data $8 (i32.const 492) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
- (data $9 (i32.const 544) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $10 (i32.const 572) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $11 (i32.const 636) "0\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\00")
- (data $12 (i32.const 1036) "\1c\04\00\00\00\00\00\00\00\00\00\00\02\00\00\00\00\04\00\000\000\000\001\000\002\000\003\000\004\000\005\000\006\000\007\000\008\000\009\000\00a\000\00b\000\00c\000\00d\000\00e\000\00f\001\000\001\001\001\002\001\003\001\004\001\005\001\006\001\007\001\008\001\009\001\00a\001\00b\001\00c\001\00d\001\00e\001\00f\002\000\002\001\002\002\002\003\002\004\002\005\002\006\002\007\002\008\002\009\002\00a\002\00b\002\00c\002\00d\002\00e\002\00f\003\000\003\001\003\002\003\003\003\004\003\005\003\006\003\007\003\008\003\009\003\00a\003\00b\003\00c\003\00d\003\00e\003\00f\004\000\004\001\004\002\004\003\004\004\004\005\004\006\004\007\004\008\004\009\004\00a\004\00b\004\00c\004\00d\004\00e\004\00f\005\000\005\001\005\002\005\003\005\004\005\005\005\006\005\007\005\008\005\009\005\00a\005\00b\005\00c\005\00d\005\00e\005\00f\006\000\006\001\006\002\006\003\006\004\006\005\006\006\006\007\006\008\006\009\006\00a\006\00b\006\00c\006\00d\006\00e\006\00f\007\000\007\001\007\002\007\003\007\004\007\005\007\006\007\007\007\008\007\009\007\00a\007\00b\007\00c\007\00d\007\00e\007\00f\008\000\008\001\008\002\008\003\008\004\008\005\008\006\008\007\008\008\008\009\008\00a\008\00b\008\00c\008\00d\008\00e\008\00f\009\000\009\001\009\002\009\003\009\004\009\005\009\006\009\007\009\008\009\009\009\00a\009\00b\009\00c\009\00d\009\00e\009\00f\00a\000\00a\001\00a\002\00a\003\00a\004\00a\005\00a\006\00a\007\00a\008\00a\009\00a\00a\00a\00b\00a\00c\00a\00d\00a\00e\00a\00f\00b\000\00b\001\00b\002\00b\003\00b\004\00b\005\00b\006\00b\007\00b\008\00b\009\00b\00a\00b\00b\00b\00c\00b\00d\00b\00e\00b\00f\00c\000\00c\001\00c\002\00c\003\00c\004\00c\005\00c\006\00c\007\00c\008\00c\009\00c\00a\00c\00b\00c\00c\00c\00d\00c\00e\00c\00f\00d\000\00d\001\00d\002\00d\003\00d\004\00d\005\00d\006\00d\007\00d\008\00d\009\00d\00a\00d\00b\00d\00c\00d\00d\00d\00e\00d\00f\00e\000\00e\001\00e\002\00e\003\00e\004\00e\005\00e\006\00e\007\00e\008\00e\009\00e\00a\00e\00b\00e\00c\00e\00d\00e\00e\00e\00f\00f\000\00f\001\00f\002\00f\003\00f\004\00f\005\00f\006\00f\007\00f\008\00f\009\00f\00a\00f\00b\00f\00c\00f\00d\00f\00e\00f\00f\00\00\00\00\00\00\00\00\00\00\00\00\00")
- (data $13 (i32.const 2092) "\\\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00H\00\00\000\001\002\003\004\005\006\007\008\009\00a\00b\00c\00d\00e\00f\00g\00h\00i\00j\00k\00l\00m\00n\00o\00p\00q\00r\00s\00t\00u\00v\00w\00x\00y\00z\00\00\00\00\00")
- (data $14 (i32.const 2188) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\001\00\00\00\00\00\00\00\00\00\00\00")
- (data $15 (i32.const 2220) "L\00\00\00\00\00\00\00\00\00\00\00\02\00\00\002\00\00\00r\00e\00s\00o\00l\00v\00e\00-\00p\00r\00o\00p\00e\00r\00t\00y\00a\00c\00c\00e\00s\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00")
- (data $16 (i32.const 2300) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\04\00\00\001\001\00\00\00\00\00\00\00\00\00")
- (data $17 (i32.const 2332) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\002\00\00\00\00\00\00\00\00\00\00\00")
- (data $18 (i32.const 2364) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\04\00\00\002\002\00\00\00\00\00\00\00\00\00")
- (data $19 (i32.const 2396) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\003\00\00\00\00\00\00\00\00\00\00\00")
- (data $20 (i32.const 2428) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\04\00\00\003\003\00\00\00\00\00\00\00\00\00")
- (data $21 (i32.const 2460) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\004\00\00\00\00\00\00\00\00\00\00\00")
- (data $22 (i32.const 2492) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\005\00\00\00\00\00\00\00\00\00\00\00")
- (data $23 (i32.const 2524) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\04\00\00\005\005\00\00\00\00\00\00\00\00\00")
- (data $24 (i32.const 2556) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\007\00\00\00\00\00\00\00\00\00\00\00")
- (data $25 (i32.const 2588) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\006\00\00\00\00\00\00\00\00\00\00\00")
- (data $26 (i32.const 2620) "\1c\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\02\00\00\008\00\00\00\00\00\00\00\00\00\00\00")
- (data $27 (i32.const 2656) "\05\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00")
+ (data $0 (i32.const 12) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e\00\00\00\00\00")
+ (data $1 (i32.const 76) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00 \00\00\00~\00l\00i\00b\00/\00r\00t\00/\00i\00t\00c\00m\00s\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $2 (i32.const 144) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $3 (i32.const 176) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $4 (i32.const 204) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00$\00\00\00I\00n\00d\00e\00x\00 \00o\00u\00t\00 \00o\00f\00 \00r\00a\00n\00g\00e\00\00\00\00\00\00\00\00\00")
+ (data $5 (i32.const 268) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s\00\00\00\00\00\00\00\00\00")
+ (data $6 (i32.const 320) "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $7 (i32.const 348) "<\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $8 (i32.const 412) "\1c\00\00\00\00\00\00\00\00\00\00\00\01\00\00\00\08\00\00\00\01\00\00\00\02\00\00\00\00\00\00\00")
+ (data $9 (i32.const 444) ",\00\00\00\00\00\00\00\00\00\00\00\05\00\00\00\10\00\00\00\b0\01\00\00\b0\01\00\00\08\00\00\00\02\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00")
+ (data $10 (i32.const 492) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1c\00\00\00i\00s\00s\00u\00e\00s\00/\002\007\003\000\00.\00t\00s\00")
+ (data $11 (i32.const 540) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s\00\00\00")
+ (data $12 (i32.const 588) ",\00\00\00\00\00\00\00\00\00\00\00\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h\00")
+ (data $13 (i32.const 640) "\06\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00\02\t\00\00")
  (table $0 1 1 funcref)
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (start $~start)
- (func $~lib/util/number/decimalCount32 (param $value i32) (result i32)
-  local.get $value
-  i32.const 100000
-  i32.lt_u
-  if
-   local.get $value
-   i32.const 100
-   i32.lt_u
-   if
-    i32.const 1
-    local.get $value
-    i32.const 10
-    i32.ge_u
-    i32.add
-    return
-   else
-    i32.const 3
-    local.get $value
-    i32.const 10000
-    i32.ge_u
-    i32.add
-    local.get $value
-    i32.const 1000
-    i32.ge_u
-    i32.add
-    return
-   end
-   unreachable
-  else
-   local.get $value
-   i32.const 10000000
-   i32.lt_u
-   if
-    i32.const 6
-    local.get $value
-    i32.const 1000000
-    i32.ge_u
-    i32.add
-    return
-   else
-    i32.const 8
-    local.get $value
-    i32.const 1000000000
-    i32.ge_u
-    i32.add
-    local.get $value
-    i32.const 100000000
-    i32.ge_u
-    i32.add
-    return
-   end
-   unreachable
-  end
-  unreachable
- )
  (func $~lib/rt/itcms/Object#set:nextWithColor (param $this i32) (param $nextWithColor i32)
   local.get $this
   local.get $nextWithColor
@@ -193,7 +116,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 320
+     i32.const 96
      i32.const 160
      i32.const 16
      call $~lib/builtins/abort
@@ -263,7 +186,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 320
+    i32.const 96
     i32.const 128
     i32.const 18
     call $~lib/builtins/abort
@@ -280,7 +203,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 320
+   i32.const 96
    i32.const 132
    i32.const 16
    call $~lib/builtins/abort
@@ -310,8 +233,8 @@
   i32.load
   i32.gt_u
   if
-   i32.const 448
-   i32.const 512
+   i32.const 224
+   i32.const 288
    i32.const 21
    i32.const 28
    call $~lib/builtins/abort
@@ -379,7 +302,7 @@
    i32.eqz
    if (result i32)
     i32.const 0
-    i32.const 320
+    i32.const 96
     i32.const 148
     i32.const 30
     call $~lib/builtins/abort
@@ -531,7 +454,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 268
    i32.const 14
    call $~lib/builtins/abort
@@ -551,7 +474,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 270
    i32.const 14
    call $~lib/builtins/abort
@@ -614,7 +537,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 284
    i32.const 14
    call $~lib/builtins/abort
@@ -767,7 +690,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 201
    i32.const 14
    call $~lib/builtins/abort
@@ -784,7 +707,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 203
    i32.const 14
    call $~lib/builtins/abort
@@ -873,7 +796,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 592
+    i32.const 368
     i32.const 221
     i32.const 16
     call $~lib/builtins/abort
@@ -916,7 +839,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 233
    i32.const 14
    call $~lib/builtins/abort
@@ -934,7 +857,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 234
    i32.const 14
    call $~lib/builtins/abort
@@ -1002,7 +925,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 251
    i32.const 14
    call $~lib/builtins/abort
@@ -1119,7 +1042,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 382
    i32.const 14
    call $~lib/builtins/abort
@@ -1165,7 +1088,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 592
+    i32.const 368
     i32.const 389
     i32.const 16
     call $~lib/builtins/abort
@@ -1197,7 +1120,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 592
+    i32.const 368
     i32.const 402
     i32.const 5
     call $~lib/builtins/abort
@@ -1441,7 +1364,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 562
    i32.const 3
    call $~lib/builtins/abort
@@ -1661,7 +1584,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 320
+     i32.const 96
      i32.const 229
      i32.const 20
      call $~lib/builtins/abort
@@ -1772,8 +1695,8 @@
   i32.const 1073741820
   i32.gt_u
   if
-   i32.const 256
-   i32.const 592
+   i32.const 32
+   i32.const 368
    i32.const 461
    i32.const 29
    call $~lib/builtins/abort
@@ -1875,7 +1798,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 334
    i32.const 14
    call $~lib/builtins/abort
@@ -1946,7 +1869,7 @@
     i32.eqz
     if
      i32.const 0
-     i32.const 592
+     i32.const 368
      i32.const 347
      i32.const 18
      call $~lib/builtins/abort
@@ -2103,7 +2026,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 361
    i32.const 14
    call $~lib/builtins/abort
@@ -2206,7 +2129,7 @@
    i32.eqz
    if
     i32.const 0
-    i32.const 592
+    i32.const 368
     i32.const 499
     i32.const 16
     call $~lib/builtins/abort
@@ -2226,7 +2149,7 @@
   i32.eqz
   if
    i32.const 0
-   i32.const 592
+   i32.const 368
    i32.const 501
    i32.const 14
    call $~lib/builtins/abort
@@ -2274,8 +2197,8 @@
   i32.const 1073741804
   i32.ge_u
   if
-   i32.const 256
-   i32.const 320
+   i32.const 32
+   i32.const 96
    i32.const 261
    i32.const 31
    call $~lib/builtins/abort
@@ -2320,513 +2243,450 @@
   local.get $ptr
   return
  )
- (func $~lib/util/number/utoa32_dec_lut (param $buffer i32) (param $num i32) (param $offset i32)
-  (local $t i32)
-  (local $r i32)
-  (local $d1 i32)
-  (local $d2 i32)
-  (local $digits1 i64)
-  (local $digits2 i64)
-  (local $t|9 i32)
-  (local $d1|10 i32)
-  (local $digits i32)
-  (local $digits|12 i32)
-  (local $digit i32)
-  loop $while-continue|0
-   local.get $num
-   i32.const 10000
-   i32.ge_u
-   if
-    local.get $num
-    i32.const 10000
-    i32.div_u
-    local.set $t
-    local.get $num
-    i32.const 10000
-    i32.rem_u
-    local.set $r
-    local.get $t
-    local.set $num
-    local.get $r
-    i32.const 100
-    i32.div_u
-    local.set $d1
-    local.get $r
-    i32.const 100
-    i32.rem_u
-    local.set $d2
-    i32.const 636
-    local.get $d1
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $digits1
-    i32.const 636
-    local.get $d2
-    i32.const 2
-    i32.shl
-    i32.add
-    i64.load32_u
-    local.set $digits2
-    local.get $offset
-    i32.const 4
-    i32.sub
-    local.set $offset
-    local.get $buffer
-    local.get $offset
-    i32.const 1
-    i32.shl
-    i32.add
-    local.get $digits1
-    local.get $digits2
-    i64.const 32
-    i64.shl
-    i64.or
-    i64.store
-    br $while-continue|0
-   end
-  end
-  local.get $num
-  i32.const 100
-  i32.ge_u
-  if
-   local.get $num
-   i32.const 100
-   i32.div_u
-   local.set $t|9
-   local.get $num
-   i32.const 100
-   i32.rem_u
-   local.set $d1|10
-   local.get $t|9
-   local.set $num
-   local.get $offset
-   i32.const 2
-   i32.sub
-   local.set $offset
-   i32.const 636
-   local.get $d1|10
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load
-   local.set $digits
-   local.get $buffer
-   local.get $offset
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $digits
-   i32.store
-  end
-  local.get $num
-  i32.const 10
-  i32.ge_u
-  if
-   local.get $offset
-   i32.const 2
-   i32.sub
-   local.set $offset
-   i32.const 636
-   local.get $num
-   i32.const 2
-   i32.shl
-   i32.add
-   i32.load
-   local.set $digits|12
-   local.get $buffer
-   local.get $offset
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $digits|12
-   i32.store
-  else
-   local.get $offset
-   i32.const 1
-   i32.sub
-   local.set $offset
-   i32.const 48
-   local.get $num
-   i32.add
-   local.set $digit
-   local.get $buffer
-   local.get $offset
-   i32.const 1
-   i32.shl
-   i32.add
-   local.get $digit
-   i32.store16
-  end
- )
- (func $~lib/util/number/utoa_hex_lut (param $buffer i32) (param $num i64) (param $offset i32)
-  loop $while-continue|0
-   local.get $offset
-   i32.const 2
-   i32.ge_u
-   if
-    local.get $offset
-    i32.const 2
-    i32.sub
-    local.set $offset
-    local.get $buffer
-    local.get $offset
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.const 1056
-    local.get $num
-    i32.wrap_i64
-    i32.const 255
-    i32.and
-    i32.const 2
-    i32.shl
-    i32.add
-    i32.load
-    i32.store
-    local.get $num
-    i64.const 8
-    i64.shr_u
-    local.set $num
-    br $while-continue|0
-   end
-  end
-  local.get $offset
-  i32.const 1
-  i32.and
-  if
-   local.get $buffer
-   i32.const 1056
-   local.get $num
-   i32.wrap_i64
-   i32.const 6
-   i32.shl
-   i32.add
-   i32.load16_u
-   i32.store16
-  end
- )
- (func $~lib/util/number/ulog_base (param $num i64) (param $base i32) (result i32)
-  (local $value i32)
-  (local $b64 i64)
-  (local $b i64)
-  (local $e i32)
-  block $~lib/util/number/isPowerOf2<i32>|inlined.0 (result i32)
-   local.get $base
-   local.set $value
-   local.get $value
-   i32.popcnt
-   i32.const 1
-   i32.eq
-   br $~lib/util/number/isPowerOf2<i32>|inlined.0
-  end
-  if
-   i32.const 63
-   local.get $num
-   i64.clz
-   i32.wrap_i64
-   i32.sub
-   i32.const 31
-   local.get $base
-   i32.clz
-   i32.sub
-   i32.div_u
-   i32.const 1
-   i32.add
-   return
-  end
-  local.get $base
-  i64.extend_i32_s
-  local.set $b64
-  local.get $b64
-  local.set $b
-  i32.const 1
-  local.set $e
-  loop $while-continue|0
-   local.get $num
-   local.get $b
-   i64.ge_u
-   if
-    local.get $num
-    local.get $b
-    i64.div_u
-    local.set $num
-    local.get $b
-    local.get $b
-    i64.mul
-    local.set $b
-    local.get $e
-    i32.const 1
-    i32.shl
-    local.set $e
-    br $while-continue|0
-   end
-  end
-  loop $while-continue|1
-   local.get $num
-   i64.const 1
-   i64.ge_u
-   if
-    local.get $num
-    local.get $b64
-    i64.div_u
-    local.set $num
-    local.get $e
-    i32.const 1
-    i32.add
-    local.set $e
-    br $while-continue|1
-   end
-  end
-  local.get $e
-  i32.const 1
-  i32.sub
-  return
- )
- (func $~lib/util/number/utoa64_any_core (param $buffer i32) (param $num i64) (param $offset i32) (param $radix i32)
-  (local $base i64)
-  (local $shift i64)
-  (local $mask i64)
-  (local $q i64)
-  local.get $radix
-  i64.extend_i32_s
-  local.set $base
-  local.get $radix
-  local.get $radix
-  i32.const 1
-  i32.sub
-  i32.and
-  i32.const 0
-  i32.eq
-  if
-   local.get $radix
-   i32.ctz
-   i32.const 7
-   i32.and
-   i64.extend_i32_s
-   local.set $shift
-   local.get $base
-   i64.const 1
-   i64.sub
-   local.set $mask
-   loop $do-loop|0
-    local.get $offset
-    i32.const 1
-    i32.sub
-    local.set $offset
-    local.get $buffer
-    local.get $offset
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.const 2112
-    local.get $num
-    local.get $mask
-    i64.and
-    i32.wrap_i64
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    i32.store16
-    local.get $num
-    local.get $shift
-    i64.shr_u
-    local.set $num
-    local.get $num
-    i64.const 0
-    i64.ne
-    br_if $do-loop|0
-   end
-  else
-   loop $do-loop|1
-    local.get $offset
-    i32.const 1
-    i32.sub
-    local.set $offset
-    local.get $num
-    local.get $base
-    i64.div_u
-    local.set $q
-    local.get $buffer
-    local.get $offset
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.const 2112
-    local.get $num
-    local.get $q
-    local.get $base
-    i64.mul
-    i64.sub
-    i32.wrap_i64
-    i32.const 1
-    i32.shl
-    i32.add
-    i32.load16_u
-    i32.store16
-    local.get $q
-    local.set $num
-    local.get $num
-    i64.const 0
-    i64.ne
-    br_if $do-loop|1
-   end
-  end
- )
- (func $~lib/number/I32#toString (param $this i32) (param $radix i32) (result i32)
+ (func $issues/2730/Box#set:value (param $this i32) (param $value i32)
   local.get $this
-  local.get $radix
-  call $~lib/util/number/itoa32
-  return
- )
- (func $~lib/rt/common/OBJECT#get:rtSize (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=16
- )
- (func $~lib/string/String#get:length (param $this i32) (result i32)
-  local.get $this
-  i32.const 20
-  i32.sub
-  call $~lib/rt/common/OBJECT#get:rtSize
-  i32.const 1
-  i32.shr_u
-  return
- )
- (func $~lib/util/string/compareImpl (param $str1 i32) (param $index1 i32) (param $str2 i32) (param $index2 i32) (param $len i32) (result i32)
-  (local $ptr1 i32)
-  (local $ptr2 i32)
-  (local $7 i32)
-  (local $a i32)
-  (local $b i32)
-  local.get $str1
-  local.get $index1
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $ptr1
-  local.get $str2
-  local.get $index2
-  i32.const 1
-  i32.shl
-  i32.add
-  local.set $ptr2
-  i32.const 0
-  i32.const 2
-  i32.lt_s
-  drop
-  local.get $len
-  i32.const 4
-  i32.ge_u
-  if (result i32)
-   local.get $ptr1
-   i32.const 7
-   i32.and
-   local.get $ptr2
-   i32.const 7
-   i32.and
-   i32.or
-   i32.eqz
-  else
-   i32.const 0
-  end
-  if
-   block $do-break|0
-    loop $do-loop|0
-     local.get $ptr1
-     i64.load
-     local.get $ptr2
-     i64.load
-     i64.ne
-     if
-      br $do-break|0
-     end
-     local.get $ptr1
-     i32.const 8
-     i32.add
-     local.set $ptr1
-     local.get $ptr2
-     i32.const 8
-     i32.add
-     local.set $ptr2
-     local.get $len
-     i32.const 4
-     i32.sub
-     local.set $len
-     local.get $len
-     i32.const 4
-     i32.ge_u
-     br_if $do-loop|0
-    end
-   end
-  end
-  loop $while-continue|1
-   local.get $len
-   local.tee $7
-   i32.const 1
-   i32.sub
-   local.set $len
-   local.get $7
-   if
-    local.get $ptr1
-    i32.load16_u
-    local.set $a
-    local.get $ptr2
-    i32.load16_u
-    local.set $b
-    local.get $a
-    local.get $b
-    i32.ne
-    if
-     local.get $a
-     local.get $b
-     i32.sub
-     return
-    end
-    local.get $ptr1
-    i32.const 2
-    i32.add
-    local.set $ptr1
-    local.get $ptr2
-    i32.const 2
-    i32.add
-    local.set $ptr2
-    br $while-continue|1
-   end
-  end
-  i32.const 0
-  return
- )
- (func $resolve-propertyaccess/Class.get:staticProperty (result i32)
-  i32.const 7
-  return
- )
- (func $resolve-propertyaccess/Class#set:instanceField (param $this i32) (param $instanceField i32)
-  local.get $this
-  local.get $instanceField
+  local.get $value
   i32.store
  )
- (func $resolve-propertyaccess/Class#get:instanceField (param $this i32) (result i32)
+ (func $issues/2730/getBox (result i32)
+  global.get $issues/2730/boxCalls
+  i32.const 1
+  i32.add
+  global.set $issues/2730/boxCalls
+  global.get $issues/2730/box
+  return
+ )
+ (func $issues/2730/Box#get:value (param $this i32) (result i32)
   local.get $this
   i32.load
  )
- (func $resolve-propertyaccess/Class#get:instanceProperty (param $this i32) (result i32)
-  i32.const 8
+ (func $issues/2730/assertOneBoxCall
+  global.get $issues/2730/boxCalls
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 19
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+ )
+ (func $~lib/math/ipow32 (param $x i32) (param $e i32) (result i32)
+  (local $out i32)
+  (local $log i32)
+  (local $4 i32)
+  i32.const 1
+  local.set $out
+  i32.const 0
+  i32.const 1
+  i32.lt_s
+  drop
+  local.get $x
+  i32.const 2
+  i32.eq
+  if
+   i32.const 1
+   local.get $e
+   i32.shl
+   i32.const 0
+   local.get $e
+   i32.const 32
+   i32.lt_u
+   select
+   return
+  end
+  local.get $e
+  i32.const 0
+  i32.le_s
+  if
+   local.get $x
+   i32.const -1
+   i32.eq
+   if
+    i32.const -1
+    i32.const 1
+    local.get $e
+    i32.const 1
+    i32.and
+    select
+    return
+   end
+   local.get $e
+   i32.const 0
+   i32.eq
+   local.get $x
+   i32.const 1
+   i32.eq
+   i32.or
+   return
+  else
+   local.get $e
+   i32.const 1
+   i32.eq
+   if
+    local.get $x
+    return
+   else
+    local.get $e
+    i32.const 2
+    i32.eq
+    if
+     local.get $x
+     local.get $x
+     i32.mul
+     return
+    else
+     local.get $e
+     i32.const 32
+     i32.lt_s
+     if
+      i32.const 32
+      local.get $e
+      i32.clz
+      i32.sub
+      local.set $log
+      block $break|0
+       block $case4|0
+        block $case3|0
+         block $case2|0
+          block $case1|0
+           block $case0|0
+            local.get $log
+            local.set $4
+            local.get $4
+            i32.const 5
+            i32.eq
+            br_if $case0|0
+            local.get $4
+            i32.const 4
+            i32.eq
+            br_if $case1|0
+            local.get $4
+            i32.const 3
+            i32.eq
+            br_if $case2|0
+            local.get $4
+            i32.const 2
+            i32.eq
+            br_if $case3|0
+            local.get $4
+            i32.const 1
+            i32.eq
+            br_if $case4|0
+            br $break|0
+           end
+           local.get $e
+           i32.const 1
+           i32.and
+           if
+            local.get $out
+            local.get $x
+            i32.mul
+            local.set $out
+           end
+           local.get $e
+           i32.const 1
+           i32.shr_u
+           local.set $e
+           local.get $x
+           local.get $x
+           i32.mul
+           local.set $x
+          end
+          local.get $e
+          i32.const 1
+          i32.and
+          if
+           local.get $out
+           local.get $x
+           i32.mul
+           local.set $out
+          end
+          local.get $e
+          i32.const 1
+          i32.shr_u
+          local.set $e
+          local.get $x
+          local.get $x
+          i32.mul
+          local.set $x
+         end
+         local.get $e
+         i32.const 1
+         i32.and
+         if
+          local.get $out
+          local.get $x
+          i32.mul
+          local.set $out
+         end
+         local.get $e
+         i32.const 1
+         i32.shr_u
+         local.set $e
+         local.get $x
+         local.get $x
+         i32.mul
+         local.set $x
+        end
+        local.get $e
+        i32.const 1
+        i32.and
+        if
+         local.get $out
+         local.get $x
+         i32.mul
+         local.set $out
+        end
+        local.get $e
+        i32.const 1
+        i32.shr_u
+        local.set $e
+        local.get $x
+        local.get $x
+        i32.mul
+        local.set $x
+       end
+       local.get $e
+       i32.const 1
+       i32.and
+       if
+        local.get $out
+        local.get $x
+        i32.mul
+        local.set $out
+       end
+      end
+      local.get $out
+      return
+     end
+    end
+   end
+  end
+  loop $while-continue|1
+   local.get $e
+   if
+    local.get $e
+    i32.const 1
+    i32.and
+    if
+     local.get $out
+     local.get $x
+     i32.mul
+     local.set $out
+    end
+    local.get $e
+    i32.const 1
+    i32.shr_u
+    local.set $e
+    local.get $x
+    local.get $x
+    i32.mul
+    local.set $x
+    br $while-continue|1
+   end
+  end
+  local.get $out
   return
+ )
+ (func $~lib/array/Array<i32>#get:length_ (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=12
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=8
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:buffer (param $this i32) (result i32)
+  local.get $this
+  i32.load
+ )
+ (func $~lib/rt/itcms/Object#get:rtSize (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=16
+ )
+ (func $~lib/rt/itcms/__renew (param $oldPtr i32) (param $size i32) (result i32)
+  (local $oldObj i32)
+  (local $newPtr i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $oldPtr
+  i32.const 20
+  i32.sub
+  local.set $oldObj
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/common/BLOCK#get:mmInfo
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.sub
+  i32.le_u
+  if
+   local.get $oldObj
+   local.get $size
+   call $~lib/rt/itcms/Object#set:rtSize
+   local.get $oldPtr
+   return
+  end
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtId
+  call $~lib/rt/itcms/__new
+  local.set $newPtr
+  local.get $newPtr
+  local.get $oldPtr
+  local.get $size
+  local.tee $4
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtSize
+  local.tee $5
+  local.get $4
+  local.get $5
+  i32.lt_u
+  select
+  memory.copy
+  local.get $newPtr
+  return
+ )
+ (func $~lib/rt/itcms/__link (param $parentPtr i32) (param $childPtr i32) (param $expectMultiple i32)
+  (local $child i32)
+  (local $parent i32)
+  (local $parentColor i32)
+  local.get $childPtr
+  i32.eqz
+  if
+   return
+  end
+  i32.const 1
+  drop
+  local.get $parentPtr
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 96
+   i32.const 295
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $childPtr
+  i32.const 20
+  i32.sub
+  local.set $child
+  local.get $child
+  call $~lib/rt/itcms/Object#get:color
+  global.get $~lib/rt/itcms/white
+  i32.eq
+  if
+   local.get $parentPtr
+   i32.const 20
+   i32.sub
+   local.set $parent
+   local.get $parent
+   call $~lib/rt/itcms/Object#get:color
+   local.set $parentColor
+   local.get $parentColor
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $expectMultiple
+    if
+     local.get $parent
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     local.get $child
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   else
+    local.get $parentColor
+    i32.const 3
+    i32.eq
+    if (result i32)
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+    else
+     i32.const 0
+    end
+    if
+     local.get $child
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
+ (func $~lib/array/Array<i32>#set:length_ (param $this i32) (param $length_ i32)
+  local.get $this
+  local.get $length_
+  i32.store offset=12
+ )
+ (func $~lib/array/Array<i32>#get:dataStart (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=4
+ )
+ (func $issues/2730/getIndex (result i32)
+  global.get $issues/2730/idxCalls
+  i32.const 1
+  i32.add
+  global.set $issues/2730/idxCalls
+  i32.const 0
+  return
+ )
+ (func $start:issues/2730
+  (local $0 i32)
+  memory.size
+  i32.const 16
+  i32.shl
+  global.get $~lib/memory/__heap_base
+  i32.sub
+  i32.const 1
+  i32.shr_u
+  global.set $~lib/rt/itcms/threshold
+  i32.const 144
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/pinSpace
+  i32.const 176
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/toSpace
+  i32.const 320
+  call $~lib/rt/itcms/initLazy
+  global.set $~lib/rt/itcms/fromSpace
+  i32.const 0
+  call $issues/2730/Box#constructor
+  global.set $issues/2730/box
+  call $issues/2730/testPropertyCompoundAssignments
+  call $issues/2730/testElementCompoundAssignments
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
-  i32.const 448
+  global.get $issues/2730/box
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  global.get $issues/2730/arr
+  local.tee $1
+  if
+   local.get $1
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  i32.const 224
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 256
+  i32.const 608
   local.get $0
   call $~lib/rt/itcms/__visit
-  i32.const 1056
-  local.get $0
-  call $~lib/rt/itcms/__visit
-  i32.const 2112
+  i32.const 32
   local.get $0
   call $~lib/rt/itcms/__visit
  )
@@ -2842,147 +2702,69 @@
  )
  (func $~lib/object/Object~visit (param $0 i32) (param $1 i32)
  )
+ (func $~lib/array/Array<i32>#get:buffer (param $this i32) (result i32)
+  local.get $this
+  i32.load
+ )
+ (func $~lib/array/Array<i32>~visit (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  call $~lib/object/Object~visit
+  local.get $0
+  local.get $1
+  call $~lib/array/Array<i32>#__visit
+ )
  (func $~lib/rt/__visit_members (param $0 i32) (param $1 i32)
   block $invalid
-   block $resolve-propertyaccess/Class
-    block $~lib/arraybuffer/ArrayBufferView
-     block $~lib/string/String
-      block $~lib/arraybuffer/ArrayBuffer
-       block $~lib/object/Object
-        local.get $0
-        i32.const 8
-        i32.sub
-        i32.load
-        br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $resolve-propertyaccess/Class $invalid
+   block $~lib/array/Array<i32>
+    block $issues/2730/Box
+     block $~lib/arraybuffer/ArrayBufferView
+      block $~lib/string/String
+       block $~lib/arraybuffer/ArrayBuffer
+        block $~lib/object/Object
+         local.get $0
+         i32.const 8
+         i32.sub
+         i32.load
+         br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $issues/2730/Box $~lib/array/Array<i32> $invalid
+        end
+        return
        end
        return
       end
       return
      end
+     local.get $0
+     local.get $1
+     call $~lib/arraybuffer/ArrayBufferView~visit
      return
     end
-    local.get $0
-    local.get $1
-    call $~lib/arraybuffer/ArrayBufferView~visit
     return
    end
+   local.get $0
+   local.get $1
+   call $~lib/array/Array<i32>~visit
    return
   end
   unreachable
  )
  (func $~start
-  call $start:resolve-propertyaccess
+  call $start:issues/2730
  )
  (func $~stack_check
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__data_end
   i32.lt_s
   if
-   i32.const 35472
-   i32.const 35520
+   i32.const 33456
+   i32.const 33504
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
  )
- (func $~lib/string/String.__eq (param $left i32) (param $right i32) (result i32)
-  (local $leftLength i32)
-  (local $3 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $left
-  local.get $right
-  i32.eq
-  if
-   i32.const 1
-   local.set $3
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $3
-   return
-  end
-  local.get $left
-  i32.const 0
-  i32.eq
-  if (result i32)
-   i32.const 1
-  else
-   local.get $right
-   i32.const 0
-   i32.eq
-  end
-  if
-   i32.const 0
-   local.set $3
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $3
-   return
-  end
-  local.get $left
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
-  call $~lib/string/String#get:length
-  local.set $leftLength
-  local.get $leftLength
-  local.get $right
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
-  call $~lib/string/String#get:length
-  i32.ne
-  if
-   i32.const 0
-   local.set $3
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $3
-   return
-  end
-  local.get $left
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store
-  local.get $3
-  i32.const 0
-  local.get $right
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  local.get $leftLength
-  call $~lib/util/string/compareImpl
-  i32.eqz
-  local.set $3
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $3
-  return
- )
- (func $resolve-propertyaccess/Class#constructor (param $this i32) (result i32)
+ (func $issues/2730/Box#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
@@ -3018,8 +2800,8 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  i32.const 6
-  call $resolve-propertyaccess/Class#set:instanceField
+  i32.const 0
+  call $issues/2730/Box#set:value
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3028,300 +2810,562 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $start:resolve-propertyaccess
-  (local $0 i32)
+ (func $issues/2730/resetBox (param $value i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.store offset=8
-  memory.size
-  i32.const 16
-  i32.shl
-  global.get $~lib/memory/__heap_base
-  i32.sub
-  i32.const 1
-  i32.shr_u
-  global.set $~lib/rt/itcms/threshold
-  i32.const 368
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/pinSpace
-  i32.const 400
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/toSpace
-  i32.const 544
-  call $~lib/rt/itcms/initLazy
-  global.set $~lib/rt/itcms/fromSpace
-  global.get $resolve-propertyaccess/Namespace.member
-  i32.const 10
-  call $~lib/number/I32#toString
+  i32.store
+  global.get $issues/2730/box
   local.set $1
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store
   local.get $1
-  i32.const 2208
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 6
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/Namespace.lazyMember
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2320
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 12
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/MergedNamespace.member
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2352
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 24
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/MergedNamespace.lazyMember
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2384
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 30
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/TypedNamespace.member
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2416
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 42
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/TypedNamespace.lazyMember
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2448
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 48
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/Enum.VALUE
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2480
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 58
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/Class.staticField
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2512
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 72
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $resolve-propertyaccess/Class.lazyStaticField
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2544
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 78
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  call $resolve-propertyaccess/Class.get:staticProperty
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2576
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 84
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
+  local.get $value
+  call $issues/2730/Box#set:value
   i32.const 0
-  call $resolve-propertyaccess/Class#constructor
-  local.tee $0
-  i32.store offset=4
-  local.get $0
-  local.set $1
+  global.set $issues/2730/boxCalls
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
-  call $resolve-propertyaccess/Class#get:instanceField
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2608
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 92
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $0
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=8
-  local.get $1
-  call $resolve-propertyaccess/Class#get:instanceProperty
-  i32.const 10
-  call $~lib/number/I32#toString
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store
-  local.get $1
-  i32.const 2640
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 2240
-   i32.const 97
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 12
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/util/number/itoa32 (param $value i32) (param $radix i32) (result i32)
-  (local $sign i32)
-  (local $out i32)
-  (local $decimals i32)
-  (local $buffer i32)
-  (local $num i32)
-  (local $offset i32)
-  (local $decimals|8 i32)
-  (local $buffer|9 i32)
-  (local $num|10 i32)
-  (local $offset|11 i32)
-  (local $val32 i32)
-  (local $decimals|13 i32)
+ (func $issues/2730/testPropertyCompoundAssignments
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 56
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 56
+  memory.fill
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $0
+  i32.store
+  local.get $0
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $0
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 2
+  i32.add
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 10
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 33
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $1
+  i32.store offset=12
+  local.get $1
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $1
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 3
+  i32.sub
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 5
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 38
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $2
+  i32.store offset=16
+  local.get $2
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $2
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 3
+  i32.mul
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 24
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 43
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $3
+  i32.store offset=20
+  local.get $3
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $3
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 2
+  i32.div_s
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 48
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $4
+  i32.store offset=24
+  local.get $4
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $4
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 3
+  i32.rem_s
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 53
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $5
+  i32.store offset=28
+  local.get $5
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $5
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 1
+  i32.shl
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 16
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 58
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $6
+  i32.store offset=32
+  local.get $6
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $6
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 1
+  i32.shr_s
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 63
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const -8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $7
+  i32.store offset=36
+  local.get $7
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $7
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 1
+  i32.shr_u
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 2147483644
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 68
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 10
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $8
+  i32.store offset=40
+  local.get $8
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $8
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 3
+  i32.and
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 73
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $9
+  i32.store offset=44
+  local.get $9
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $9
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 3
+  i32.or
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 11
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 78
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $10
+  i32.store offset=48
+  local.get $10
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $10
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 3
+  i32.xor
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 11
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 83
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  i32.const 3
+  call $issues/2730/resetBox
+  global.get $~lib/memory/__stack_pointer
+  call $issues/2730/getBox
+  local.tee $11
+  i32.store offset=52
+  local.get $11
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  local.get $11
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=8
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 2
+  call $~lib/math/ipow32
+  call $issues/2730/Box#set:value
+  global.get $issues/2730/box
+  local.set $12
+  global.get $~lib/memory/__stack_pointer
+  local.get $12
+  i32.store offset=4
+  local.get $12
+  call $issues/2730/Box#get:value
+  i32.const 9
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 88
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  call $issues/2730/assertOneBoxCall
+  global.get $~lib/memory/__stack_pointer
+  i32.const 56
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/array/ensureCapacity (param $array i32) (param $newSize i32) (param $alignLog2 i32) (param $canGrow i32)
+  (local $oldCapacity i32)
+  (local $oldData i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $newCapacity i32)
+  (local $9 i32)
+  (local $10 i32)
+  (local $11 i32)
+  (local $12 i32)
+  (local $newData i32)
   (local $14 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -3331,165 +3375,329 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  local.get $radix
-  i32.const 2
-  i32.lt_s
-  if (result i32)
-   i32.const 1
-  else
-   local.get $radix
-   i32.const 36
-   i32.gt_s
-  end
+  local.get $array
+  local.set $14
+  global.get $~lib/memory/__stack_pointer
+  local.get $14
+  i32.store
+  local.get $14
+  call $~lib/arraybuffer/ArrayBufferView#get:byteLength
+  local.set $oldCapacity
+  local.get $newSize
+  local.get $oldCapacity
+  local.get $alignLog2
+  i32.shr_u
+  i32.gt_u
   if
-   i32.const 32
-   i32.const 160
-   i32.const 373
-   i32.const 5
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $value
-  i32.eqz
-  if
-   i32.const 224
+   local.get $newSize
+   i32.const 1073741820
+   local.get $alignLog2
+   i32.shr_u
+   i32.gt_u
+   if
+    i32.const 608
+    i32.const 560
+    i32.const 19
+    i32.const 48
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $array
    local.set $14
    global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
    local.get $14
-   return
-  end
-  local.get $value
-  i32.const 31
-  i32.shr_u
-  i32.const 1
-  i32.shl
-  local.set $sign
-  local.get $sign
-  if
-   i32.const 0
-   local.get $value
-   i32.sub
-   local.set $value
-  end
-  local.get $radix
-  i32.const 10
-  i32.eq
-  if
-   local.get $value
-   call $~lib/util/number/decimalCount32
-   local.set $decimals
-   global.get $~lib/memory/__stack_pointer
-   local.get $decimals
-   i32.const 1
-   i32.shl
-   local.get $sign
-   i32.add
-   i32.const 2
-   call $~lib/rt/itcms/__new
-   local.tee $out
    i32.store
-   local.get $out
-   local.get $sign
-   i32.add
-   local.set $buffer
-   local.get $value
-   local.set $num
-   local.get $decimals
-   local.set $offset
-   i32.const 0
-   i32.const 1
-   i32.ge_s
-   drop
-   local.get $buffer
-   local.get $num
-   local.get $offset
-   call $~lib/util/number/utoa32_dec_lut
-  else
-   local.get $radix
-   i32.const 16
-   i32.eq
+   local.get $14
+   call $~lib/arraybuffer/ArrayBufferView#get:buffer
+   local.set $oldData
+   local.get $newSize
+   local.tee $6
+   i32.const 8
+   local.tee $7
+   local.get $6
+   local.get $7
+   i32.gt_u
+   select
+   local.get $alignLog2
+   i32.shl
+   local.set $newCapacity
+   local.get $canGrow
    if
-    i32.const 31
-    local.get $value
-    i32.clz
-    i32.sub
-    i32.const 2
-    i32.shr_s
-    i32.const 1
-    i32.add
-    local.set $decimals|8
-    global.get $~lib/memory/__stack_pointer
-    local.get $decimals|8
+    local.get $oldCapacity
     i32.const 1
     i32.shl
-    local.get $sign
-    i32.add
-    i32.const 2
-    call $~lib/rt/itcms/__new
-    local.tee $out
-    i32.store
-    local.get $out
-    local.get $sign
-    i32.add
-    local.set $buffer|9
-    local.get $value
-    local.set $num|10
-    local.get $decimals|8
-    local.set $offset|11
-    i32.const 0
-    i32.const 1
-    i32.ge_s
-    drop
-    local.get $buffer|9
-    local.get $num|10
-    i64.extend_i32_u
-    local.get $offset|11
-    call $~lib/util/number/utoa_hex_lut
-   else
-    local.get $value
-    local.set $val32
-    local.get $val32
-    i64.extend_i32_u
-    local.get $radix
-    call $~lib/util/number/ulog_base
-    local.set $decimals|13
-    global.get $~lib/memory/__stack_pointer
-    local.get $decimals|13
-    i32.const 1
-    i32.shl
-    local.get $sign
-    i32.add
-    i32.const 2
-    call $~lib/rt/itcms/__new
-    local.tee $out
-    i32.store
-    local.get $out
-    local.get $sign
-    i32.add
-    local.get $val32
-    i64.extend_i32_u
-    local.get $decimals|13
-    local.get $radix
-    call $~lib/util/number/utoa64_any_core
+    local.tee $9
+    i32.const 1073741820
+    local.tee $10
+    local.get $9
+    local.get $10
+    i32.lt_u
+    select
+    local.tee $11
+    local.get $newCapacity
+    local.tee $12
+    local.get $11
+    local.get $12
+    i32.gt_u
+    select
+    local.set $newCapacity
    end
+   local.get $oldData
+   local.get $newCapacity
+   call $~lib/rt/itcms/__renew
+   local.set $newData
+   i32.const 2
+   global.get $~lib/shared/runtime/Runtime.Incremental
+   i32.ne
+   drop
+   local.get $newData
+   local.get $oldData
+   i32.ne
+   if
+    local.get $array
+    local.get $newData
+    i32.store
+    local.get $array
+    local.get $newData
+    i32.store offset=4
+    local.get $array
+    local.get $newData
+    i32.const 0
+    call $~lib/rt/itcms/__link
+   end
+   local.get $array
+   local.get $newCapacity
+   i32.store offset=8
   end
-  local.get $sign
-  if
-   local.get $out
-   i32.const 45
-   i32.store16
-  end
-  local.get $out
-  local.set $14
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
-  local.get $14
+ )
+ (func $~lib/array/Array<i32>#__set (param $this i32) (param $index i32) (param $value i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $index
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store
+  local.get $3
+  call $~lib/array/Array<i32>#get:length_
+  i32.ge_u
+  if
+   local.get $index
+   i32.const 0
+   i32.lt_s
+   if
+    i32.const 224
+    i32.const 560
+    i32.const 130
+    i32.const 22
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $this
+   local.get $index
+   i32.const 1
+   i32.add
+   i32.const 2
+   i32.const 1
+   call $~lib/array/ensureCapacity
+   local.get $this
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store
+   local.get $3
+   local.get $index
+   i32.const 1
+   i32.add
+   call $~lib/array/Array<i32>#set:length_
+  end
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store
+  local.get $3
+  call $~lib/array/Array<i32>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  local.get $value
+  i32.store
+  i32.const 0
+  drop
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/array/Array<i32>#__get (param $this i32) (param $index i32) (result i32)
+  (local $value i32)
+  (local $3 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $index
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store
+  local.get $3
+  call $~lib/array/Array<i32>#get:length_
+  i32.ge_u
+  if
+   i32.const 224
+   i32.const 560
+   i32.const 114
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $this
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  local.get $3
+  i32.store
+  local.get $3
+  call $~lib/array/Array<i32>#get:dataStart
+  local.get $index
+  i32.const 2
+  i32.shl
+  i32.add
+  i32.load
+  local.set $value
+  i32.const 0
+  drop
+  local.get $value
+  local.set $3
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $3
   return
+ )
+ (func $issues/2730/testElementCompoundAssignments
+  (local $0 i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i64.const 0
+  i64.store
+  i32.const 0
+  global.set $issues/2730/idxCalls
+  global.get $issues/2730/arr
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  i32.const 1
+  call $~lib/array/Array<i32>#__set
+  call $issues/2730/getIndex
+  local.set $0
+  global.get $issues/2730/arr
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  local.get $0
+  global.get $issues/2730/arr
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=4
+  local.get $1
+  local.get $0
+  call $~lib/array/Array<i32>#__get
+  i32.const 2
+  i32.or
+  call $~lib/array/Array<i32>#__set
+  global.get $issues/2730/arr
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store
+  local.get $1
+  i32.const 0
+  call $~lib/array/Array<i32>#__get
+  i32.const 3
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 96
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $issues/2730/idxCalls
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 512
+   i32.const 97
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/array/Array<i32>#__visit (param $this i32) (param $cookie i32)
+  (local $2 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  i32.const 0
+  drop
+  local.get $this
+  local.set $2
+  global.get $~lib/memory/__stack_pointer
+  local.get $2
+  i32.store
+  local.get $2
+  call $~lib/array/Array<i32>#get:buffer
+  local.get $cookie
+  call $~lib/rt/itcms/__visit
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/object/Object#constructor (param $this i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/issues/2730.release.wat
+++ b/tests/compiler/issues/2730.release.wat
@@ -1,9 +1,9 @@
 (module
- (type $0 (func))
- (type $1 (func (param i32)))
+ (type $0 (func (param i32)))
+ (type $1 (func))
  (type $2 (func (param i32 i32)))
  (type $3 (func (result i32)))
- (type $4 (func (param i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
  (type $5 (func (param i32 i32 i32 i32)))
  (type $6 (func (param i32 i32 i64)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
@@ -17,7 +17,10 @@
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/fromSpace (mut i32) (i32.const 0))
  (global $~lib/rt/tlsf/ROOT (mut i32) (i32.const 0))
- (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34492))
+ (global $issues/2730/box (mut i32) (i32.const 0))
+ (global $issues/2730/boxCalls (mut i32) (i32.const 0))
+ (global $issues/2730/idxCalls (mut i32) (i32.const 0))
+ (global $~lib/memory/__stack_pointer (mut i32) (i32.const 34460))
  (memory $0 1)
  (data $0 (i32.const 1036) "<")
  (data $0.1 (i32.const 1048) "\02\00\00\00(\00\00\00A\00l\00l\00o\00c\00a\00t\00i\00o\00n\00 \00t\00o\00o\00 \00l\00a\00r\00g\00e")
@@ -29,19 +32,33 @@
  (data $5.1 (i32.const 1304) "\02\00\00\00\14\00\00\00~\00l\00i\00b\00/\00r\00t\00.\00t\00s")
  (data $7 (i32.const 1372) "<")
  (data $7.1 (i32.const 1384) "\02\00\00\00\1e\00\00\00~\00l\00i\00b\00/\00r\00t\00/\00t\00l\00s\00f\00.\00t\00s")
- (data $8 (i32.const 1436) "|")
- (data $8.1 (i32.const 1448) "\02\00\00\00^\00\00\00U\00n\00e\00x\00p\00e\00c\00t\00e\00d\00 \00\'\00n\00u\00l\00l\00\'\00 \00(\00n\00o\00t\00 \00a\00s\00s\00i\00g\00n\00e\00d\00 \00o\00r\00 \00f\00a\00i\00l\00e\00d\00 \00c\00a\00s\00t\00)")
- (data $9 (i32.const 1564) "<")
- (data $9.1 (i32.const 1576) "\02\00\00\00\1e\00\00\00m\00a\00n\00a\00g\00e\00d\00-\00c\00a\00s\00t\00.\00t\00s")
- (data $10 (i32.const 1628) "<")
- (data $10.1 (i32.const 1640) "\02\00\00\00 \00\00\00i\00n\00v\00a\00l\00i\00d\00 \00d\00o\00w\00n\00c\00a\00s\00t")
- (data $11 (i32.const 1696) "\06\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00 ")
+ (data $8 (i32.const 1436) "\1c")
+ (data $8.1 (i32.const 1448) "\01\00\00\00\08\00\00\00\01\00\00\00\02")
+ (data $9 (i32.const 1468) ",")
+ (data $9.1 (i32.const 1480) "\05\00\00\00\10\00\00\00\b0\05\00\00\b0\05\00\00\08\00\00\00\02")
+ (data $10 (i32.const 1516) ",")
+ (data $10.1 (i32.const 1528) "\02\00\00\00\1c\00\00\00i\00s\00s\00u\00e\00s\00/\002\007\003\000\00.\00t\00s")
+ (data $11 (i32.const 1564) ",")
+ (data $11.1 (i32.const 1576) "\02\00\00\00\1a\00\00\00~\00l\00i\00b\00/\00a\00r\00r\00a\00y\00.\00t\00s")
+ (data $12 (i32.const 1612) ",")
+ (data $12.1 (i32.const 1624) "\02\00\00\00\1c\00\00\00I\00n\00v\00a\00l\00i\00d\00 \00l\00e\00n\00g\00t\00h")
+ (data $13 (i32.const 1664) "\06\00\00\00 \00\00\00 \00\00\00 \00\00\00\00\00\00\00 \00\00\00\02\t")
  (export "memory" (memory $0))
  (start $~start)
  (func $~lib/rt/itcms/visitRoots
   (local $0 i32)
   (local $1 i32)
+  global.get $issues/2730/box
+  local.tee $0
+  if
+   local.get $0
+   call $~lib/rt/itcms/__visit
+  end
+  i32.const 1488
+  call $~lib/rt/itcms/__visit
   i32.const 1248
+  call $~lib/rt/itcms/__visit
+  i32.const 1632
   call $~lib/rt/itcms/__visit
   i32.const 1056
   call $~lib/rt/itcms/__visit
@@ -83,10 +100,139 @@
    end
   end
  )
- (func $~lib/rt/itcms/__visit (param $0 i32)
+ (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
+  local.get $0
+  global.get $~lib/rt/itcms/iter
+  i32.eq
+  if
+   local.get $0
+   i32.load offset=8
+   local.tee $1
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 148
+    i32.const 30
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   global.set $~lib/rt/itcms/iter
+  end
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$198
+   local.get $0
+   i32.load offset=4
+   i32.const -4
+   i32.and
+   local.tee $1
+   i32.eqz
+   if
+    local.get $0
+    i32.load offset=8
+    i32.eqz
+    local.get $0
+    i32.const 34460
+    i32.lt_u
+    i32.and
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1120
+     i32.const 128
+     i32.const 18
+     call $~lib/builtins/abort
+     unreachable
+    end
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$198
+   end
+   local.get $0
+   i32.load offset=8
+   local.tee $2
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 132
+    i32.const 16
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   local.get $1
+   local.get $2
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.or
+   i32.store offset=4
+  end
+  global.get $~lib/rt/itcms/toSpace
+  local.set $2
+  local.get $0
+  i32.load offset=12
+  local.tee $1
+  i32.const 2
+  i32.le_u
+  if (result i32)
+   i32.const 1
+  else
+   local.get $1
+   i32.const 1664
+   i32.load
+   i32.gt_u
+   if
+    i32.const 1248
+    i32.const 1312
+    i32.const 21
+    i32.const 28
+    call $~lib/builtins/abort
+    unreachable
+   end
+   local.get $1
+   i32.const 2
+   i32.shl
+   i32.const 1668
+   i32.add
+   i32.load
+   i32.const 32
+   i32.and
+  end
+  local.set $3
+  local.get $2
+  i32.load offset=8
+  local.set $1
+  local.get $0
+  global.get $~lib/rt/itcms/white
+  i32.eqz
+  i32.const 2
+  local.get $3
+  select
+  local.get $2
+  i32.or
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  i32.store offset=8
+  local.get $1
+  local.get $0
+  local.get $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.or
+  i32.store offset=4
+  local.get $2
+  local.get $0
+  i32.store offset=8
+ )
+ (func $~lib/rt/itcms/__visit (param $0 i32)
   local.get $0
   i32.eqz
   if
@@ -96,139 +242,14 @@
   local.get $0
   i32.const 20
   i32.sub
-  local.tee $1
+  local.tee $0
   i32.load offset=4
   i32.const 3
   i32.and
   i32.eq
   if
-   local.get $1
-   global.get $~lib/rt/itcms/iter
-   i32.eq
-   if
-    local.get $1
-    i32.load offset=8
-    local.tee $0
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 148
-     i32.const 30
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    global.set $~lib/rt/itcms/iter
-   end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$136
-    local.get $1
-    i32.load offset=4
-    i32.const -4
-    i32.and
-    local.tee $0
-    i32.eqz
-    if
-     local.get $1
-     i32.load offset=8
-     i32.eqz
-     local.get $1
-     i32.const 34492
-     i32.lt_u
-     i32.and
-     i32.eqz
-     if
-      i32.const 0
-      i32.const 1120
-      i32.const 128
-      i32.const 18
-      call $~lib/builtins/abort
-      unreachable
-     end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$136
-    end
-    local.get $1
-    i32.load offset=8
-    local.tee $2
-    i32.eqz
-    if
-     i32.const 0
-     i32.const 1120
-     i32.const 132
-     i32.const 16
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    local.get $2
-    i32.store offset=8
-    local.get $2
-    local.get $0
-    local.get $2
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    i32.or
-    i32.store offset=4
-   end
-   global.get $~lib/rt/itcms/toSpace
-   local.set $2
-   local.get $1
-   i32.load offset=12
-   local.tee $0
-   i32.const 2
-   i32.le_u
-   if (result i32)
-    i32.const 1
-   else
-    local.get $0
-    i32.const 1696
-    i32.load
-    i32.gt_u
-    if
-     i32.const 1248
-     i32.const 1312
-     i32.const 21
-     i32.const 28
-     call $~lib/builtins/abort
-     unreachable
-    end
-    local.get $0
-    i32.const 2
-    i32.shl
-    i32.const 1700
-    i32.add
-    i32.load
-    i32.const 32
-    i32.and
-   end
-   local.set $3
-   local.get $2
-   i32.load offset=8
-   local.set $0
-   local.get $1
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.const 2
-   local.get $3
-   select
-   local.get $2
-   i32.or
-   i32.store offset=4
-   local.get $1
    local.get $0
-   i32.store offset=8
-   local.get $0
-   local.get $1
-   local.get $0
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.or
-   i32.store offset=4
-   local.get $2
-   local.get $1
-   i32.store offset=8
+   call $~lib/rt/itcms/Object#makeGray
    global.get $~lib/rt/itcms/visitCount
    i32.const 1
    i32.add
@@ -761,10 +782,10 @@
   if
    unreachable
   end
-  i32.const 34496
+  i32.const 34464
   i32.const 0
   i32.store
-  i32.const 36064
+  i32.const 36032
   i32.const 0
   i32.store
   loop $for-loop|0
@@ -775,7 +796,7 @@
     local.get $0
     i32.const 2
     i32.shl
-    i32.const 34496
+    i32.const 34464
     i32.add
     i32.const 0
     i32.store offset=4
@@ -793,7 +814,7 @@
       i32.add
       i32.const 2
       i32.shl
-      i32.const 34496
+      i32.const 34464
       i32.add
       i32.const 0
       i32.store offset=96
@@ -811,14 +832,14 @@
     br $for-loop|0
    end
   end
-  i32.const 34496
-  i32.const 36068
+  i32.const 34464
+  i32.const 36036
   memory.size
   i64.extend_i32_s
   i64.const 16
   i64.shl
   call $~lib/rt/tlsf/addMemory
-  i32.const 34496
+  i32.const 34464
   global.set $~lib/rt/tlsf/ROOT
  )
  (func $~lib/rt/itcms/step (result i32)
@@ -903,7 +924,7 @@
      local.set $0
      loop $while-continue|0
       local.get $0
-      i32.const 34492
+      i32.const 34460
       i32.lt_u
       if
        local.get $0
@@ -999,7 +1020,7 @@
      unreachable
     end
     local.get $0
-    i32.const 34492
+    i32.const 34460
     i32.lt_u
     if
      local.get $0
@@ -1022,7 +1043,7 @@
      i32.const 4
      i32.add
      local.tee $0
-     i32.const 34492
+     i32.const 34460
      i32.ge_u
      if
       global.get $~lib/rt/tlsf/ROOT
@@ -1081,18 +1102,85 @@
   end
   i32.const 0
  )
- (func $~lib/rt/tlsf/searchBlock (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  local.get $1
+  i32.const 256
+  i32.lt_u
+  if
+   local.get $1
+   i32.const 4
+   i32.shr_u
+   local.set $1
+  else
+   local.get $1
+   i32.const 536870910
+   i32.lt_u
+   if
+    local.get $1
+    i32.const 1
+    i32.const 27
+    local.get $1
+    i32.clz
+    i32.sub
+    i32.shl
+    i32.add
+    i32.const 1
+    i32.sub
+    local.set $1
+   end
+   local.get $1
+   i32.const 31
+   local.get $1
+   i32.clz
+   i32.sub
+   local.tee $2
+   i32.const 4
+   i32.sub
+   i32.shr_u
+   i32.const 16
+   i32.xor
+   local.set $1
+   local.get $2
+   i32.const 7
+   i32.sub
+   local.set $2
+  end
+  local.get $1
+  i32.const 16
+  i32.lt_u
+  local.get $2
+  i32.const 23
+  i32.lt_u
+  i32.and
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 334
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
   local.get $0
+  local.get $2
+  i32.const 2
+  i32.shl
+  i32.add
   i32.load offset=4
-  i32.const -2
+  i32.const -1
+  local.get $1
+  i32.shl
   i32.and
   local.tee $1
   if (result i32)
    local.get $0
    local.get $1
    i32.ctz
+   local.get $2
+   i32.const 4
+   i32.shl
+   i32.add
    i32.const 2
    i32.shl
    i32.add
@@ -1100,19 +1188,23 @@
   else
    local.get $0
    i32.load
-   i32.const -2
+   i32.const -1
+   local.get $2
+   i32.const 1
+   i32.add
+   i32.shl
    i32.and
    local.tee $1
    if (result i32)
     local.get $0
     local.get $1
     i32.ctz
-    local.tee $2
+    local.tee $1
     i32.const 2
     i32.shl
     i32.add
     i32.load offset=4
-    local.tee $1
+    local.tee $2
     i32.eqz
     if
      i32.const 0
@@ -1123,9 +1215,9 @@
      unreachable
     end
     local.get $0
-    local.get $1
-    i32.ctz
     local.get $2
+    i32.ctz
+    local.get $1
     i32.const 4
     i32.shl
     i32.add
@@ -1138,23 +1230,35 @@
    end
   end
  )
- (func $~lib/rt/itcms/__new (param $0 i32) (result i32)
-  (local $1 i32)
+ (func $~lib/rt/itcms/__new (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  local.get $0
+  i32.const 1073741804
+  i32.ge_u
+  if
+   i32.const 1056
+   i32.const 1120
+   i32.const 261
+   i32.const 31
+   call $~lib/builtins/abort
+   unreachable
+  end
   global.get $~lib/rt/itcms/total
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
    block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
-    local.set $1
+    local.set $2
     loop $do-loop|0
-     local.get $1
+     local.get $2
      call $~lib/rt/itcms/step
      i32.sub
-     local.set $1
+     local.set $2
      global.get $~lib/rt/itcms/state
      i32.eqz
      if
@@ -1166,7 +1270,7 @@
       global.set $~lib/rt/itcms/threshold
       br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
-     local.get $1
+     local.get $2
      i32.const 0
      i32.gt_s
      br_if $do-loop|0
@@ -1189,31 +1293,86 @@
    call $~lib/rt/tlsf/initialize
   end
   global.get $~lib/rt/tlsf/ROOT
+  local.set $4
+  local.get $0
+  i32.const 16
+  i32.add
   local.tee $2
+  i32.const 1073741820
+  i32.gt_u
+  if
+   i32.const 1056
+   i32.const 1392
+   i32.const 461
+   i32.const 29
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $4
+  local.get $2
+  i32.const 12
+  i32.le_u
+  if (result i32)
+   i32.const 12
+  else
+   local.get $2
+   i32.const 19
+   i32.add
+   i32.const -16
+   i32.and
+   i32.const 4
+   i32.sub
+  end
+  local.tee $5
   call $~lib/rt/tlsf/searchBlock
-  local.tee $1
+  local.tee $2
   i32.eqz
   if
    memory.size
-   local.tee $1
+   local.tee $2
+   local.get $5
+   i32.const 256
+   i32.ge_u
+   if (result i32)
+    local.get $5
+    i32.const 536870910
+    i32.lt_u
+    if (result i32)
+     local.get $5
+     i32.const 1
+     i32.const 27
+     local.get $5
+     i32.clz
+     i32.sub
+     i32.shl
+     i32.add
+     i32.const 1
+     i32.sub
+    else
+     local.get $5
+    end
+   else
+    local.get $5
+   end
    i32.const 4
-   local.get $2
+   local.get $4
    i32.load offset=1568
-   local.get $1
+   local.get $2
    i32.const 16
    i32.shl
    i32.const 4
    i32.sub
    i32.ne
    i32.shl
-   i32.const 65563
+   i32.add
+   i32.const 65535
    i32.add
    i32.const -65536
    i32.and
    i32.const 16
    i32.shr_u
    local.tee $3
-   local.get $1
+   local.get $2
    local.get $3
    i32.gt_s
    select
@@ -1229,8 +1388,8 @@
      unreachable
     end
    end
+   local.get $4
    local.get $2
-   local.get $1
    i32.const 16
    i32.shl
    memory.size
@@ -1238,9 +1397,10 @@
    i64.const 16
    i64.shl
    call $~lib/rt/tlsf/addMemory
-   local.get $2
+   local.get $4
+   local.get $5
    call $~lib/rt/tlsf/searchBlock
-   local.tee $1
+   local.tee $2
    i32.eqz
    if
     i32.const 0
@@ -1251,12 +1411,12 @@
     unreachable
    end
   end
-  local.get $1
+  local.get $5
+  local.get $2
   i32.load
   i32.const -4
   i32.and
-  i32.const 28
-  i32.lt_u
+  i32.gt_u
   if
    i32.const 0
    i32.const 1392
@@ -1265,92 +1425,108 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $4
   local.get $2
-  local.get $1
   call $~lib/rt/tlsf/removeBlock
-  local.get $1
+  local.get $2
   i32.load
-  local.tee $3
+  local.set $6
+  local.get $5
+  i32.const 4
+  i32.add
+  i32.const 15
+  i32.and
+  if
+   i32.const 0
+   i32.const 1392
+   i32.const 361
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $6
   i32.const -4
   i32.and
-  i32.const 28
+  local.get $5
   i32.sub
-  local.tee $4
+  local.tee $3
   i32.const 16
   i32.ge_u
   if
-   local.get $1
-   local.get $3
+   local.get $2
+   local.get $5
+   local.get $6
    i32.const 2
    i32.and
-   i32.const 28
    i32.or
    i32.store
-   local.get $1
-   i32.const 32
+   local.get $2
+   i32.const 4
    i32.add
-   local.tee $3
-   local.get $4
+   local.get $5
+   i32.add
+   local.tee $5
+   local.get $3
    i32.const 4
    i32.sub
    i32.const 1
    i32.or
    i32.store
-   local.get $2
-   local.get $3
+   local.get $4
+   local.get $5
    call $~lib/rt/tlsf/insertBlock
   else
-   local.get $1
-   local.get $3
+   local.get $2
+   local.get $6
    i32.const -2
    i32.and
    i32.store
-   local.get $1
+   local.get $2
    i32.const 4
    i32.add
-   local.get $1
+   local.get $2
    i32.load
    i32.const -4
    i32.and
    i32.add
-   local.tee $2
-   local.get $2
+   local.tee $3
+   local.get $3
    i32.load
    i32.const -3
    i32.and
    i32.store
   end
+  local.get $2
   local.get $1
-  local.get $0
   i32.store offset=12
-  local.get $1
-  i32.const 0
+  local.get $2
+  local.get $0
   i32.store offset=16
   global.get $~lib/rt/itcms/fromSpace
-  local.tee $0
+  local.tee $1
   i32.load offset=8
-  local.set $2
+  local.set $3
+  local.get $2
   local.get $1
-  local.get $0
   global.get $~lib/rt/itcms/white
   i32.or
   i32.store offset=4
-  local.get $1
   local.get $2
+  local.get $3
   i32.store offset=8
+  local.get $3
   local.get $2
-  local.get $1
-  local.get $2
+  local.get $3
   i32.load offset=4
   i32.const 3
   i32.and
   i32.or
   i32.store offset=4
-  local.get $0
   local.get $1
+  local.get $2
   i32.store offset=8
   global.get $~lib/rt/itcms/total
-  local.get $1
+  local.get $2
   i32.load
   i32.const -4
   i32.and
@@ -1358,19 +1534,19 @@
   i32.add
   i32.add
   global.set $~lib/rt/itcms/total
-  local.get $1
+  local.get $2
   i32.const 20
   i32.add
-  local.tee $0
+  local.tee $1
   i32.const 0
-  i32.const 0
-  memory.fill
   local.get $0
+  memory.fill
+  local.get $1
  )
  (func $~lib/rt/__visit_members (param $0 i32)
   block $invalid
-   block $managed-cast/Animal
-    block $managed-cast/Cat
+   block $~lib/array/Array<i32>
+    block $issues/2730/Box
      block $~lib/arraybuffer/ArrayBufferView
       block $~lib/string/String
        block $~lib/arraybuffer/ArrayBuffer
@@ -1379,7 +1555,7 @@
          i32.const 8
          i32.sub
          i32.load
-         br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $managed-cast/Cat $managed-cast/Animal $invalid
+         br_table $~lib/object/Object $~lib/arraybuffer/ArrayBuffer $~lib/string/String $~lib/arraybuffer/ArrayBufferView $issues/2730/Box $~lib/array/Array<i32> $invalid
         end
         return
        end
@@ -1394,6 +1570,34 @@
     end
     return
    end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1692
+   i32.lt_s
+   if
+    i32.const 34480
+    i32.const 34528
+    i32.const 1
+    i32.const 1
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   i32.load
+   call $~lib/rt/itcms/__visit
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
    return
   end
   unreachable
@@ -1401,22 +1605,11 @@
  (func $~start
   (local $0 i32)
   (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
+  block $__inlined_func$start:issues/2730
    memory.size
    i32.const 16
    i32.shl
-   i32.const 34492
+   i32.const 34460
    i32.sub
    i32.const 1
    i32.shr_u
@@ -1445,473 +1638,948 @@
    i32.store
    i32.const 1344
    global.set $~lib/rt/itcms/fromSpace
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
    global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.eqz
-   if
-    i32.const 1456
-    i32.const 1584
-    i32.const 14
-    i32.const 12
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   call $managed-cast/testUpcastToNullable
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   local.get $0
-   call $managed-cast/testUpcastToNullable
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   block $__inlined_func$~instanceof|managed-cast/Cat$84 (result i32)
+   block $folding-inner0
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=4
-    i32.const 0
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load
+    i32.const 1692
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i64.const 0
+    i64.store
+    global.get $~lib/memory/__stack_pointer
     i32.const 4
-    i32.ne
-    br_if $__inlined_func$~instanceof|managed-cast/Cat$84
-    drop
-    i32.const 1
-   end
-   i32.eqz
-   if
-    i32.const 1648
-    i32.const 1584
-    i32.const 31
-    i32.const 9
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   block $__inlined_func$~instanceof|managed-cast/Cat$87 (result i32)
+    i32.const 4
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=4
     global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1692
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store
     local.get $0
     i32.eqz
     if
-     i32.const 1456
-     i32.const 1584
-     i32.const 36
-     i32.const 9
-     call $~lib/builtins/abort
-     unreachable
+     global.get $~lib/memory/__stack_pointer
+     i32.const 0
+     i32.const 0
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store
     end
-    local.get $0
-    i32.store offset=8
-    i32.const 0
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load
-    i32.const 4
-    i32.ne
-    br_if $__inlined_func$~instanceof|managed-cast/Cat$87
-    drop
-    i32.const 1
-   end
-   i32.eqz
-   if
-    i32.const 1648
-    i32.const 1584
-    i32.const 36
-    i32.const 9
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$~instanceof|managed-cast/Cat$90 (result i32)
     global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
     local.get $0
     i32.store
-    i32.const 0
-    local.get $0
-    i32.const 8
-    i32.sub
-    i32.load
-    i32.const 4
-    i32.ne
-    br_if $__inlined_func$~instanceof|managed-cast/Cat$90
-    drop
-    i32.const 1
-   end
-   i32.eqz
-   if
-    i32.const 1648
-    i32.const 1584
-    i32.const 41
-    i32.const 30
-    call $~lib/builtins/abort
-    unreachable
-   end
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   if
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=8
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   call $managed-cast/Cat#constructor
-   local.set $0
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   if
+    i32.store offset=4
     local.get $0
+    i32.const 0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    local.get $0
+    global.set $issues/2730/box
+    call $issues/2730/testPropertyCompoundAssignments
+    global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.sub
-    i32.load
-    i32.const 4
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1692
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i64.const 0
+    i64.store
+    i32.const 0
+    global.set $issues/2730/idxCalls
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1488
+    i32.store
+    i32.const 1
+    call $~lib/array/Array<i32>#__set
+    global.get $issues/2730/idxCalls
+    i32.const 1
+    i32.add
+    global.set $issues/2730/idxCalls
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1488
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1488
+    i32.store offset=4
+    call $~lib/array/Array<i32>#__get
+    i32.const 2
+    i32.or
+    call $~lib/array/Array<i32>#__set
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1488
+    i32.store
+    call $~lib/array/Array<i32>#__get
+    i32.const 3
     i32.ne
     if
-     i32.const 1648
-     i32.const 1584
-     i32.const 47
-     i32.const 30
+     i32.const 0
+     i32.const 1536
+     i32.const 96
+     i32.const 3
      call $~lib/builtins/abort
      unreachable
     end
-   else
-    i32.const 0
-    local.set $0
-   end
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   if
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=8
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   i32.const 34492
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/rt/itcms/state
-   i32.const 0
-   i32.gt_s
-   if
-    loop $while-continue|0
-     global.get $~lib/rt/itcms/state
-     if
-      call $~lib/rt/itcms/step
-      drop
-      br $while-continue|0
-     end
-    end
-   end
-   call $~lib/rt/itcms/step
-   drop
-   loop $while-continue|1
-    global.get $~lib/rt/itcms/state
+    global.get $issues/2730/idxCalls
+    i32.const 1
+    i32.ne
     if
-     call $~lib/rt/itcms/step
-     drop
-     br $while-continue|1
+     i32.const 0
+     i32.const 1536
+     i32.const 97
+     i32.const 3
+     call $~lib/builtins/abort
+     unreachable
     end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    br $__inlined_func$start:issues/2730
    end
-   global.get $~lib/rt/itcms/total
-   i64.extend_i32_u
-   i64.const 200
-   i64.mul
-   i64.const 100
-   i64.div_u
-   i32.wrap_i64
-   i32.const 1024
-   i32.add
-   global.set $~lib/rt/itcms/threshold
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   return
+   i32.const 34480
+   i32.const 34528
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 34512
-  i32.const 34560
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
  )
- (func $managed-cast/Cat#constructor (result i32)
-  (local $0 i32)
+ (func $issues/2730/resetBox (param $0 i32)
   (local $1 i32)
-  (local $2 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  block $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   call $~lib/rt/itcms/__new
-   local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 5
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1724
-   i32.lt_s
-   br_if $folding-inner0
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.eqz
-   if
-    global.get $~lib/memory/__stack_pointer
-    i32.const 0
-    call $~lib/rt/itcms/__new
-    local.tee $0
-    i32.store
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $0
-   return
-  end
-  i32.const 34512
-  i32.const 34560
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
- )
- (func $managed-cast/testUpcastToNullable (param $0 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
-  i32.const 1724
+  i32.const 1692
   i32.lt_s
   if
-   i32.const 34512
-   i32.const 34560
+   i32.const 34480
+   i32.const 34528
    i32.const 1
    i32.const 1
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
+  i32.const 0
+  i32.store
   global.get $~lib/memory/__stack_pointer
+  global.get $issues/2730/box
+  local.tee $1
+  i32.store
+  local.get $1
   local.get $0
   i32.store
-  local.get $0
+  i32.const 0
+  global.set $issues/2730/boxCalls
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
+ (func $issues/2730/testPropertyCompoundAssignments
+  (local $0 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 56
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1692
+  i32.lt_s
   if
+   i32.const 34480
+   i32.const 34528
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.const 56
+  memory.fill
+  i32.const 8
+  call $issues/2730/resetBox
+  global.get $issues/2730/boxCalls
+  i32.const 1
+  i32.add
+  global.set $issues/2730/boxCalls
+  global.get $~lib/memory/__stack_pointer
+  global.get $issues/2730/box
+  local.tee $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store offset=8
+  local.get $0
+  local.get $0
+  i32.load
+  i32.const 2
+  i32.add
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  global.get $issues/2730/box
+  local.tee $0
+  i32.store offset=4
+  local.get $0
+  i32.load
+  i32.const 10
+  i32.ne
+  if
+   i32.const 0
+   i32.const 1536
+   i32.const 33
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $folding-inner0
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 3
+   i32.sub
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 5
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 38
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=16
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 3
+   i32.mul
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 24
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 43
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=20
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 2
+   i32.div_s
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 4
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 48
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=24
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 3
+   i32.rem_s
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 2
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 53
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=28
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 1
+   i32.shl
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 16
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 58
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=32
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 1
+   i32.shr_s
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 4
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 63
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const -8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=36
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 1
+   i32.shr_u
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 2147483644
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 68
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 10
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=40
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 3
+   i32.and
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 2
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 73
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=44
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 3
+   i32.or
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 11
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 78
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 8
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=48
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $0
+   i32.load
+   i32.const 3
+   i32.xor
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 11
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 83
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   i32.const 3
+   call $issues/2730/resetBox
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.add
+   global.set $issues/2730/boxCalls
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=52
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
+   block $__inlined_func$~lib/math/ipow32$141 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store offset=8
+    i32.const 4
+    local.get $0
+    i32.load
+    local.tee $0
+    i32.const 2
+    i32.eq
+    br_if $__inlined_func$~lib/math/ipow32$141
+    drop
+    local.get $0
+    local.get $0
+    i32.mul
+   end
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $issues/2730/box
+   local.tee $0
+   i32.store offset=4
+   local.get $0
+   i32.load
+   i32.const 9
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1536
+    i32.const 88
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $issues/2730/boxCalls
+   i32.const 1
+   i32.ne
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 56
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   return
+  end
+  i32.const 0
+  i32.const 1536
+  i32.const 19
+  i32.const 3
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $~lib/array/Array<i32>#__set (param $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1692
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1488
+   i32.store
+   i32.const 1500
+   i32.load
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1692
+    i32.lt_s
+    br_if $folding-inner0
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.store
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1488
+    i32.store
+    i32.const 1496
+    i32.load
+    local.tee $1
+    i32.const 2
+    i32.shr_u
+    i32.eqz
+    if
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1488
+     i32.store
+     block $__inlined_func$~lib/rt/itcms/__renew$195
+      i32.const 32
+      i32.const 1073741820
+      local.get $1
+      i32.const 1
+      i32.shl
+      local.tee $1
+      local.get $1
+      i32.const 1073741820
+      i32.ge_u
+      select
+      local.tee $1
+      local.get $1
+      i32.const 32
+      i32.le_u
+      select
+      local.tee $3
+      i32.const 1488
+      i32.load
+      local.tee $2
+      i32.const 20
+      i32.sub
+      local.tee $4
+      i32.load
+      i32.const -4
+      i32.and
+      i32.const 16
+      i32.sub
+      i32.le_u
+      if
+       local.get $4
+       local.get $3
+       i32.store offset=16
+       local.get $2
+       local.set $1
+       br $__inlined_func$~lib/rt/itcms/__renew$195
+      end
+      local.get $3
+      local.get $4
+      i32.load offset=12
+      call $~lib/rt/itcms/__new
+      local.tee $1
+      local.get $2
+      local.get $3
+      local.get $4
+      i32.load offset=16
+      local.tee $4
+      local.get $3
+      local.get $4
+      i32.lt_u
+      select
+      memory.copy
+     end
+     local.get $1
+     local.get $2
+     i32.ne
+     if
+      i32.const 1488
+      local.get $1
+      i32.store
+      i32.const 1492
+      local.get $1
+      i32.store
+      local.get $1
+      if
+       global.get $~lib/rt/itcms/white
+       local.get $1
+       i32.const 20
+       i32.sub
+       local.tee $1
+       i32.load offset=4
+       i32.const 3
+       i32.and
+       i32.eq
+       if
+        i32.const 1472
+        i32.load
+        i32.const 3
+        i32.and
+        local.tee $2
+        global.get $~lib/rt/itcms/white
+        i32.eqz
+        i32.eq
+        if
+         local.get $1
+         call $~lib/rt/itcms/Object#makeGray
+        else
+         global.get $~lib/rt/itcms/state
+         i32.const 1
+         i32.eq
+         local.get $2
+         i32.const 3
+         i32.eq
+         i32.and
+         if
+          local.get $1
+          call $~lib/rt/itcms/Object#makeGray
+         end
+        end
+       end
+      end
+     end
+     i32.const 1496
+     local.get $3
+     i32.store
+    end
+    global.get $~lib/memory/__stack_pointer
+    i32.const 4
+    i32.add
+    global.set $~lib/memory/__stack_pointer
+    global.get $~lib/memory/__stack_pointer
+    i32.const 1488
+    i32.store
+    i32.const 1500
+    i32.const 1
+    i32.store
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1488
+   i32.store
+   i32.const 1492
+   i32.load
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   return
+  end
+  i32.const 34480
+  i32.const 34528
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
+ )
+ (func $~lib/array/Array<i32>#__get (result i32)
+  (local $0 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1692
+  i32.lt_s
+  if
+   i32.const 34480
+   i32.const 34528
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 8
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1488
+  i32.store
+  i32.const 1500
+  i32.load
+  i32.eqz
+  if
+   i32.const 1248
+   i32.const 1584
+   i32.const 114
+   i32.const 42
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 1488
+  i32.store
+  i32.const 1492
+  i32.load
+  i32.load
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/issues/2730.ts
+++ b/tests/compiler/issues/2730.ts
@@ -1,0 +1,101 @@
+class Box {
+  value: i32 = 0;
+}
+
+let box = new Box();
+let boxCalls: i32 = 0;
+
+function getBox(): Box {
+  boxCalls++;
+  return box;
+}
+
+function resetBox(value: i32): void {
+  box.value = value;
+  boxCalls = 0;
+}
+
+function assertOneBoxCall(): void {
+  assert(boxCalls == 1);
+}
+
+let arr = [1, 2];
+let idxCalls: i32 = 0;
+
+function getIndex(): i32 {
+  idxCalls++;
+  return 0;
+}
+
+function testPropertyCompoundAssignments(): void {
+  resetBox(8);
+  getBox().value += 2;
+  assert(box.value == 10);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value -= 3;
+  assert(box.value == 5);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value *= 3;
+  assert(box.value == 24);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value /= 2;
+  assert(box.value == 4);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value %= 3;
+  assert(box.value == 2);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value <<= 1;
+  assert(box.value == 16);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value >>= 1;
+  assert(box.value == 4);
+  assertOneBoxCall();
+
+  resetBox(-8);
+  getBox().value >>>= 1;
+  assert(box.value == 2147483644);
+  assertOneBoxCall();
+
+  resetBox(10);
+  getBox().value &= 3;
+  assert(box.value == 2);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value |= 3;
+  assert(box.value == 11);
+  assertOneBoxCall();
+
+  resetBox(8);
+  getBox().value ^= 3;
+  assert(box.value == 11);
+  assertOneBoxCall();
+
+  resetBox(3);
+  getBox().value **= 2;
+  assert(box.value == 9);
+  assertOneBoxCall();
+}
+
+function testElementCompoundAssignments(): void {
+  idxCalls = 0;
+  arr[0] = 1;
+  arr[getIndex()] |= 2;
+  assert(arr[0] == 3);
+  assert(idxCalls == 1);
+}
+
+testPropertyCompoundAssignments();
+testElementCompoundAssignments();

--- a/tests/compiler/issues/2873.debug.wat
+++ b/tests/compiler/issues/2873.debug.wat
@@ -3602,7 +3602,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -3668,21 +3668,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -3698,6 +3683,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/issues/2873.release.wat
+++ b/tests/compiler/issues/2873.release.wat
@@ -1335,7 +1335,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$138
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$137
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -1359,7 +1359,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$138
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$137
     end
     local.get $1
     i32.load offset=8
@@ -2444,7 +2444,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$72
+   block $__inlined_func$~lib/rt/itcms/interrupt$71
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -2461,7 +2461,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$72
+      br $__inlined_func$~lib/rt/itcms/interrupt$71
      end
      local.get $1
      i32.const 0
@@ -3078,7 +3078,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinFloatArray<f32>$143
+   block $__inlined_func$~lib/util/string/joinFloatArray<f32>$142
     local.get $1
     i32.const 1
     i32.sub
@@ -3092,7 +3092,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 3152
      local.set $1
-     br $__inlined_func$~lib/util/string/joinFloatArray<f32>$143
+     br $__inlined_func$~lib/util/string/joinFloatArray<f32>$142
     end
     local.get $4
     i32.eqz
@@ -3105,7 +3105,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinFloatArray<f32>$143
+     br $__inlined_func$~lib/util/string/joinFloatArray<f32>$142
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 3184
@@ -3201,7 +3201,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinFloatArray<f32>$143
+     br $__inlined_func$~lib/util/string/joinFloatArray<f32>$142
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -3267,7 +3267,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinFloatArray<f64>$144
+   block $__inlined_func$~lib/util/string/joinFloatArray<f64>$143
     local.get $0
     i32.const 1
     i32.sub
@@ -3281,7 +3281,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 3152
      local.set $1
-     br $__inlined_func$~lib/util/string/joinFloatArray<f64>$144
+     br $__inlined_func$~lib/util/string/joinFloatArray<f64>$143
     end
     local.get $4
     i32.eqz
@@ -3294,7 +3294,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinFloatArray<f64>$144
+     br $__inlined_func$~lib/util/string/joinFloatArray<f64>$143
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 3184
@@ -3394,7 +3394,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinFloatArray<f64>$144
+     br $__inlined_func$~lib/util/string/joinFloatArray<f64>$143
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -3546,7 +3546,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$82
+   block $__inlined_func$~lib/util/string/compareImpl$81
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -3566,7 +3566,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$82
+      br_if $__inlined_func$~lib/util/string/compareImpl$81
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/logical.debug.wat
+++ b/tests/compiler/logical.debug.wat
@@ -2038,7 +2038,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2104,21 +2104,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2134,6 +2119,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/logical.release.wat
+++ b/tests/compiler/logical.release.wat
@@ -139,7 +139,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$122
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$121
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -163,7 +163,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$122
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$121
     end
     local.get $1
     i32.load offset=8
@@ -1165,7 +1165,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1182,7 +1182,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/managed-cast.debug.wat
+++ b/tests/compiler/managed-cast.debug.wat
@@ -2003,7 +2003,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2069,21 +2069,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2099,6 +2084,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/new.debug.wat
+++ b/tests/compiler/new.debug.wat
@@ -2006,7 +2006,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2072,21 +2072,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2102,6 +2087,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/new.release.wat
+++ b/tests/compiler/new.release.wat
@@ -157,7 +157,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$115
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -181,7 +181,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$115
     end
     local.get $1
     i32.load offset=8
@@ -1183,7 +1183,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1200,7 +1200,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/number.debug.wat
+++ b/tests/compiler/number.debug.wat
@@ -2106,7 +2106,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2172,21 +2172,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2202,6 +2187,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/number.release.wat
+++ b/tests/compiler/number.release.wat
@@ -166,7 +166,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$165
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$164
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -190,7 +190,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$165
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$164
     end
     local.get $1
     i32.load offset=8
@@ -1275,7 +1275,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1292,7 +1292,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0
@@ -1693,7 +1693,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/itoa32$73
+  block $__inlined_func$~lib/util/number/itoa32$72
    local.get $0
    i32.eqz
    if
@@ -1703,7 +1703,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 1248
     local.set $0
-    br $__inlined_func$~lib/util/number/itoa32$73
+    br $__inlined_func$~lib/util/number/itoa32$72
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 0
@@ -2674,7 +2674,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$81
+   block $__inlined_func$~lib/util/string/compareImpl$80
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2694,7 +2694,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$81
+      br_if $__inlined_func$~lib/util/string/compareImpl$80
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -2098,7 +2098,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2164,21 +2164,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2194,6 +2179,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -71,7 +71,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$205
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$204
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -95,7 +95,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$205
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$204
    end
    local.get $0
    i32.load offset=8
@@ -1506,7 +1506,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$68
+   block $__inlined_func$~lib/rt/itcms/interrupt$67
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1523,7 +1523,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$68
+      br $__inlined_func$~lib/rt/itcms/interrupt$67
      end
      local.get $2
      i32.const 0
@@ -1782,7 +1782,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$83
+   block $__inlined_func$~lib/util/string/compareImpl$82
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1802,7 +1802,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$83
+      br_if $__inlined_func$~lib/util/string/compareImpl$82
       local.get $2
       i32.const 2
       i32.add
@@ -2478,7 +2478,7 @@
    i32.const 1
    i32.shl
    local.set $3
-   block $__inlined_func$~lib/string/String#substring$210
+   block $__inlined_func$~lib/string/String#substring$209
     local.get $2
     i32.const 0
     local.get $2
@@ -2499,7 +2499,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1568
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$210
+     br $__inlined_func$~lib/string/String#substring$209
     end
     local.get $3
     i32.eqz
@@ -2516,7 +2516,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1056
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$210
+     br $__inlined_func$~lib/string/String#substring$209
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2

--- a/tests/compiler/operator-overload-non-ambiguity.debug.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.debug.wat
@@ -2001,7 +2001,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2067,21 +2067,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2097,6 +2082,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/operator-overload-non-ambiguity.release.wat
+++ b/tests/compiler/operator-overload-non-ambiguity.release.wat
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$115
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$115
     end
     local.get $1
     i32.load offset=8
@@ -1143,7 +1143,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1160,7 +1160,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/optional-typeparameters.debug.wat
+++ b/tests/compiler/optional-typeparameters.debug.wat
@@ -2014,7 +2014,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2080,21 +2080,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2110,6 +2095,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/optional-typeparameters.release.wat
+++ b/tests/compiler/optional-typeparameters.release.wat
@@ -143,7 +143,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$131
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$130
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -167,7 +167,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$131
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$130
     end
     local.get $1
     i32.load offset=8
@@ -1169,7 +1169,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1186,7 +1186,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/reexport.debug.wat
+++ b/tests/compiler/reexport.debug.wat
@@ -2047,7 +2047,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2113,21 +2113,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2143,6 +2128,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/reexport.release.wat
+++ b/tests/compiler/reexport.release.wat
@@ -150,7 +150,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$118
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -174,7 +174,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$118
     end
     local.get $1
     i32.load offset=8
@@ -1176,7 +1176,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $0
     loop $do-loop|0
@@ -1193,7 +1193,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $0
      i32.const 0

--- a/tests/compiler/rereexport.debug.wat
+++ b/tests/compiler/rereexport.debug.wat
@@ -2040,7 +2040,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2106,21 +2106,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2136,6 +2121,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/rereexport.release.wat
+++ b/tests/compiler/rereexport.release.wat
@@ -148,7 +148,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$120
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -172,7 +172,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$120
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
     end
     local.get $1
     i32.load offset=8
@@ -1174,7 +1174,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $0
     loop $do-loop|0
@@ -1191,7 +1191,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $0
      i32.const 0

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -2022,7 +2022,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2088,21 +2088,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2118,6 +2103,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -124,7 +124,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$143
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$142
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -148,7 +148,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$143
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$142
    end
    local.get $0
    i32.load offset=8
@@ -1252,7 +1252,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1269,7 +1269,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -1671,7 +1671,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/utoa64$73
+  block $__inlined_func$~lib/util/number/utoa64$72
    local.get $0
    i64.eqz
    if
@@ -1681,7 +1681,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 1728
     local.set $2
-    br $__inlined_func$~lib/util/number/utoa64$73
+    br $__inlined_func$~lib/util/number/utoa64$72
    end
    local.get $0
    i64.const 4294967295
@@ -2339,7 +2339,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
-   block $__inlined_func$~lib/util/number/utoa32$74
+   block $__inlined_func$~lib/util/number/utoa32$73
     local.get $2
     i32.eqz
     if
@@ -2349,7 +2349,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1728
      local.set $0
-     br $__inlined_func$~lib/util/number/utoa32$74
+     br $__inlined_func$~lib/util/number/utoa32$73
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2

--- a/tests/compiler/resolve-binary.debug.wat
+++ b/tests/compiler/resolve-binary.debug.wat
@@ -2242,7 +2242,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2308,21 +2308,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2338,6 +2323,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/resolve-binary.release.wat
+++ b/tests/compiler/resolve-binary.release.wat
@@ -348,7 +348,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$165
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$164
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -372,7 +372,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$165
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$164
     end
     local.get $1
     i32.load offset=8
@@ -1457,7 +1457,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1474,7 +1474,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -1875,7 +1875,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/itoa32$74
+  block $__inlined_func$~lib/util/number/itoa32$73
    local.get $0
    i32.eqz
    if
@@ -1885,7 +1885,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 1376
     local.set $0
-    br $__inlined_func$~lib/util/number/itoa32$74
+    br $__inlined_func$~lib/util/number/itoa32$73
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 0
@@ -3017,7 +3017,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$81
+   block $__inlined_func$~lib/util/string/compareImpl$80
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -3037,7 +3037,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$81
+      br_if $__inlined_func$~lib/util/string/compareImpl$80
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -2045,7 +2045,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2111,21 +2111,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2141,6 +2126,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -176,7 +176,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$153
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$152
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -200,7 +200,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$153
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$152
    end
    local.get $0
    i32.load offset=8
@@ -1304,7 +1304,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1321,7 +1321,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2880,7 +2880,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/utoa32$79
+  block $__inlined_func$~lib/util/number/utoa32$78
    local.get $0
    i32.const 255
    i32.and
@@ -2893,7 +2893,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 3536
     local.set $0
-    br $__inlined_func$~lib/util/number/utoa32$79
+    br $__inlined_func$~lib/util/number/utoa32$78
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 3
@@ -3268,7 +3268,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$97
+   block $__inlined_func$~lib/util/string/compareImpl$96
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -3288,7 +3288,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$97
+      br_if $__inlined_func$~lib/util/string/compareImpl$96
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/resolve-function-expression.debug.wat
+++ b/tests/compiler/resolve-function-expression.debug.wat
@@ -2088,7 +2088,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2154,21 +2154,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2184,6 +2169,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/resolve-function-expression.release.wat
+++ b/tests/compiler/resolve-function-expression.release.wat
@@ -158,7 +158,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$124
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$123
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -182,7 +182,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$124
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$123
     end
     local.get $1
     i32.load offset=8
@@ -1274,7 +1274,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/itoa32$73
+  block $__inlined_func$~lib/util/number/itoa32$72
    local.get $0
    i32.eqz
    if
@@ -1284,7 +1284,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 1424
     local.set $2
-    br $__inlined_func$~lib/util/number/itoa32$73
+    br $__inlined_func$~lib/util/number/itoa32$72
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 0
@@ -1364,7 +1364,7 @@
    global.get $~lib/rt/itcms/threshold
    i32.ge_u
    if
-    block $__inlined_func$~lib/rt/itcms/interrupt$69
+    block $__inlined_func$~lib/rt/itcms/interrupt$68
      i32.const 2048
      local.set $2
      loop $do-loop|0
@@ -1381,7 +1381,7 @@
        i32.const 1024
        i32.add
        global.set $~lib/rt/itcms/threshold
-       br $__inlined_func$~lib/rt/itcms/interrupt$69
+       br $__inlined_func$~lib/rt/itcms/interrupt$68
       end
       local.get $2
       i32.const 0
@@ -2008,7 +2008,7 @@
        end
       end
      end
-     block $__inlined_func$~lib/util/string/compareImpl$80
+     block $__inlined_func$~lib/util/string/compareImpl$79
       loop $while-continue|1
        local.get $1
        local.tee $0
@@ -2028,7 +2028,7 @@
         local.get $0
         local.get $2
         i32.ne
-        br_if $__inlined_func$~lib/util/string/compareImpl$80
+        br_if $__inlined_func$~lib/util/string/compareImpl$79
         local.get $5
         i32.const 2
         i32.add

--- a/tests/compiler/resolve-new.debug.wat
+++ b/tests/compiler/resolve-new.debug.wat
@@ -2001,7 +2001,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2067,21 +2067,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2097,6 +2082,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/resolve-new.release.wat
+++ b/tests/compiler/resolve-new.release.wat
@@ -122,7 +122,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -146,7 +146,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
     end
     local.get $1
     i32.load offset=8
@@ -1148,7 +1148,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1165,7 +1165,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/resolve-propertyaccess.release.wat
+++ b/tests/compiler/resolve-propertyaccess.release.wat
@@ -157,7 +157,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$126
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$125
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -181,7 +181,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$126
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$125
     end
     local.get $1
     i32.load offset=8
@@ -1266,7 +1266,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1283,7 +1283,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -1582,7 +1582,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/itoa32$73
+  block $__inlined_func$~lib/util/number/itoa32$72
    local.get $0
    i32.eqz
    if
@@ -1592,7 +1592,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 1248
     local.set $2
-    br $__inlined_func$~lib/util/number/itoa32$73
+    br $__inlined_func$~lib/util/number/itoa32$72
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 0
@@ -1923,7 +1923,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$77
+   block $__inlined_func$~lib/util/string/compareImpl$76
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1943,7 +1943,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$77
+      br_if $__inlined_func$~lib/util/string/compareImpl$76
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/resolve-ternary.debug.wat
+++ b/tests/compiler/resolve-ternary.debug.wat
@@ -2096,7 +2096,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2162,21 +2162,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2192,6 +2177,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/resolve-ternary.release.wat
+++ b/tests/compiler/resolve-ternary.release.wat
@@ -163,7 +163,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$128
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$127
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -187,7 +187,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$128
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$127
     end
     local.get $1
     i32.load offset=8
@@ -1272,7 +1272,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1289,7 +1289,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0
@@ -2883,7 +2883,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$84
+   block $__inlined_func$~lib/util/string/compareImpl$83
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2903,7 +2903,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$84
+      br_if $__inlined_func$~lib/util/string/compareImpl$83
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/resolve-unary.debug.wat
+++ b/tests/compiler/resolve-unary.debug.wat
@@ -2088,7 +2088,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2154,21 +2154,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2184,6 +2169,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/resolve-unary.release.wat
+++ b/tests/compiler/resolve-unary.release.wat
@@ -183,7 +183,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$156
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$155
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -207,7 +207,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$156
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$155
     end
     local.get $1
     i32.load offset=8
@@ -1292,7 +1292,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1309,7 +1309,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -1608,7 +1608,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/itoa32$73
+  block $__inlined_func$~lib/util/number/itoa32$72
    local.get $0
    i32.eqz
    if
@@ -1618,7 +1618,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 1248
     local.set $2
-    br $__inlined_func$~lib/util/number/itoa32$73
+    br $__inlined_func$~lib/util/number/itoa32$72
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 0
@@ -1983,7 +1983,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$79
+   block $__inlined_func$~lib/util/string/compareImpl$78
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2003,7 +2003,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$79
+      br_if $__inlined_func$~lib/util/string/compareImpl$78
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -2004,7 +2004,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2070,21 +2070,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2100,6 +2085,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -108,7 +108,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$121
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$120
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -132,7 +132,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$121
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$120
    end
    local.get $0
    i32.load offset=8
@@ -1236,7 +1236,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1253,7 +1253,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/rt/alloc-large-memory.debug.wat
+++ b/tests/compiler/rt/alloc-large-memory.debug.wat
@@ -1312,7 +1312,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -1378,21 +1378,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -1408,6 +1393,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/rt/finalize.debug.wat
+++ b/tests/compiler/rt/finalize.debug.wat
@@ -2024,7 +2024,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2090,21 +2090,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2120,6 +2105,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/rt/finalize.release.wat
+++ b/tests/compiler/rt/finalize.release.wat
@@ -120,7 +120,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -144,7 +144,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
     end
     local.get $1
     i32.load offset=8
@@ -1161,7 +1161,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1178,7 +1178,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -2001,7 +2001,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2067,21 +2067,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2097,6 +2082,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$118
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$118
     end
     local.get $1
     i32.load offset=8
@@ -1226,7 +1226,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1243,7 +1243,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/rt/runtime-incremental-export.debug.wat
+++ b/tests/compiler/rt/runtime-incremental-export.debug.wat
@@ -2007,7 +2007,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2073,21 +2073,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2103,6 +2088,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/rt/runtime-incremental-export.release.wat
+++ b/tests/compiler/rt/runtime-incremental-export.release.wat
@@ -1245,7 +1245,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1262,7 +1262,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/rt/runtime-minimal-export.debug.wat
+++ b/tests/compiler/rt/runtime-minimal-export.debug.wat
@@ -1329,7 +1329,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -1395,21 +1395,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -1425,6 +1410,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/simd.debug.wat
+++ b/tests/compiler/simd.debug.wat
@@ -2040,7 +2040,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2106,21 +2106,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2136,6 +2121,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/simd.release.wat
+++ b/tests/compiler/simd.release.wat
@@ -133,7 +133,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$132
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$131
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -157,7 +157,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$132
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$131
    end
    local.get $0
    i32.load offset=8
@@ -1458,7 +1458,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$68
+   block $__inlined_func$~lib/rt/itcms/interrupt$67
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1475,7 +1475,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$68
+      br $__inlined_func$~lib/rt/itcms/interrupt$67
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/std/array-literal.debug.wat
+++ b/tests/compiler/std/array-literal.debug.wat
@@ -2036,7 +2036,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2102,21 +2102,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2132,6 +2117,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/array-literal.release.wat
+++ b/tests/compiler/std/array-literal.release.wat
@@ -163,7 +163,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$154
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$153
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -187,7 +187,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$154
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$153
    end
    local.get $0
    i32.load offset=8
@@ -1291,7 +1291,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1308,7 +1308,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -1967,7 +1967,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$149
+   block $__inlined_func$~lib/rt/itcms/__renew$148
     i32.const 1073741820
     local.get $3
     i32.const 1
@@ -2010,7 +2010,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$149
+     br $__inlined_func$~lib/rt/itcms/__renew$148
     end
     local.get $3
     local.get $4

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -2345,7 +2345,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2411,21 +2411,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2441,6 +2426,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -758,7 +758,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$731
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$730
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -782,7 +782,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$731
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$730
    end
    local.get $0
    i32.load offset=8
@@ -2094,7 +2094,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$68
+   block $__inlined_func$~lib/rt/itcms/interrupt$67
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -2111,7 +2111,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$68
+      br $__inlined_func$~lib/rt/itcms/interrupt$67
      end
      local.get $2
      i32.const 0
@@ -6892,7 +6892,7 @@
   i32.lt_s
   select
   local.set $0
-  block $__inlined_func$~lib/util/bytes/FILL<u32>$139
+  block $__inlined_func$~lib/util/bytes/FILL<u32>$138
    local.get $1
    i32.eqz
    local.get $1
@@ -6917,7 +6917,7 @@
      i32.shl
      memory.fill
     end
-    br $__inlined_func$~lib/util/bytes/FILL<u32>$139
+    br $__inlined_func$~lib/util/bytes/FILL<u32>$138
    end
    loop $for-loop|0
     local.get $0
@@ -7187,7 +7187,7 @@
   i32.lt_s
   select
   local.set $0
-  block $__inlined_func$~lib/util/bytes/FILL<f32>$148
+  block $__inlined_func$~lib/util/bytes/FILL<f32>$147
    local.get $1
    i32.reinterpret_f32
    i32.eqz
@@ -7209,7 +7209,7 @@
      i32.shl
      memory.fill
     end
-    br $__inlined_func$~lib/util/bytes/FILL<f32>$148
+    br $__inlined_func$~lib/util/bytes/FILL<f32>$147
    end
    loop $for-loop|0
     local.get $0
@@ -7589,7 +7589,7 @@
     select
     local.set $1
    end
-   block $__inlined_func$~lib/rt/itcms/__renew$653
+   block $__inlined_func$~lib/rt/itcms/__renew$652
     local.get $3
     i32.const 20
     i32.sub
@@ -7607,7 +7607,7 @@
      i32.store offset=16
      local.get $3
      local.set $2
-     br $__inlined_func$~lib/rt/itcms/__renew$653
+     br $__inlined_func$~lib/rt/itcms/__renew$652
     end
     local.get $1
     local.get $4
@@ -13082,7 +13082,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<i32>$658 (result i32)
+   block $__inlined_func$std/array/isSorted<i32>$657 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -13150,7 +13150,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<i32>$658
+       br $__inlined_func$std/array/isSorted<i32>$657
       end
       local.get $0
       i32.const 1
@@ -14387,7 +14387,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$660 (result i32)
+   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$659 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -14470,7 +14470,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$660
+       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$659
       end
       local.get $1
       i32.const 1
@@ -14897,7 +14897,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$736
+   block $__inlined_func$~lib/string/String#concat$735
     local.get $1
     i32.const 20
     i32.sub
@@ -14916,7 +14916,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$736
+     br $__inlined_func$~lib/string/String#concat$735
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -15105,7 +15105,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     local.get $0
     i32.const 1
     i32.sub
@@ -15119,7 +15119,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     end
     local.get $7
     i32.eqz
@@ -15132,7 +15132,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -15231,7 +15231,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$738
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$737
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -15297,7 +15297,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     local.get $0
     i32.const 1
     i32.sub
@@ -15311,7 +15311,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     end
     local.get $7
     i32.eqz
@@ -15324,7 +15324,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -15423,7 +15423,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$739
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$738
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -16202,7 +16202,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     local.get $0
     i32.const 1
     i32.sub
@@ -16216,7 +16216,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     end
     local.get $6
     i32.eqz
@@ -16229,7 +16229,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16322,7 +16322,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$740
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$739
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -16398,7 +16398,7 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
-     block $__inlined_func$~lib/util/number/utoa64$485
+     block $__inlined_func$~lib/util/number/utoa64$484
       local.get $3
       i64.eqz
       if
@@ -16408,7 +16408,7 @@
        global.set $~lib/memory/__stack_pointer
        i32.const 7712
        local.set $1
-       br $__inlined_func$~lib/util/number/utoa64$485
+       br $__inlined_func$~lib/util/number/utoa64$484
       end
       local.get $3
       i64.const 4294967295
@@ -16747,7 +16747,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     local.get $0
     i32.const 1
     i32.sub
@@ -16761,7 +16761,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     end
     local.get $6
     i32.eqz
@@ -16774,7 +16774,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -16867,7 +16867,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$742
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -21106,7 +21106,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   block $__inlined_func$~lib/array/Array<f32>#indexOf$714
+   block $__inlined_func$~lib/array/Array<f32>#indexOf$713
     local.get $2
     i32.load offset=12
     local.tee $4
@@ -21122,7 +21122,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<f32>#indexOf$714
+     br $__inlined_func$~lib/array/Array<f32>#indexOf$713
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21148,7 +21148,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f32>#indexOf$714
+       br $__inlined_func$~lib/array/Array<f32>#indexOf$713
       end
       local.get $0
       i32.const 1
@@ -21200,7 +21200,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store
-   block $__inlined_func$~lib/array/Array<f64>#indexOf$715
+   block $__inlined_func$~lib/array/Array<f64>#indexOf$714
     local.get $2
     i32.load offset=12
     local.tee $4
@@ -21216,7 +21216,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/array/Array<f64>#indexOf$715
+     br $__inlined_func$~lib/array/Array<f64>#indexOf$714
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21242,7 +21242,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f64>#indexOf$715
+       br $__inlined_func$~lib/array/Array<f64>#indexOf$714
       end
       local.get $0
       i32.const 1
@@ -21553,7 +21553,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/array/Array<f32>#includes$716 (result i32)
+   block $__inlined_func$~lib/array/Array<f32>#includes$715 (result i32)
     i32.const 1
     i32.const 2
     i32.const 9
@@ -21593,7 +21593,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f32>#includes$716
+     br $__inlined_func$~lib/array/Array<f32>#includes$715
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21621,7 +21621,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f32>#includes$716
+       br $__inlined_func$~lib/array/Array<f32>#includes$715
       end
       local.get $0
       i32.const 1
@@ -21645,7 +21645,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/array/Array<f64>#includes$717 (result i32)
+   block $__inlined_func$~lib/array/Array<f64>#includes$716 (result i32)
     i32.const 1
     i32.const 3
     i32.const 12
@@ -21685,7 +21685,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f64>#includes$717
+     br $__inlined_func$~lib/array/Array<f64>#includes$716
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -21713,7 +21713,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f64>#includes$717
+       br $__inlined_func$~lib/array/Array<f64>#includes$716
       end
       local.get $0
       i32.const 1
@@ -27067,7 +27067,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$662 (result i32)
+   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$661 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store offset=8
@@ -27148,7 +27148,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$662
+       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$661
       end
       local.get $1
       i32.const 1
@@ -27180,7 +27180,7 @@
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748 (result i32)
+   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747 (result i32)
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
@@ -27220,7 +27220,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747
     end
     local.get $0
     local.get $2
@@ -27231,7 +27231,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 1
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747
     end
     i32.const 0
     local.set $1
@@ -27291,7 +27291,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$748
+       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$747
       end
       local.get $1
       i32.const 1
@@ -27491,7 +27491,7 @@
        global.get $~lib/memory/__stack_pointer
        i32.const 10032
        i32.store
-       block $__inlined_func$~lib/string/String#charAt$737
+       block $__inlined_func$~lib/string/String#charAt$736
         local.get $12
         i32.const 10028
         i32.load
@@ -27505,7 +27505,7 @@
          global.set $~lib/memory/__stack_pointer
          i32.const 11568
          local.set $2
-         br $__inlined_func$~lib/string/String#charAt$737
+         br $__inlined_func$~lib/string/String#charAt$736
         end
         global.get $~lib/memory/__stack_pointer
         i32.const 2
@@ -28309,7 +28309,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     local.get $1
     i32.const 1
     i32.sub
@@ -28323,7 +28323,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $2
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     end
     local.get $1
     i32.eqz
@@ -28336,7 +28336,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -28433,7 +28433,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$741
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$740
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -28527,7 +28527,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     local.get $1
     i32.const 1
     i32.sub
@@ -28541,7 +28541,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $2
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     end
     local.get $1
     i32.eqz
@@ -28554,7 +28554,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -28651,7 +28651,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$741
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -2009,7 +2009,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2075,21 +2075,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2105,6 +2090,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -113,7 +113,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$185
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$184
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -137,7 +137,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$185
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$184
    end
    local.get $0
    i32.load offset=8
@@ -1241,7 +1241,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1258,7 +1258,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -2016,7 +2016,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2082,21 +2082,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2112,6 +2097,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -121,7 +121,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$221
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$220
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -145,7 +145,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$221
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$220
    end
    local.get $0
    i32.load offset=8
@@ -1249,7 +1249,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1266,7 +1266,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -2401,7 +2401,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2467,21 +2467,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2497,6 +2482,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -504,7 +504,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$376
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$375
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -528,7 +528,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$376
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$375
    end
    local.get $0
    i32.load offset=8
@@ -1632,7 +1632,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1649,7 +1649,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2021,7 +2021,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/itoa32$73
+  block $__inlined_func$~lib/util/number/itoa32$72
    local.get $0
    i32.eqz
    if
@@ -2031,7 +2031,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 1872
     local.set $2
-    br $__inlined_func$~lib/util/number/itoa32$73
+    br $__inlined_func$~lib/util/number/itoa32$72
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 0
@@ -3306,7 +3306,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1872
    i32.store
-   block $__inlined_func$~lib/string/String#padStart$384
+   block $__inlined_func$~lib/string/String#padStart$383
     i32.const 1868
     i32.load
     i32.const -2
@@ -3325,7 +3325,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/string/String#padStart$384
+     br $__inlined_func$~lib/string/String#padStart$383
     end
     global.get $~lib/memory/__stack_pointer
     local.get $5
@@ -3762,7 +3762,7 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    block $__inlined_func$~lib/string/String#concat$385
+    block $__inlined_func$~lib/string/String#concat$384
      local.get $4
      i32.const 20
      i32.sub
@@ -3781,7 +3781,7 @@
       global.set $~lib/memory/__stack_pointer
       i32.const 3456
       local.set $1
-      br $__inlined_func$~lib/string/String#concat$385
+      br $__inlined_func$~lib/string/String#concat$384
      end
      global.get $~lib/memory/__stack_pointer
      local.get $1
@@ -5116,7 +5116,7 @@
    i32.load16_u
    local.set $0
    loop $while-continue|0
-    block $__inlined_func$~lib/util/string/isSpace$164 (result i32)
+    block $__inlined_func$~lib/util/string/isSpace$163 (result i32)
      local.get $0
      i32.const 128
      i32.or
@@ -5131,7 +5131,7 @@
      local.get $0
      i32.const 5760
      i32.lt_u
-     br_if $__inlined_func$~lib/util/string/isSpace$164
+     br_if $__inlined_func$~lib/util/string/isSpace$163
      drop
      i32.const 1
      local.get $0
@@ -5139,7 +5139,7 @@
      i32.add
      i32.const 10
      i32.le_u
-     br_if $__inlined_func$~lib/util/string/isSpace$164
+     br_if $__inlined_func$~lib/util/string/isSpace$163
      drop
      block $break|0
       block $case0|0
@@ -5174,7 +5174,7 @@
        br $break|0
       end
       i32.const 1
-      br $__inlined_func$~lib/util/string/isSpace$164
+      br $__inlined_func$~lib/util/string/isSpace$163
      end
      i32.const 0
     end
@@ -5422,7 +5422,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$363
+   block $__inlined_func$~lib/rt/itcms/__renew$362
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -5465,7 +5465,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$363
+     br $__inlined_func$~lib/rt/itcms/__renew$362
     end
     local.get $3
     local.get $4
@@ -6169,7 +6169,7 @@
       global.get $~lib/memory/__stack_pointer
       local.get $2
       i32.store
-      block $__inlined_func$~lib/string/String#charCodeAt$386
+      block $__inlined_func$~lib/string/String#charCodeAt$385
        local.get $3
        local.get $2
        i32.const 20
@@ -6185,7 +6185,7 @@
         global.set $~lib/memory/__stack_pointer
         i32.const -1
         local.set $0
-        br $__inlined_func$~lib/string/String#charCodeAt$386
+        br $__inlined_func$~lib/string/String#charCodeAt$385
        end
        local.get $2
        local.get $3
@@ -6436,7 +6436,7 @@
       call $~lib/util/string/strtol<i32>
       local.set $6
       global.get $~lib/memory/__stack_pointer
-      block $__inlined_func$~lib/string/String#substr$387 (result i32)
+      block $__inlined_func$~lib/string/String#substr$386 (result i32)
        global.get $~lib/memory/__stack_pointer
        local.get $2
        i32.store offset=44
@@ -6499,7 +6499,7 @@
         i32.add
         global.set $~lib/memory/__stack_pointer
         i32.const 3456
-        br $__inlined_func$~lib/string/String#substr$387
+        br $__inlined_func$~lib/string/String#substr$386
        end
        global.get $~lib/memory/__stack_pointer
        local.get $8
@@ -6549,7 +6549,7 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1872
       i32.store
-      block $__inlined_func$~lib/string/String#padEnd$388
+      block $__inlined_func$~lib/string/String#padEnd$387
        i32.const 1868
        i32.load
        i32.const -2
@@ -6565,7 +6565,7 @@
         i32.const 8
         i32.add
         global.set $~lib/memory/__stack_pointer
-        br $__inlined_func$~lib/string/String#padEnd$388
+        br $__inlined_func$~lib/string/String#padEnd$387
        end
        global.get $~lib/memory/__stack_pointer
        i32.const 6

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -2032,7 +2032,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2098,21 +2098,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2128,6 +2113,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -134,7 +134,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$1422
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$1421
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -158,7 +158,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$1422
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$1421
    end
    local.get $0
    i32.load offset=8
@@ -1262,7 +1262,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1279,7 +1279,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2474,7 +2474,7 @@
     select
     local.set $1
    end
-   block $__inlined_func$~lib/rt/itcms/__renew$1377
+   block $__inlined_func$~lib/rt/itcms/__renew$1376
     local.get $4
     i32.const 20
     i32.sub
@@ -2492,7 +2492,7 @@
      i32.store offset=16
      local.get $4
      local.set $2
-     br $__inlined_func$~lib/rt/itcms/__renew$1377
+     br $__inlined_func$~lib/rt/itcms/__renew$1376
     end
     local.get $1
     local.get $3
@@ -3203,7 +3203,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<i8,i8>#find$1378"
+   block $"__inlined_func$~lib/map/Map<i8,i8>#find$1377"
     loop $while-continue|0
      local.get $3
      if
@@ -3227,7 +3227,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<i8,i8>#find$1378"
+       br $"__inlined_func$~lib/map/Map<i8,i8>#find$1377"
       end
       local.get $4
       i32.const -2
@@ -5753,7 +5753,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<u8,u8>#find$1383"
+   block $"__inlined_func$~lib/map/Map<u8,u8>#find$1382"
     loop $while-continue|0
      local.get $3
      if
@@ -5777,7 +5777,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<u8,u8>#find$1383"
+       br $"__inlined_func$~lib/map/Map<u8,u8>#find$1382"
       end
       local.get $4
       i32.const -2
@@ -7943,7 +7943,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<i16,i16>#find$1388"
+   block $"__inlined_func$~lib/map/Map<i16,i16>#find$1387"
     loop $while-continue|0
      local.get $3
      if
@@ -7967,7 +7967,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<i16,i16>#find$1388"
+       br $"__inlined_func$~lib/map/Map<i16,i16>#find$1387"
       end
       local.get $4
       i32.const -2
@@ -9959,7 +9959,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<u16,u16>#find$1393"
+   block $"__inlined_func$~lib/map/Map<u16,u16>#find$1392"
     loop $while-continue|0
      local.get $3
      if
@@ -9983,7 +9983,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<u16,u16>#find$1393"
+       br $"__inlined_func$~lib/map/Map<u16,u16>#find$1392"
       end
       local.get $4
       i32.const -2
@@ -15197,7 +15197,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<i64,i64>#find$1403"
+   block $"__inlined_func$~lib/map/Map<i64,i64>#find$1402"
     loop $while-continue|0
      local.get $3
      if
@@ -15219,7 +15219,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<i64,i64>#find$1403"
+       br $"__inlined_func$~lib/map/Map<i64,i64>#find$1402"
       end
       local.get $4
       i32.const -2
@@ -17449,7 +17449,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<u64,u64>#find$1408"
+   block $"__inlined_func$~lib/map/Map<u64,u64>#find$1407"
     loop $while-continue|0
      local.get $3
      if
@@ -17471,7 +17471,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<u64,u64>#find$1408"
+       br $"__inlined_func$~lib/map/Map<u64,u64>#find$1407"
       end
       local.get $4
       i32.const -2
@@ -22003,7 +22003,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<f64,f64>#find$1418"
+   block $"__inlined_func$~lib/map/Map<f64,f64>#find$1417"
     loop $while-continue|0
      local.get $3
      if
@@ -22025,7 +22025,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<f64,f64>#find$1418"
+       br $"__inlined_func$~lib/map/Map<f64,f64>#find$1417"
       end
       local.get $4
       i32.const -2

--- a/tests/compiler/std/new.debug.wat
+++ b/tests/compiler/std/new.debug.wat
@@ -2018,7 +2018,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2084,21 +2084,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2114,6 +2099,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/new.release.wat
+++ b/tests/compiler/std/new.release.wat
@@ -122,7 +122,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$113
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -146,7 +146,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$113
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
     end
     local.get $1
     i32.load offset=8
@@ -1148,7 +1148,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $0
     loop $do-loop|0
@@ -1165,7 +1165,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $0
      i32.const 0

--- a/tests/compiler/std/operator-overloading.debug.wat
+++ b/tests/compiler/std/operator-overloading.debug.wat
@@ -2074,7 +2074,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2140,21 +2140,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2170,6 +2155,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/operator-overloading.release.wat
+++ b/tests/compiler/std/operator-overloading.release.wat
@@ -187,7 +187,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$334
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$333
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -211,7 +211,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$334
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$333
     end
     local.get $1
     i32.load offset=8
@@ -1213,7 +1213,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$68
+   block $__inlined_func$~lib/rt/itcms/interrupt$67
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1230,7 +1230,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$68
+      br $__inlined_func$~lib/rt/itcms/interrupt$67
      end
      local.get $1
      i32.const 0
@@ -2359,7 +2359,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$199
+   block $__inlined_func$~lib/util/string/compareImpl$198
     loop $while-continue|1
      local.get $0
      local.tee $2
@@ -2379,7 +2379,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$199
+      br_if $__inlined_func$~lib/util/string/compareImpl$198
       local.get $1
       i32.const 2
       i32.add

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -2027,7 +2027,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2093,21 +2093,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2123,6 +2108,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -125,7 +125,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$904
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$903
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -149,7 +149,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$904
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$903
    end
    local.get $0
    i32.load offset=8
@@ -1253,7 +1253,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1270,7 +1270,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2466,7 +2466,7 @@
     select
     local.set $1
    end
-   block $__inlined_func$~lib/rt/itcms/__renew$893
+   block $__inlined_func$~lib/rt/itcms/__renew$892
     local.get $4
     i32.const 20
     i32.sub
@@ -2484,7 +2484,7 @@
      i32.store offset=16
      local.get $4
      local.set $2
-     br $__inlined_func$~lib/rt/itcms/__renew$893
+     br $__inlined_func$~lib/rt/itcms/__renew$892
     end
     local.get $1
     local.get $3

--- a/tests/compiler/std/static-array.debug.wat
+++ b/tests/compiler/std/static-array.debug.wat
@@ -2043,7 +2043,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2109,21 +2109,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2139,6 +2124,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/static-array.release.wat
+++ b/tests/compiler/std/static-array.release.wat
@@ -137,7 +137,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$155
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$154
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -161,7 +161,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$155
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$154
    end
    local.get $0
    i32.load offset=8
@@ -1432,7 +1432,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$145
+   block $__inlined_func$~lib/rt/itcms/__renew$144
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -1470,7 +1470,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$145
+     br $__inlined_func$~lib/rt/itcms/__renew$144
     end
     local.get $4
     i32.load offset=12
@@ -1490,7 +1490,7 @@
     global.get $~lib/rt/itcms/threshold
     i32.ge_u
     if
-     block $__inlined_func$~lib/rt/itcms/interrupt$69
+     block $__inlined_func$~lib/rt/itcms/interrupt$68
       i32.const 2048
       local.set $1
       loop $do-loop|0
@@ -1507,7 +1507,7 @@
         i32.const 1024
         i32.add
         global.set $~lib/rt/itcms/threshold
-        br $__inlined_func$~lib/rt/itcms/interrupt$69
+        br $__inlined_func$~lib/rt/itcms/interrupt$68
        end
        local.get $1
        i32.const 0

--- a/tests/compiler/std/staticarray.debug.wat
+++ b/tests/compiler/std/staticarray.debug.wat
@@ -2109,7 +2109,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2175,21 +2175,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2205,6 +2190,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/staticarray.release.wat
+++ b/tests/compiler/std/staticarray.release.wat
@@ -260,7 +260,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$267
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$266
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -284,7 +284,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$267
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$266
    end
    local.get $0
    i32.load offset=8
@@ -1596,7 +1596,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1613,7 +1613,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -3140,7 +3140,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$106
+   block $__inlined_func$~lib/util/string/compareImpl$105
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -3160,7 +3160,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$106
+      br_if $__inlined_func$~lib/util/string/compareImpl$105
       local.get $2
       i32.const 2
       i32.add
@@ -3372,7 +3372,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+   block $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$273
     local.get $0
     i32.const 20
     i32.sub
@@ -3392,7 +3392,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $2
-     br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+     br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$273
     end
     local.get $2
     i32.const 0
@@ -3434,7 +3434,7 @@
        i32.const 8
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$274
+       br $__inlined_func$~lib/staticarray/StaticArray<~lib/string/String>#indexOf$273
       end
       local.get $2
       i32.const 1
@@ -4084,7 +4084,7 @@
        global.get $~lib/memory/__stack_pointer
        local.get $10
        i32.store
-       block $__inlined_func$~lib/rt/itcms/__renew$224
+       block $__inlined_func$~lib/rt/itcms/__renew$223
         i32.const 1073741820
         local.get $1
         i32.const 1
@@ -4127,7 +4127,7 @@
          i32.store offset=16
          local.get $1
          local.set $2
-         br $__inlined_func$~lib/rt/itcms/__renew$224
+         br $__inlined_func$~lib/rt/itcms/__renew$223
         end
         local.get $4
         local.get $3
@@ -6296,7 +6296,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276 (result i32)
+   block $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$275 (result i32)
     i32.const 8
     i32.const 10
     call $~lib/rt/itcms/__new
@@ -6337,7 +6337,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276
+     br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$275
     end
     loop $while-continue|0
      local.get $1
@@ -6359,7 +6359,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$276
+       br $__inlined_func$~lib/staticarray/StaticArray<f64>#includes$275
       end
       local.get $1
       i32.const 1
@@ -6383,7 +6383,7 @@
     call $~lib/builtins/abort
     unreachable
    end
-   block $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277 (result i32)
+   block $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$276 (result i32)
     i32.const 4
     i32.const 11
     call $~lib/rt/itcms/__new
@@ -6424,7 +6424,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277
+     br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$276
     end
     loop $while-continue|030
      local.get $1
@@ -6446,7 +6446,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$277
+       br $__inlined_func$~lib/staticarray/StaticArray<f32>#includes$276
       end
       local.get $1
       i32.const 1

--- a/tests/compiler/std/string-casemapping.debug.wat
+++ b/tests/compiler/std/string-casemapping.debug.wat
@@ -2195,7 +2195,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2261,21 +2261,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2291,6 +2276,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/string-casemapping.release.wat
+++ b/tests/compiler/std/string-casemapping.release.wat
@@ -571,7 +571,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$143
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$142
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -595,7 +595,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$143
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$142
     end
     local.get $1
     i32.load offset=8
@@ -1680,7 +1680,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1697,7 +1697,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -2734,7 +2734,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$81
+   block $__inlined_func$~lib/util/string/compareImpl$80
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2754,7 +2754,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$81
+      br_if $__inlined_func$~lib/util/string/compareImpl$80
       local.get $2
       i32.const 2
       i32.add
@@ -3483,7 +3483,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$148
+   block $__inlined_func$~lib/string/String#concat$147
     local.get $1
     i32.const 20
     i32.sub
@@ -3502,7 +3502,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1056
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$148
+     br $__inlined_func$~lib/string/String#concat$147
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0

--- a/tests/compiler/std/string-encoding.debug.wat
+++ b/tests/compiler/std/string-encoding.debug.wat
@@ -2034,7 +2034,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2100,21 +2100,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2130,6 +2115,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/string-encoding.release.wat
+++ b/tests/compiler/std/string-encoding.release.wat
@@ -158,7 +158,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$158
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$157
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -182,7 +182,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$158
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$157
     end
     local.get $1
     i32.load offset=8
@@ -1267,7 +1267,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1284,7 +1284,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -2968,7 +2968,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$94
+   block $__inlined_func$~lib/util/string/compareImpl$93
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2988,7 +2988,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$94
+      br_if $__inlined_func$~lib/util/string/compareImpl$93
       local.get $2
       i32.const 2
       i32.add
@@ -4146,7 +4146,7 @@
     end
    end
   end
-  block $__inlined_func$~lib/rt/itcms/__renew$157
+  block $__inlined_func$~lib/rt/itcms/__renew$156
    local.get $1
    local.get $0
    i32.sub
@@ -4165,7 +4165,7 @@
     local.get $3
     local.get $2
     i32.store offset=16
-    br $__inlined_func$~lib/rt/itcms/__renew$157
+    br $__inlined_func$~lib/rt/itcms/__renew$156
    end
    local.get $2
    local.get $3

--- a/tests/compiler/std/string.debug.wat
+++ b/tests/compiler/std/string.debug.wat
@@ -2632,7 +2632,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2698,21 +2698,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2728,6 +2713,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/string.release.wat
+++ b/tests/compiler/std/string.release.wat
@@ -1149,7 +1149,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$287
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$286
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1173,7 +1173,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$287
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$286
    end
    local.get $0
    i32.load offset=8
@@ -2277,7 +2277,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -2294,7 +2294,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -10235,7 +10235,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/string/String#charCodeAt$294
+   block $__inlined_func$~lib/string/String#charCodeAt$293
     local.get $0
     i32.const 20
     i32.sub
@@ -10250,7 +10250,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/string/String#charCodeAt$294
+     br $__inlined_func$~lib/string/String#charCodeAt$293
     end
     local.get $0
     i32.load16_u
@@ -10289,7 +10289,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $4
    i32.store
-   block $__inlined_func$~lib/string/String#codePointAt$295
+   block $__inlined_func$~lib/string/String#codePointAt$294
     local.get $4
     i32.const 20
     i32.sub
@@ -10306,7 +10306,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const -1
      local.set $0
-     br $__inlined_func$~lib/string/String#codePointAt$295
+     br $__inlined_func$~lib/string/String#codePointAt$294
     end
     local.get $0
     i32.const 2
@@ -10324,7 +10324,7 @@
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/string/String#codePointAt$295
+     br $__inlined_func$~lib/string/String#codePointAt$294
     end
     local.get $4
     i32.load16_u offset=4
@@ -10338,7 +10338,7 @@
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/string/String#codePointAt$295
+     br $__inlined_func$~lib/string/String#codePointAt$294
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 4
@@ -10799,7 +10799,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 2176
    i32.store
-   block $__inlined_func$~lib/string/String#startsWith$296
+   block $__inlined_func$~lib/string/String#startsWith$295
     local.get $4
     i32.const 2172
     i32.load
@@ -10814,7 +10814,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 0
      local.set $0
-     br $__inlined_func$~lib/string/String#startsWith$296
+     br $__inlined_func$~lib/string/String#startsWith$295
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -10891,7 +10891,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 2208
    i32.store
-   block $__inlined_func$~lib/string/String#endsWith$297
+   block $__inlined_func$~lib/string/String#endsWith$296
     i32.const 536870910
     local.get $4
     local.get $4
@@ -10914,7 +10914,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 0
      local.set $0
-     br $__inlined_func$~lib/string/String#endsWith$297
+     br $__inlined_func$~lib/string/String#endsWith$296
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -22179,7 +22179,7 @@
     end
    else
     global.get $~lib/memory/__stack_pointer
-    block $__inlined_func$~lib/util/number/ulog_base$171 (result i32)
+    block $__inlined_func$~lib/util/number/ulog_base$170 (result i32)
      local.get $2
      i64.extend_i32_u
      local.set $5
@@ -22200,7 +22200,7 @@
       i32.div_u
       i32.const 1
       i32.add
-      br $__inlined_func$~lib/util/number/ulog_base$171
+      br $__inlined_func$~lib/util/number/ulog_base$170
      end
      local.get $1
      i64.extend_i32_s
@@ -22460,7 +22460,7 @@
     end
    else
     global.get $~lib/memory/__stack_pointer
-    block $__inlined_func$~lib/util/number/ulog_base$175 (result i32)
+    block $__inlined_func$~lib/util/number/ulog_base$174 (result i32)
      local.get $0
      i64.extend_i32_u
      local.set $4
@@ -22481,7 +22481,7 @@
       i32.div_u
       i32.const 1
       i32.add
-      br $__inlined_func$~lib/util/number/ulog_base$175
+      br $__inlined_func$~lib/util/number/ulog_base$174
      end
      local.get $1
      i64.extend_i32_s
@@ -22799,7 +22799,7 @@
     end
    else
     global.get $~lib/memory/__stack_pointer
-    block $__inlined_func$~lib/util/number/ulog_base$180 (result i32)
+    block $__inlined_func$~lib/util/number/ulog_base$179 (result i32)
      local.get $0
      local.set $2
      local.get $1
@@ -22819,7 +22819,7 @@
       i32.div_u
       i32.const 1
       i32.add
-      br $__inlined_func$~lib/util/number/ulog_base$180
+      br $__inlined_func$~lib/util/number/ulog_base$179
      end
      local.get $1
      i64.extend_i32_s
@@ -23164,7 +23164,7 @@
     end
    else
     global.get $~lib/memory/__stack_pointer
-    block $__inlined_func$~lib/util/number/ulog_base$185 (result i32)
+    block $__inlined_func$~lib/util/number/ulog_base$184 (result i32)
      local.get $0
      local.set $2
      local.get $1
@@ -23184,7 +23184,7 @@
       i32.div_u
       i32.const 1
       i32.add
-      br $__inlined_func$~lib/util/number/ulog_base$185
+      br $__inlined_func$~lib/util/number/ulog_base$184
      end
      local.get $1
      i64.extend_i32_s

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -2063,7 +2063,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2129,21 +2129,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2159,6 +2144,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -206,7 +206,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$246
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$245
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -230,7 +230,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$246
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$245
    end
    local.get $0
    i32.load offset=8
@@ -1334,7 +1334,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1351,7 +1351,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $2
      i32.const 0
@@ -2189,7 +2189,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$88
+   block $__inlined_func$~lib/util/string/compareImpl$87
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2209,7 +2209,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$88
+      br_if $__inlined_func$~lib/util/string/compareImpl$87
       local.get $2
       i32.const 2
       i32.add
@@ -3507,7 +3507,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$253
+   block $__inlined_func$~lib/string/String#concat$252
     local.get $1
     i32.const 20
     i32.sub
@@ -3526,7 +3526,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1888
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$253
+     br $__inlined_func$~lib/string/String#concat$252
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -2375,7 +2375,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2441,21 +2441,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2471,6 +2456,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -766,7 +766,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$1403
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$1402
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -790,7 +790,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$1403
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$1402
    end
    local.get $0
    i32.load offset=8
@@ -2102,7 +2102,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$68
+   block $__inlined_func$~lib/rt/itcms/interrupt$67
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -2119,7 +2119,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$68
+      br $__inlined_func$~lib/rt/itcms/interrupt$67
      end
      local.get $2
      i32.const 0
@@ -12338,7 +12338,7 @@
   i32.lt_s
   select
   local.set $0
-  block $__inlined_func$~lib/util/bytes/FILL<u32>$202
+  block $__inlined_func$~lib/util/bytes/FILL<u32>$201
    local.get $1
    i32.eqz
    local.get $1
@@ -12363,7 +12363,7 @@
      i32.shl
      memory.fill
     end
-    br $__inlined_func$~lib/util/bytes/FILL<u32>$202
+    br $__inlined_func$~lib/util/bytes/FILL<u32>$201
    end
    loop $for-loop|0
     local.get $0
@@ -35302,7 +35302,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1407
     local.get $0
     i32.const 1
     i32.sub
@@ -35316,7 +35316,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1407
     end
     local.get $6
     i32.eqz
@@ -35329,7 +35329,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1407
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -35422,7 +35422,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1408
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1407
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -35556,7 +35556,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$714
+   block $__inlined_func$~lib/util/string/compareImpl$713
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -35576,7 +35576,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$714
+      br_if $__inlined_func$~lib/util/string/compareImpl$713
       local.get $2
       i32.const 2
       i32.add
@@ -35650,7 +35650,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1408
     local.get $0
     i32.const 1
     i32.sub
@@ -35664,7 +35664,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1408
     end
     local.get $6
     i32.eqz
@@ -35677,7 +35677,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1408
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -35770,7 +35770,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1409
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1408
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -35865,7 +35865,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1409
     local.get $0
     i32.const 1
     i32.sub
@@ -35879,7 +35879,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1409
     end
     local.get $6
     i32.eqz
@@ -35892,7 +35892,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1409
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -35989,7 +35989,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1410
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1409
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -36055,7 +36055,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1410
     local.get $0
     i32.const 1
     i32.sub
@@ -36069,7 +36069,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1410
     end
     local.get $6
     i32.eqz
@@ -36082,7 +36082,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1410
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -36179,7 +36179,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1411
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1410
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -36245,7 +36245,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1411
     local.get $0
     i32.const 1
     i32.sub
@@ -36259,7 +36259,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1411
     end
     local.get $6
     i32.eqz
@@ -36272,7 +36272,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1411
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -36369,7 +36369,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1412
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1411
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -36435,7 +36435,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1412
     local.get $0
     i32.const 1
     i32.sub
@@ -36449,7 +36449,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1412
     end
     local.get $6
     i32.eqz
@@ -36462,7 +36462,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1412
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -36559,7 +36559,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1413
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1412
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -37004,7 +37004,7 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
-     block $__inlined_func$~lib/util/number/utoa64$749
+     block $__inlined_func$~lib/util/number/utoa64$748
       local.get $3
       i64.eqz
       if
@@ -37014,7 +37014,7 @@
        global.set $~lib/memory/__stack_pointer
        i32.const 8000
        local.set $1
-       br $__inlined_func$~lib/util/number/utoa64$749
+       br $__inlined_func$~lib/util/number/utoa64$748
       end
       local.get $3
       i64.const 4294967295

--- a/tests/compiler/std/uri.debug.wat
+++ b/tests/compiler/std/uri.debug.wat
@@ -2077,7 +2077,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2143,21 +2143,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2173,6 +2158,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/std/uri.release.wat
+++ b/tests/compiler/std/uri.release.wat
@@ -238,7 +238,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$132
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$131
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -262,7 +262,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$132
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$131
     end
     local.get $1
     i32.load offset=8
@@ -1347,7 +1347,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1364,7 +1364,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -2782,7 +2782,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$88
+   block $__inlined_func$~lib/util/string/compareImpl$87
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2802,7 +2802,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$88
+      br_if $__inlined_func$~lib/util/string/compareImpl$87
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/super-inline.debug.wat
+++ b/tests/compiler/super-inline.debug.wat
@@ -2002,7 +2002,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2068,21 +2068,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2098,6 +2083,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/super-inline.release.wat
+++ b/tests/compiler/super-inline.release.wat
@@ -129,7 +129,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$115
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -153,7 +153,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$115
     end
     local.get $1
     i32.load offset=8
@@ -1155,7 +1155,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1172,7 +1172,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0

--- a/tests/compiler/switch.debug.wat
+++ b/tests/compiler/switch.debug.wat
@@ -2328,7 +2328,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2394,21 +2394,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2424,6 +2409,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/switch.release.wat
+++ b/tests/compiler/switch.release.wat
@@ -160,7 +160,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$186
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$185
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -184,7 +184,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$186
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$185
     end
     local.get $1
     i32.load offset=8
@@ -1269,7 +1269,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1286,7 +1286,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -1708,7 +1708,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$76
+   block $__inlined_func$~lib/util/string/compareImpl$75
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1728,7 +1728,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$76
+      br_if $__inlined_func$~lib/util/string/compareImpl$75
       local.get $2
       i32.const 2
       i32.add
@@ -1880,7 +1880,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$191
+   block $__inlined_func$~lib/string/String#concat$190
     local.get $1
     i32.const 20
     i32.sub
@@ -1899,7 +1899,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1296
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$191
+     br $__inlined_func$~lib/string/String#concat$190
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0

--- a/tests/compiler/templateliteral.debug.wat
+++ b/tests/compiler/templateliteral.debug.wat
@@ -2188,7 +2188,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2254,21 +2254,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2284,6 +2269,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/templateliteral.release.wat
+++ b/tests/compiler/templateliteral.release.wat
@@ -212,7 +212,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$165
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$164
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -236,7 +236,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$165
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$164
    end
    local.get $0
    i32.load offset=8
@@ -1340,7 +1340,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $2
     loop $do-loop|0
@@ -1357,7 +1357,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $2
      i32.const 0
@@ -1817,7 +1817,7 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i32.store
-  block $__inlined_func$~lib/util/number/itoa32$75
+  block $__inlined_func$~lib/util/number/itoa32$74
    local.get $0
    i32.eqz
    if
@@ -1827,7 +1827,7 @@
     global.set $~lib/memory/__stack_pointer
     i32.const 2032
     local.set $0
-    br $__inlined_func$~lib/util/number/itoa32$75
+    br $__inlined_func$~lib/util/number/itoa32$74
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 0
@@ -4077,7 +4077,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$91
+   block $__inlined_func$~lib/util/string/compareImpl$90
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -4097,7 +4097,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$91
+      br_if $__inlined_func$~lib/util/string/compareImpl$90
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/typeof.debug.wat
+++ b/tests/compiler/typeof.debug.wat
@@ -2140,7 +2140,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2206,21 +2206,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2236,6 +2221,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/typeof.release.wat
+++ b/tests/compiler/typeof.release.wat
@@ -145,7 +145,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$118
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -169,7 +169,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$118
     end
     local.get $1
     i32.load offset=8
@@ -1171,7 +1171,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$70
+   block $__inlined_func$~lib/rt/itcms/interrupt$69
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1188,7 +1188,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$70
+      br $__inlined_func$~lib/rt/itcms/interrupt$69
      end
      local.get $1
      i32.const 0
@@ -1572,7 +1572,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$78
+   block $__inlined_func$~lib/util/string/compareImpl$77
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -1592,7 +1592,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$78
+      br_if $__inlined_func$~lib/util/string/compareImpl$77
       local.get $2
       i32.const 2
       i32.add

--- a/tests/compiler/while.debug.wat
+++ b/tests/compiler/while.debug.wat
@@ -2423,7 +2423,7 @@
   (local $remaining i32)
   (local $spare i32)
   (local $block|6 i32)
-  (local $block|7 i32)
+  (local $7 i32)
   local.get $block
   call $~lib/rt/common/BLOCK#get:mmInfo
   local.set $blockInfo
@@ -2489,21 +2489,6 @@
    i32.xor
    i32.and
    call $~lib/rt/common/BLOCK#set:mmInfo
-   block $~lib/rt/tlsf/GETRIGHT|inlined.3 (result i32)
-    local.get $block
-    local.set $block|7
-    local.get $block|7
-    i32.const 4
-    i32.add
-    local.get $block|7
-    call $~lib/rt/common/BLOCK#get:mmInfo
-    i32.const 3
-    i32.const -1
-    i32.xor
-    i32.and
-    i32.add
-    br $~lib/rt/tlsf/GETRIGHT|inlined.3
-   end
    block $~lib/rt/tlsf/GETRIGHT|inlined.2 (result i32)
     local.get $block
     local.set $block|6
@@ -2519,6 +2504,9 @@
     i32.add
     br $~lib/rt/tlsf/GETRIGHT|inlined.2
    end
+   local.set $7
+   local.get $7
+   local.get $7
    call $~lib/rt/common/BLOCK#get:mmInfo
    i32.const 2
    i32.const -1

--- a/tests/compiler/while.release.wat
+++ b/tests/compiler/while.release.wat
@@ -117,7 +117,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$128
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$127
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -141,7 +141,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$128
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$127
     end
     local.get $1
     i32.load offset=8
@@ -1143,7 +1143,7 @@
   global.get $~lib/rt/itcms/threshold
   i32.ge_u
   if
-   block $__inlined_func$~lib/rt/itcms/interrupt$69
+   block $__inlined_func$~lib/rt/itcms/interrupt$68
     i32.const 2048
     local.set $1
     loop $do-loop|0
@@ -1160,7 +1160,7 @@
       i32.const 1024
       i32.add
       global.set $~lib/rt/itcms/threshold
-      br $__inlined_func$~lib/rt/itcms/interrupt$69
+      br $__inlined_func$~lib/rt/itcms/interrupt$68
      end
      local.get $1
      i32.const 0


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes #2730 . 
This PR fixes a compound-assignment codegen bug where the lhs could be evaluated twice (for example, in patterns like method-call receivers or indexed access), causing duplicated side effects.

Changes proposed in this pull request:
⯈Added a side-effect cache path for compound assignment in the compiler so side-effectful receiver/index expressions are evaluated once and reused.
⯈Introduced helper logic to detect cache-eligible targets (property/element access) and side-effectful sub-expressions
⯈The reason so many test fixtures are affected is that there is a match assignment statement on line 375 of rt/tlsf.ts, which lhs gets compiled twice (which is semantically incorrect).

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
