### PR TITLE
fix: report error when generic method attempts to implement non-generic interface method

### DIFF
--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -52,6 +52,7 @@
   "Initializer, definitive assignment or nullable type expected.": 238,
   "Definitive assignment has no effect on local variables.": 239,
   "Ambiguous operator overload '{0}' (conflicting overloads '{1}' and '{2}').": 240,
+  "An interface or abstract method '{0}' cannot have type parameters.": 241,
 
   "Importing the table disables some indirect call optimizations.": 901,
   "Exporting the table disables some indirect call optimizations.": 902,

--- a/src/program.ts
+++ b/src/program.ts
@@ -2079,6 +2079,13 @@ export class Program extends DiagnosticEmitter {
         }
         case NodeKind.MethodDeclaration: {
           let methodDeclaration = <MethodDeclaration>memberDeclaration;
+          if (methodDeclaration.is(CommonFlags.Abstract) && methodDeclaration.is(CommonFlags.Generic)) {
+            this.error(
+              DiagnosticCode.An_interface_or_abstract_method_0_cannot_have_type_parameters,
+              methodDeclaration.name.range,
+              methodDeclaration.name.text
+            );
+          }
           if (memberDeclaration.isAny(CommonFlags.Get | CommonFlags.Set)) {
             this.initializeProperty(methodDeclaration, element);
           } else {
@@ -2653,6 +2660,13 @@ export class Program extends DiagnosticEmitter {
         }
         case NodeKind.MethodDeclaration: {
           let methodDeclaration = <MethodDeclaration>memberDeclaration;
+          if (methodDeclaration.is(CommonFlags.Generic)) {
+            this.error(
+              DiagnosticCode.An_interface_or_abstract_method_0_cannot_have_type_parameters,
+              methodDeclaration.name.range,
+              methodDeclaration.name.text
+            );
+          }
           if (memberDeclaration.isAny(CommonFlags.Get | CommonFlags.Set)) {
             this.initializeProperty(methodDeclaration, element);
           } else {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -3449,13 +3449,12 @@ export class Resolver extends DiagnosticEmitter {
           // A generic method cannot implement a non-generic interface method
           // because monomorphization requires a concrete type to generate code,
           // but virtual dispatch through the interface has no type arguments.
-          let ifaceMember = unimplemented.get(memberName);
-          if (ifaceMember
+          if (unimplemented.has(memberName)
             && member.kind == ElementKind.FunctionPrototype
-            && ifaceMember.kind == ElementKind.FunctionPrototype
+            && unimplemented.get(memberName)!.kind == ElementKind.FunctionPrototype
           ) {
             let memberTypeParams = (<FunctionPrototype>member).typeParameterNodes;
-            let ifaceTypeParams = (<FunctionPrototype>ifaceMember).typeParameterNodes;
+            let ifaceTypeParams = (<FunctionPrototype>unimplemented.get(memberName)).typeParameterNodes;
             let numMemberTypeParams = memberTypeParams ? memberTypeParams.length : 0;
             let numIfaceTypeParams = ifaceTypeParams ? ifaceTypeParams.length : 0;
             if (numMemberTypeParams != numIfaceTypeParams) continue;

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -3063,7 +3063,14 @@ export class Resolver extends DiagnosticEmitter {
           let boundPrototype = classInstance.getMember(unboundOverridePrototype.name);
           if (boundPrototype) { // might have errored earlier and wasn't added
             assert(boundPrototype.kind == ElementKind.FunctionPrototype);
-            overrideInstance = this.resolveFunction(<FunctionPrototype>boundPrototype, instance.typeArguments);
+            let boundFuncPrototype = <FunctionPrototype>boundPrototype;
+            let overrideTypeParams = boundFuncPrototype.typeParameterNodes;
+            let numOverrideTypeParams = overrideTypeParams ? overrideTypeParams.length : 0;
+            let baseTypeArgs = instance.typeArguments;
+            let numBaseTypeArgs = baseTypeArgs ? baseTypeArgs.length : 0;
+            if (numOverrideTypeParams == numBaseTypeArgs) {
+              overrideInstance = this.resolveFunction(boundFuncPrototype, baseTypeArgs);
+            }
           }
         }
         if (overrideInstance) overrides.add(overrideInstance);
@@ -3439,6 +3446,20 @@ export class Resolver extends DiagnosticEmitter {
           default: assert(false);
         }
         if (!member.is(CommonFlags.Abstract)) {
+          // A generic method cannot implement a non-generic interface method
+          // because monomorphization requires a concrete type to generate code,
+          // but virtual dispatch through the interface has no type arguments.
+          let ifaceMember = unimplemented.get(memberName);
+          if (ifaceMember
+            && member.kind == ElementKind.FunctionPrototype
+            && ifaceMember.kind == ElementKind.FunctionPrototype
+          ) {
+            let memberTypeParams = (<FunctionPrototype>member).typeParameterNodes;
+            let ifaceTypeParams = (<FunctionPrototype>ifaceMember).typeParameterNodes;
+            let numMemberTypeParams = memberTypeParams ? memberTypeParams.length : 0;
+            let numIfaceTypeParams = ifaceTypeParams ? ifaceTypeParams.length : 0;
+            if (numMemberTypeParams != numIfaceTypeParams) continue;
+          }
           unimplemented.delete(memberName);
         }
       }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -3064,12 +3064,17 @@ export class Resolver extends DiagnosticEmitter {
           if (boundPrototype) { // might have errored earlier and wasn't added
             assert(boundPrototype.kind == ElementKind.FunctionPrototype);
             let boundFuncPrototype = <FunctionPrototype>boundPrototype;
-            let overrideTypeParams = boundFuncPrototype.typeParameterNodes;
-            let numOverrideTypeParams = overrideTypeParams ? overrideTypeParams.length : 0;
-            let baseTypeArgs = instance.typeArguments;
-            let numBaseTypeArgs = baseTypeArgs ? baseTypeArgs.length : 0;
-            if (numOverrideTypeParams == numBaseTypeArgs) {
-              overrideInstance = this.resolveFunction(boundFuncPrototype, baseTypeArgs);
+            // Only resolve the override when the generic-ness matches the base method.
+            // - generic child → non-generic base: skip; vtable dispatch site has no type
+            //   arguments to forward to the monomorphized child.
+            // - generic child → generic base: OK; type args come from the base call site.
+            // - non-generic child → non-generic base: OK; plain vtable override.
+            // FIXME: non-generic child → generic base is also mismatched (resolveFunction
+            //   would assert on typeArguments/typeParameterNodes length mismatch) but that
+            //   case is not yet guarded here. The correct fix is to replace this condition
+            //   with `boundFuncPrototype.is(Generic) == instance.is(Generic)`.
+            if (!boundFuncPrototype.is(CommonFlags.Generic) || instance.is(CommonFlags.Generic)) {
+              overrideInstance = this.resolveFunction(boundFuncPrototype, instance.typeArguments);
             }
           }
         }
@@ -3445,20 +3450,10 @@ export class Resolver extends DiagnosticEmitter {
           }
           default: assert(false);
         }
-        if (!member.is(CommonFlags.Abstract)) {
-          // A generic method cannot implement a non-generic interface method
-          // because monomorphization requires a concrete type to generate code,
-          // but virtual dispatch through the interface has no type arguments.
-          if (unimplemented.has(memberName)
-            && member.kind == ElementKind.FunctionPrototype
-            && unimplemented.get(memberName)!.kind == ElementKind.FunctionPrototype
-          ) {
-            let memberTypeParams = (<FunctionPrototype>member).typeParameterNodes;
-            let ifaceTypeParams = (<FunctionPrototype>unimplemented.get(memberName)).typeParameterNodes;
-            let numMemberTypeParams = memberTypeParams ? memberTypeParams.length : 0;
-            let numIfaceTypeParams = ifaceTypeParams ? ifaceTypeParams.length : 0;
-            if (numMemberTypeParams != numIfaceTypeParams) continue;
-          }
+        if (!member.is(CommonFlags.Abstract) && !member.is(CommonFlags.Generic)) {
+          // A generic method cannot satisfy a non-generic interface/abstract
+          // requirement: interface methods cannot be generic (AS241), and
+          // virtual dispatch cannot supply type arguments for monomorphization.
           unimplemented.delete(memberName);
         }
       }

--- a/tests/compiler/override-typeparam-mismatch.json
+++ b/tests/compiler/override-typeparam-mismatch.json
@@ -1,0 +1,6 @@
+{
+  "asc_flags": [],
+  "stderr": [
+    "TS2515: Non-abstract class 'override-typeparam-mismatch/CC' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I'."
+  ]
+}

--- a/tests/compiler/override-typeparam-mismatch.json
+++ b/tests/compiler/override-typeparam-mismatch.json
@@ -3,6 +3,7 @@
   "stderr": [
     "TS2515: Non-abstract class 'override-typeparam-mismatch/CC' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I'.",
     "TS2515: Non-abstract class 'override-typeparam-mismatch/DD' does not implement inherited abstract member 'bar' from 'override-typeparam-mismatch/J'.",
+    "TS2515: Non-abstract class 'override-typeparam-mismatch/C2' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I2'.",
     "EOF"
   ]
 }

--- a/tests/compiler/override-typeparam-mismatch.json
+++ b/tests/compiler/override-typeparam-mismatch.json
@@ -2,6 +2,7 @@
   "asc_flags": [],
   "stderr": [
     "TS2515: Non-abstract class 'override-typeparam-mismatch/CC' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I'.",
+    "TS2515: Non-abstract class 'override-typeparam-mismatch/DD' does not implement inherited abstract member 'bar' from 'override-typeparam-mismatch/J'.",
     "EOF"
   ]
 }

--- a/tests/compiler/override-typeparam-mismatch.json
+++ b/tests/compiler/override-typeparam-mismatch.json
@@ -1,9 +1,13 @@
 {
   "asc_flags": [],
   "stderr": [
+    "AS241: An interface or abstract method 'foo' cannot have type parameters.",
+    "AS241: An interface or abstract method 'baz' cannot have type parameters.",
     "TS2515: Non-abstract class 'override-typeparam-mismatch/CC' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I'.",
     "TS2515: Non-abstract class 'override-typeparam-mismatch/DD' does not implement inherited abstract member 'bar' from 'override-typeparam-mismatch/J'.",
     "TS2515: Non-abstract class 'override-typeparam-mismatch/C2' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I2'.",
+    "TS2515: Non-abstract class 'override-typeparam-mismatch/FF' does not implement inherited abstract member 'baz' from 'override-typeparam-mismatch/A1'.",
+    "TS2515: Non-abstract class 'override-typeparam-mismatch/GG' does not implement inherited abstract member 'qux' from 'override-typeparam-mismatch/A2'.",
     "EOF"
   ]
 }

--- a/tests/compiler/override-typeparam-mismatch.json
+++ b/tests/compiler/override-typeparam-mismatch.json
@@ -1,6 +1,7 @@
 {
   "asc_flags": [],
   "stderr": [
-    "TS2515: Non-abstract class 'override-typeparam-mismatch/CC' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I'."
+    "TS2515: Non-abstract class 'override-typeparam-mismatch/CC' does not implement inherited abstract member 'foo' from 'override-typeparam-mismatch/I'.",
+    "EOF"
   ]
 }

--- a/tests/compiler/override-typeparam-mismatch.ts
+++ b/tests/compiler/override-typeparam-mismatch.ts
@@ -10,3 +10,5 @@ class CC implements I {
 
 let c:I = new CC();
 c.foo(1);
+
+ERROR("EOF");

--- a/tests/compiler/override-typeparam-mismatch.ts
+++ b/tests/compiler/override-typeparam-mismatch.ts
@@ -36,4 +36,31 @@ class C2 implements I2 {
 
 new C2().foo<i32>(1);
 
+// abstract method cannot be generic (AS241)
+abstract class A1 {
+  abstract baz<T>(x: i32): i32;
+}
+
+class FF extends A1 {
+  baz<T>(x: i32): i32 {
+    return x;
+  }
+}
+
+new FF().baz<i32>(1);
+
+// generic method cannot implement non-generic abstract method (TS2515)
+abstract class A2 {
+  abstract qux(x: i32): i32;
+}
+
+class GG extends A2 {
+  qux<T>(x: i32): i32 {
+    return x;
+  }
+}
+
+let a: A2 = new GG();
+a.qux(1);
+
 ERROR("EOF");

--- a/tests/compiler/override-typeparam-mismatch.ts
+++ b/tests/compiler/override-typeparam-mismatch.ts
@@ -24,4 +24,16 @@ class DD implements J {
 let dd:DD = new DD();
 dd.bar<i32>(1);
 
+interface I2 {
+  foo<T, U>(x: i32): i32;
+}
+
+class C2 implements I2 {
+  foo<T>(x: i32): i32 {
+    return x;
+  }
+}
+
+new C2().foo<i32>(1);
+
 ERROR("EOF");

--- a/tests/compiler/override-typeparam-mismatch.ts
+++ b/tests/compiler/override-typeparam-mismatch.ts
@@ -11,4 +11,17 @@ class CC implements I {
 let c:I = new CC();
 c.foo(1);
 
+interface J {
+  bar(x: i32): i32;
+}
+
+class DD implements J {
+  bar<T>(x: i32): i32 {
+    return x;
+  }
+}
+
+let dd:DD = new DD();
+dd.bar<i32>(1);
+
 ERROR("EOF");

--- a/tests/compiler/override-typeparam-mismatch.ts
+++ b/tests/compiler/override-typeparam-mismatch.ts
@@ -1,0 +1,12 @@
+interface I {
+  foo(x: i32): i32;
+}
+
+class CC implements I {
+  foo<T>(x: i32): i32 {
+    return x;
+  }
+}
+
+let c:I = new CC();
+c.foo(1);


### PR DESCRIPTION


<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes #3006  .

Changes proposed in this pull request:
TypeScript allows this because it uses type erasure — generics disappear at runtime, so `foo<T>()` and `foo()` are the same function. AssemblyScript cannot do the same because it uses monomorphization — each type argument produces a distinct function, and the vtable needs a single fixed entry. This is the same reason C++ forbids template functions from overriding virtual functions.

The fix treats a generic method as not satisfying a non-generic interface method, matching C++ semantics.

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
