### PR TITLE
fix: forbidden override between generic function and concrete function

### DIFF
--- a/src/diagnosticMessages.json
+++ b/src/diagnosticMessages.json
@@ -53,6 +53,7 @@
   "Definitive assignment has no effect on local variables.": 239,
   "Ambiguous operator overload '{0}' (conflicting overloads '{1}' and '{2}').": 240,
   "An interface or abstract method '{0}' cannot have type parameters.": 241,
+  "Cannot override generic method '{0}' with a non-generic method or vice versa.": 242,
 
   "Importing the table disables some indirect call optimizations.": 901,
   "Exporting the table disables some indirect call optimizations.": 902,

--- a/src/program.ts
+++ b/src/program.ts
@@ -1557,6 +1557,16 @@ export class Program extends DiagnosticEmitter {
     ) {
       let thisMethod = <FunctionPrototype>thisMember;
       let baseMethod = <FunctionPrototype>baseMember;
+      let thisIsGeneric = thisMethod.is(CommonFlags.Generic);
+      let baseIsGeneric = baseMethod.is(CommonFlags.Generic);
+      if (thisIsGeneric != baseIsGeneric) {
+        this.errorRelated(
+          DiagnosticCode.Cannot_override_generic_method_0_with_a_non_generic_method_or_vice_versa,
+          thisMethod.identifierNode.range, baseMethod.identifierNode.range,
+          thisMethod.name
+        );
+        return;
+      }
       if (!thisMethod.visibilityEquals(baseMethod)) {
         this.errorRelated(
           DiagnosticCode.Overload_signatures_must_all_be_public_private_or_protected,

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2934,7 +2934,8 @@ export class Resolver extends DiagnosticEmitter {
           } else {
             if (baseMember.kind == ElementKind.FunctionPrototype) {
               let basePrototype = <FunctionPrototype>baseMember;
-              let baseIsGeneric = basePrototype.typeParameterNodes != null && basePrototype.typeParameterNodes.length > 0;
+              let baseTypeParameterNodes = basePrototype.typeParameterNodes;
+              let baseIsGeneric = baseTypeParameterNodes != null && baseTypeParameterNodes.length > 0;
               let instanceIsGeneric = typeArguments != null && typeArguments.length > 0;
               if (baseIsGeneric != instanceIsGeneric) {
                 // Cannot mix generic and non-generic functions in an override chain

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2933,11 +2933,23 @@ export class Resolver extends DiagnosticEmitter {
             incompatibleOverride = false;
           } else {
             if (baseMember.kind == ElementKind.FunctionPrototype) {
-              // Possibly generic. Resolve with same type arguments to obtain the correct one.
               let basePrototype = <FunctionPrototype>baseMember;
-              let baseFunction = this.resolveFunction(basePrototype, typeArguments, new Map(), ReportMode.Swallow);
-              if (baseFunction && instance.signature.isAssignableTo(baseFunction.signature, true)) {
-                incompatibleOverride = false;
+              let baseIsGeneric = basePrototype.typeParameterNodes != null && basePrototype.typeParameterNodes.length > 0;
+              let instanceIsGeneric = typeArguments != null && typeArguments.length > 0;
+              if (baseIsGeneric != instanceIsGeneric) {
+                // Cannot mix generic and non-generic functions in an override chain
+                this.errorRelated(
+                  DiagnosticCode.Cannot_override_generic_method_0_with_a_non_generic_method_or_vice_versa,
+                  instance.identifierAndSignatureRange, baseMember.identifierAndSignatureRange,
+                  methodOrPropertyName
+                );
+                incompatibleOverride = false; // already reported
+              } else {
+                // Possibly generic. Resolve with same type arguments to obtain the correct one.
+                let baseFunction = this.resolveFunction(basePrototype, typeArguments, new Map(), ReportMode.Swallow);
+                if (baseFunction && instance.signature.isAssignableTo(baseFunction.signature, true)) {
+                  incompatibleOverride = false;
+                }
               }
             }
           }
@@ -3069,11 +3081,8 @@ export class Resolver extends DiagnosticEmitter {
             //   arguments to forward to the monomorphized child.
             // - generic child → generic base: OK; type args come from the base call site.
             // - non-generic child → non-generic base: OK; plain vtable override.
-            // FIXME: non-generic child → generic base is also mismatched (resolveFunction
-            //   would assert on typeArguments/typeParameterNodes length mismatch) but that
-            //   case is not yet guarded here. The correct fix is to replace this condition
-            //   with `boundFuncPrototype.is(Generic) == instance.is(Generic)`.
-            if (!boundFuncPrototype.is(CommonFlags.Generic) || instance.is(CommonFlags.Generic)) {
+            // - non-generic child → generic base: skip; mismatched generic-ness.
+            if (boundFuncPrototype.is(CommonFlags.Generic) == instance.is(CommonFlags.Generic)) {
               overrideInstance = this.resolveFunction(boundFuncPrototype, instance.typeArguments);
             }
           }

--- a/tests/compiler/override-generic-mismatch.json
+++ b/tests/compiler/override-generic-mismatch.json
@@ -1,0 +1,8 @@
+{
+  "asc_flags": [],
+  "stderr": [
+    "AS242: Cannot override generic method 'foo' with a non-generic method or vice versa.",
+    "AS242: Cannot override generic method 'bar' with a non-generic method or vice versa.",
+    "EOF"
+  ]
+}

--- a/tests/compiler/override-generic-mismatch.ts
+++ b/tests/compiler/override-generic-mismatch.ts
@@ -1,0 +1,25 @@
+// Non-generic method overriding generic method
+class A {
+  foo<T>(x: T): void {}
+}
+
+class B extends A {
+  foo(x: i32): void {}
+}
+
+let a:A = new B();
+a.foo<i32>(1);
+
+// Generic method overriding non-generic method
+class C {
+  bar(x: i32): void {}
+}
+
+class D extends C {
+  bar<T>(x: T): void {}
+}
+
+let c:C = new D();
+c.bar(1);
+
+ERROR("EOF");


### PR DESCRIPTION
<!--
 Thanks for submitting a pull request to AssemblyScript! Please take a moment to
 review the contributing guidelines linked below, and confirm with an [x] 🙂
-->
Fixes #3013  .

Changes proposed in this pull request:
In current assemblyscript, 

1. when concrete function override generic function
Compile crashed
```
let called: string = "";

class A {
  foo<T>(x: T): void {
    called = "A";
  }
}

class B extends A {
  foo(x: i32): void {
    called = "B";
  }
}

let a: A = new B();
a.foo<i32>(1);
assert(called == "B");
```

Error message
```shell
node ./bin/asc.js --debug -o build/test.wasm -t build/test.wat test.ts
2
Debugger attached.

▌ Whoops, the AssemblyScript compiler has crashed during compile :-(
▌ 
▌ Here is the stack trace hinting at the problem, perhaps it's useful?
▌ 
▌ AssertionError: assertion failed
▌     at assert2 (/Users/Q479807/workspace/github/assemblyscript/std/portable/index.js:216:11)
▌     at Resolver.resolveFunction (/Users/Q479807/workspace/github/assemblyscript/src/resolver.ts:2790:7)
▌     at Resolver.resolveOverrides (/Users/Q479807/workspace/github/assemblyscript/src/resolver.ts:3077:39)
▌     at _Compiler.compile (/Users/Q479807/workspace/github/assemblyscript/src/compiler.ts:615:42)
▌     at Module.compile (/Users/Q479807/workspace/github/assemblyscript/src/index-wasm.ts:358:32)
▌     at Module.main (/Users/Q479807/workspace/github/assemblyscript/cli/index.js:732:31)
▌     at async file:///Users/Q479807/workspace/github/assemblyscript/bin/asc.js:33:22
▌ 
▌ If you see where the error is, feel free to send us a pull request. If not,
▌ please let us know: https://github.com/AssemblyScript/assemblyscript/issues
▌ 
▌ Thank you!
```

2. When generic function override concrete function
The output is different with typescript.
In typescript the output is `B`
But in assemblyscript, the output is `A`
```
type i32 = number;
let trace = console.log;
class A {
  foo(x: i32): void {
    trace("A");
  }
}

class B extends A {
  foo<T>(x: T): void {
    trace("B");
  }
}

let a:A = new B();
a.foo(1);
```

## Proposed solution 
Assemblyscript can't follow typescript's behavior when override between generic and concrete function. Because typescript uses structural typing for type checking and erase type for code emitting. 
But assemblyscript use nominal typing and need the type for code emitting. For example, in case 2, if assemblyscript need to follow typescript's behavior, it need a complex typing inference system to emit function B::foo<i32>. I don't think it's worth the effort

So this PR just totally forbidden override between generic function and concrete function

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
