### PR TITLE
fix: optimize dayOfWeek & dateFromEpoch routines in date

### DIFF
--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -62,7 +62,7 @@ export class Date {
       let timeString: string;
       dateString = dateTimeString.substring(0, posT);
       timeString = dateTimeString.substring(posT + 1);
-      
+
       // might end with an offset ("Z", "+05:30", "-08:00", etc.)
       for (let i = timeString.length - 1; i >= 0; i--) {
         let c = timeString.charCodeAt(i);
@@ -82,8 +82,8 @@ export class Date {
           } else {
             let offsetHours = i32.parse(timeString.substring(i + 1));
             offsetMs = offsetHours * MILLIS_PER_HOUR;
-          }    
-    
+          }
+
           if (c == 45) offsetMs = -offsetMs; // negative offset
           timeString = timeString.substring(0, i);
           break;
@@ -361,7 +361,8 @@ function dayOfWeek(year: i32, month: i32, day: i32): i32 {
   const tab = memory.data<u8>([0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4]);
 
   year -= i32(month < 3);
-  year += floorDiv(year, 4) - floorDiv(year, 100) + floorDiv(year, YEARS_PER_EPOCH);
+  const century = floorDiv(year >> 2, 100 >> 2);
+  year += (year >> 2) + (century >> 2) - century;
   month = <i32>load<u8>(tab + month - 1);
   return euclidRem(year + month + day, 7);
 }

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -362,7 +362,7 @@ function dayOfWeek(year: i32, month: i32, day: i32): i32 {
 
   year -= i32(month < 3);
   const century = floorDiv(year >> 2, 100 >> 2);
-  year += (year >> 2) + (century >> 2) - century;
+  year += (year >> 2) - century + (century >> 2);
   month = <i32>load<u8>(tab + month - 1);
   return euclidRem(year + month + day, 7);
 }

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -332,17 +332,15 @@ function invalidDate(millis: i64): bool {
 // Paper: https://arxiv.org/pdf/2102.06959.pdf
 function dateFromEpoch(ms: i64): i32 {
   let da = (<i32>floorDiv(ms, MILLIS_PER_DAY) * 4 + EPOCH_OFFSET * 4) | 3;
-  let q0 = floorDiv(da, DAYS_PER_EPOCH); // [0, 146096]
+  let q0 = floorDiv(da, DAYS_PER_EPOCH);  // [0, 146096]
   let r1 = <u32>da - q0 * DAYS_PER_EPOCH;
   let u1 = u64(r1 | 3) * 2939745;
   let dm1 = <u32>u1 / 11758980;
   let n1 = 2141 * dm1 + 197913;
   let year = 100 * q0 + i32(u1 >>> 32);
-  let mo = n1 >>> 16;
-  _day = (n1 & 0xFFFF) / 2141 + 1; // [1, 31]
-  if (dm1 >= 306) { mo -= 12; ++year; }
-  _month = mo; // [1, 12]
-  return year;
+  _day = (n1 & 0xFFFF) / 2141 + 1;              // [1, 31]
+  _month = (n1 >>> 16) - (dm1 >= 306 ? 12 : 0); // [1, 12]
+  return year + (dm1 >= 306 ?  1 : 0);
 }
 
 // http://howardhinnant.github.io/date_algorithms.html#days_from_civil

--- a/std/assembly/date.ts
+++ b/std/assembly/date.ts
@@ -3,15 +3,14 @@ import { Date as Date_binding } from "./bindings/dom";
 
 // @ts-ignore: decorator
 @inline const
+  MILLIS_LIMIT      = 8640000000000000,
   MILLIS_PER_DAY    = 1000 * 60 * 60 * 24,
   MILLIS_PER_HOUR   = 1000 * 60 * 60,
   MILLIS_PER_MINUTE = 1000 * 60,
   MILLIS_PER_SECOND = 1000,
-
-  YEARS_PER_EPOCH = 400,
-  DAYS_PER_EPOCH = 146097,
-  EPOCH_OFFSET = 719468, // Jan 1, 1970
-  MILLIS_LIMIT = 8640000000000000;
+  YEARS_PER_EPOCH   = 400,
+  DAYS_PER_EPOCH    = 146097, // 400 * 365 + 400 / 4 - 400 / 100 + 1
+  EPOCH_OFFSET      = 719468; // Jan 1, 1970
 
 // ymdFromEpochDays returns values via globals to avoid allocations
 // @ts-ignore: decorator
@@ -347,11 +346,11 @@ function dateFromEpoch(ms: i64): i32 {
 }
 
 // http://howardhinnant.github.io/date_algorithms.html#days_from_civil
-function daysSinceEpoch(y: i32, m: i32, d: i32): i64 {
-  y -= i32(m <= 2);
-  let era = <u32>floorDiv(y, YEARS_PER_EPOCH);
-  let yoe = <u32>y - era * YEARS_PER_EPOCH; // [0, 399]
-  let doy = <u32>(153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1; // [0, 365]
+function daysSinceEpoch(year: i32, month: i32, day: i32): i64 {
+  year -= i32(month <= 2);
+  let era = <u32>floorDiv(year, YEARS_PER_EPOCH);
+  let yoe = <u32>year - era * YEARS_PER_EPOCH; // [0, 399]
+  let doy = <u32>(153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1; // [0, 365]
   let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
   return <i64><i32>(era * 146097 + doe - EPOCH_OFFSET);
 }
@@ -360,9 +359,9 @@ function daysSinceEpoch(y: i32, m: i32, d: i32): i64 {
 function dayOfWeek(year: i32, month: i32, day: i32): i32 {
   const tab = memory.data<u8>([0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4]);
 
-  year -= i32(month < 3);
-  const century = floorDiv(year >> 2, 100 >> 2);
-  year += (year >> 2) - century + (century >> 2);
+  year -= i32(month <= 2);
+  const cent = floorDiv(year >> 2, 100 >> 2);
+  year += (year >> 2) - cent + (cent >> 2);
   month = <i32>load<u8>(tab + month - 1);
   return euclidRem(year + month + day, 7);
 }

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -2705,12 +2705,9 @@
  (func $~lib/date/dayOfWeek (param $year i32) (param $month i32) (param $day i32) (result i32)
   (local $a i32)
   (local $b i32)
-  (local $a|5 i32)
-  (local $b|6 i32)
-  (local $a|7 i32)
-  (local $b|8 i32)
-  (local $a|9 i32)
-  (local $b|10 i32)
+  (local $century i32)
+  (local $a|6 i32)
+  (local $b|7 i32)
   (local $m i32)
   local.get $year
   local.get $month
@@ -2718,11 +2715,14 @@
   i32.lt_s
   i32.sub
   local.set $year
-  local.get $year
   block $~lib/date/floorDiv<i32>|inlined.2 (result i32)
    local.get $year
+   i32.const 2
+   i32.shr_s
    local.set $a
-   i32.const 4
+   i32.const 100
+   i32.const 2
+   i32.shr_s
    local.set $b
    local.get $a
    local.get $a
@@ -2740,50 +2740,17 @@
    i32.div_s
    br $~lib/date/floorDiv<i32>|inlined.2
   end
-  block $~lib/date/floorDiv<i32>|inlined.3 (result i32)
-   local.get $year
-   local.set $a|5
-   i32.const 100
-   local.set $b|6
-   local.get $a|5
-   local.get $a|5
-   i32.const 0
-   i32.lt_s
-   if (result i32)
-    local.get $b|6
-    i32.const 1
-    i32.sub
-   else
-    i32.const 0
-   end
-   i32.sub
-   local.get $b|6
-   i32.div_s
-   br $~lib/date/floorDiv<i32>|inlined.3
-  end
-  i32.sub
-  block $~lib/date/floorDiv<i32>|inlined.4 (result i32)
-   local.get $year
-   local.set $a|7
-   i32.const 400
-   local.set $b|8
-   local.get $a|7
-   local.get $a|7
-   i32.const 0
-   i32.lt_s
-   if (result i32)
-    local.get $b|8
-    i32.const 1
-    i32.sub
-   else
-    i32.const 0
-   end
-   i32.sub
-   local.get $b|8
-   i32.div_s
-   br $~lib/date/floorDiv<i32>|inlined.4
-  end
+  local.set $century
+  local.get $year
+  local.get $year
+  i32.const 2
+  i32.shr_s
+  local.get $century
+  i32.const 2
+  i32.shr_s
   i32.add
+  local.get $century
+  i32.sub
   i32.add
   local.set $year
   i32.const 556
@@ -2799,11 +2766,11 @@
    i32.add
    local.get $day
    i32.add
-   local.set $a|9
+   local.set $a|6
    i32.const 7
-   local.set $b|10
-   local.get $a|9
-   local.get $b|10
+   local.set $b|7
+   local.get $a|6
+   local.get $b|7
    i32.rem_s
    local.set $m
    local.get $m
@@ -2811,7 +2778,7 @@
    i32.const 0
    i32.lt_s
    if (result i32)
-    local.get $b|10
+    local.get $b|7
    else
     i32.const 0
    end
@@ -8782,14 +8749,19 @@
   (local $162 i32)
   (local $163 i32)
   (local $164 i32)
+  (local $165 i32)
+  (local $166 i32)
+  (local $167 i32)
+  (local $168 i32)
+  (local $169 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 436
+  i32.const 456
   i32.sub
   global.set $~lib/memory/__stack_pointer
   call $~stack_check
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 436
+  i32.const 456
   memory.fill
   block $~lib/date/Date.UTC|inlined.0 (result i64)
    i32.const 1970
@@ -9284,11 +9256,11 @@
    local.tee $58
    i32.store offset=4
    local.get $58
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.0
   end
@@ -9304,11 +9276,11 @@
    unreachable
   end
   local.get $57
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   local.get $56
   i64.const 1
   i64.add
@@ -9320,11 +9292,11 @@
    local.tee $59
    i32.store offset=12
    local.get $59
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.1
   end
@@ -9353,11 +9325,11 @@
    local.tee $61
    i32.store offset=20
    local.get $61
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.0
   end
@@ -9378,11 +9350,11 @@
    local.tee $62
    i32.store offset=24
    local.get $62
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -9405,11 +9377,11 @@
    local.tee $63
    i32.store offset=28
    local.get $63
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.0
   end
@@ -9425,11 +9397,11 @@
    unreachable
   end
   local.get $60
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCHours
   i32.const 22
   i32.eq
@@ -9443,11 +9415,11 @@
    unreachable
   end
   local.get $60
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMinutes
   i32.const 9
   i32.eq
@@ -9461,11 +9433,11 @@
    unreachable
   end
   local.get $60
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCSeconds
   i32.const 43
   i32.eq
@@ -9479,11 +9451,11 @@
    unreachable
   end
   local.get $60
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 706
   i32.eq
@@ -9508,11 +9480,11 @@
    local.tee $65
    i32.store offset=36
    local.get $65
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.1
   end
@@ -9533,11 +9505,11 @@
    local.tee $66
    i32.store offset=40
    local.get $66
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -9560,11 +9532,11 @@
    local.tee $67
    i32.store offset=44
    local.get $67
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.1
   end
@@ -9580,11 +9552,11 @@
    unreachable
   end
   local.get $64
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCHours
   i32.const 1
   i32.eq
@@ -9598,11 +9570,11 @@
    unreachable
   end
   local.get $64
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMinutes
   i32.const 3
   i32.eq
@@ -9616,11 +9588,11 @@
    unreachable
   end
   local.get $64
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCSeconds
   i32.const 11
   i32.eq
@@ -9634,11 +9606,11 @@
    unreachable
   end
   local.get $64
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 274
   i32.eq
@@ -9658,11 +9630,11 @@
   local.tee $68
   i32.store offset=48
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 984
   i32.eq
@@ -9676,19 +9648,19 @@
    unreachable
   end
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 12
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 12
   i32.eq
@@ -9702,19 +9674,19 @@
    unreachable
   end
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 568
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 568
   i32.eq
@@ -9728,11 +9700,11 @@
    unreachable
   end
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 0
   call $~lib/date/Date#setUTCMilliseconds
   block $~lib/date/Date#getTime|inlined.2 (result i64)
@@ -9741,11 +9713,11 @@
    local.tee $69
    i32.store offset=52
    local.get $69
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.2
   end
@@ -9761,11 +9733,11 @@
    unreachable
   end
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 999
   call $~lib/date/Date#setUTCMilliseconds
   block $~lib/date/Date#getTime|inlined.3 (result i64)
@@ -9774,11 +9746,11 @@
    local.tee $70
    i32.store offset=56
    local.get $70
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.3
   end
@@ -9794,19 +9766,19 @@
    unreachable
   end
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 2000
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 0
   i32.eq
@@ -9825,11 +9797,11 @@
    local.tee $71
    i32.store offset=60
    local.get $71
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.4
   end
@@ -9845,19 +9817,19 @@
    unreachable
   end
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const -2000
   call $~lib/date/Date#setUTCMilliseconds
   local.get $68
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 0
   i32.eq
@@ -9876,11 +9848,11 @@
    local.tee $72
    i32.store offset=64
    local.get $72
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.5
   end
@@ -9902,11 +9874,11 @@
   local.tee $73
   i32.store offset=68
   local.get $73
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCSeconds
   i32.const 31
   i32.eq
@@ -9920,19 +9892,19 @@
    unreachable
   end
   local.get $73
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 12
   call $~lib/date/Date#setUTCSeconds
   local.get $73
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCSeconds
   i32.const 12
   i32.eq
@@ -9946,19 +9918,19 @@
    unreachable
   end
   local.get $73
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 50
   call $~lib/date/Date#setUTCSeconds
   local.get $73
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCSeconds
   i32.const 50
   i32.eq
@@ -9972,11 +9944,11 @@
    unreachable
   end
   local.get $73
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 0
   call $~lib/date/Date#setUTCSeconds
   block $~lib/date/Date#getTime|inlined.6 (result i64)
@@ -9985,11 +9957,11 @@
    local.tee $74
    i32.store offset=72
    local.get $74
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.6
   end
@@ -10005,11 +9977,11 @@
    unreachable
   end
   local.get $73
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 59
   call $~lib/date/Date#setUTCSeconds
   block $~lib/date/Date#getTime|inlined.7 (result i64)
@@ -10018,11 +9990,11 @@
    local.tee $75
    i32.store offset=76
    local.get $75
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.7
   end
@@ -10044,11 +10016,11 @@
   local.tee $76
   i32.store offset=80
   local.get $76
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMinutes
   i32.const 45
   i32.eq
@@ -10062,19 +10034,19 @@
    unreachable
   end
   local.get $76
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 12
   call $~lib/date/Date#setUTCMinutes
   local.get $76
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMinutes
   i32.const 12
   i32.eq
@@ -10088,19 +10060,19 @@
    unreachable
   end
   local.get $76
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 50
   call $~lib/date/Date#setUTCMinutes
   local.get $76
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMinutes
   i32.const 50
   i32.eq
@@ -10114,11 +10086,11 @@
    unreachable
   end
   local.get $76
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 0
   call $~lib/date/Date#setUTCMinutes
   block $~lib/date/Date#getTime|inlined.8 (result i64)
@@ -10127,11 +10099,11 @@
    local.tee $77
    i32.store offset=84
    local.get $77
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.8
   end
@@ -10147,11 +10119,11 @@
    unreachable
   end
   local.get $76
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 59
   call $~lib/date/Date#setUTCMinutes
   block $~lib/date/Date#getTime|inlined.9 (result i64)
@@ -10160,11 +10132,11 @@
    local.tee $78
    i32.store offset=88
    local.get $78
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.9
   end
@@ -10186,11 +10158,11 @@
   local.tee $79
   i32.store offset=92
   local.get $79
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCHours
   i32.const 17
   i32.eq
@@ -10204,19 +10176,19 @@
    unreachable
   end
   local.get $79
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 12
   call $~lib/date/Date#setUTCHours
   local.get $79
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCHours
   i32.const 12
   i32.eq
@@ -10230,19 +10202,19 @@
    unreachable
   end
   local.get $79
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 2
   call $~lib/date/Date#setUTCHours
   local.get $79
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCHours
   i32.const 2
   i32.eq
@@ -10256,11 +10228,11 @@
    unreachable
   end
   local.get $79
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 0
   call $~lib/date/Date#setUTCHours
   block $~lib/date/Date#getTime|inlined.10 (result i64)
@@ -10269,11 +10241,11 @@
    local.tee $80
    i32.store offset=96
    local.get $80
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.10
   end
@@ -10289,11 +10261,11 @@
    unreachable
   end
   local.get $79
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 23
   call $~lib/date/Date#setUTCHours
   block $~lib/date/Date#getTime|inlined.11 (result i64)
@@ -10302,11 +10274,11 @@
    local.tee $81
    i32.store offset=100
    local.get $81
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.11
   end
@@ -10333,11 +10305,11 @@
    local.tee $83
    i32.store offset=108
    local.get $83
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.2
   end
@@ -10358,11 +10330,11 @@
    local.tee $84
    i32.store offset=112
    local.get $84
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -10380,11 +10352,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 12
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getUTCDate|inlined.2 (result i32)
@@ -10393,11 +10365,11 @@
    local.tee $85
    i32.store offset=116
    local.get $85
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.2
   end
@@ -10413,11 +10385,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 2
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getUTCDate|inlined.3 (result i32)
@@ -10426,11 +10398,11 @@
    local.tee $86
    i32.store offset=120
    local.get $86
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.3
   end
@@ -10446,62 +10418,62 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 1
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 30
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
   i32.const 0
   call $~lib/date/Date#setUTCMonth@varargs
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 1
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 31
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 2024
   call $~lib/date/Date#setUTCFullYear
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 1
   i32.const 1
   global.set $~argumentsLength
@@ -10513,11 +10485,11 @@
    local.tee $87
    i32.store offset=124
    local.get $87
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -10535,27 +10507,27 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 1
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 29
   call $~lib/date/Date#setUTCDate
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 1
   i32.const 1
   global.set $~argumentsLength
@@ -10567,11 +10539,11 @@
    local.tee $88
    i32.store offset=128
    local.get $88
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.12
   end
@@ -10592,11 +10564,11 @@
    local.tee $89
    i32.store offset=132
    local.get $89
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -10619,11 +10591,11 @@
    local.tee $90
    i32.store offset=136
    local.get $90
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.4
   end
@@ -10639,11 +10611,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMinutes
   i32.const 3
   i32.eq
@@ -10657,11 +10629,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCSeconds
   i32.const 11
   i32.eq
@@ -10675,11 +10647,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   call $~lib/date/Date#getUTCMilliseconds
   i32.const 274
   i32.eq
@@ -10699,11 +10671,11 @@
   local.tee $82
   i32.store offset=104
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 20
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.13 (result i64)
@@ -10712,11 +10684,11 @@
    local.tee $91
    i32.store offset=140
    local.get $91
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.13
   end
@@ -10732,11 +10704,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 1
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.14 (result i64)
@@ -10745,11 +10717,11 @@
    local.tee $92
    i32.store offset=144
    local.get $92
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.14
   end
@@ -10765,11 +10737,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 1000
   call $~lib/date/Date#setUTCMilliseconds
   block $~lib/date/Date#getTime|inlined.15 (result i64)
@@ -10778,11 +10750,11 @@
    local.tee $93
    i32.store offset=148
    local.get $93
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.15
   end
@@ -10798,11 +10770,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 60
   i32.const 60
   i32.mul
@@ -10815,11 +10787,11 @@
    local.tee $94
    i32.store offset=152
    local.get $94
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.16
   end
@@ -10835,11 +10807,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 60
   i32.const 60
   i32.mul
@@ -10854,11 +10826,11 @@
    local.tee $95
    i32.store offset=156
    local.get $95
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.17
   end
@@ -10874,11 +10846,11 @@
    unreachable
   end
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 60
   i32.const 60
   i32.mul
@@ -10893,11 +10865,11 @@
    local.tee $96
    i32.store offset=160
    local.get $96
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.18
   end
@@ -10919,11 +10891,11 @@
   local.tee $82
   i32.store offset=104
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const -2208
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.19 (result i64)
@@ -10932,11 +10904,11 @@
    local.tee $97
    i32.store offset=164
    local.get $97
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.19
   end
@@ -10958,11 +10930,11 @@
   local.tee $82
   i32.store offset=104
   local.get $82
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 2208
   call $~lib/date/Date#setUTCDate
   block $~lib/date/Date#getTime|inlined.20 (result i64)
@@ -10971,11 +10943,11 @@
    local.tee $98
    i32.store offset=168
    local.get $98
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.20
   end
@@ -10998,25 +10970,25 @@
    local.tee $99
    i32.store offset=172
    local.get $99
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $99
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $99
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.0
@@ -11042,25 +11014,25 @@
    local.tee $100
    i32.store offset=176
    local.get $100
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $100
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $100
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.1
@@ -11088,25 +11060,25 @@
    local.tee $101
    i32.store offset=180
    local.get $101
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $101
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $101
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.2
@@ -11132,25 +11104,25 @@
    local.tee $102
    i32.store offset=184
    local.get $102
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $102
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $102
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.3
@@ -11174,25 +11146,25 @@
    local.tee $103
    i32.store offset=188
    local.get $103
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $103
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $103
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.4
@@ -11218,25 +11190,25 @@
    local.tee $104
    i32.store offset=192
    local.get $104
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $104
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $104
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.5
@@ -11264,25 +11236,25 @@
    local.tee $105
    i32.store offset=196
    local.get $105
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $105
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $105
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.6
@@ -11308,25 +11280,25 @@
    local.tee $106
    i32.store offset=200
    local.get $106
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    local.get $106
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    local.get $106
-   local.set $164
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    call $~lib/date/dayOfWeek
    br $~lib/date/Date#getUTCDay|inlined.7
@@ -11342,23 +11314,233 @@
    call $~lib/builtins/abort
    unreachable
   end
+  block $~lib/date/Date#getUTCDay|inlined.8 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i64.const -8640000000000000
+   call $~lib/date/Date#constructor
+   local.tee $107
+   i32.store offset=204
+   local.get $107
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   local.get $107
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:month
+   local.get $107
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:day
+   call $~lib/date/dayOfWeek
+   br $~lib/date/Date#getUTCDay|inlined.8
+  end
+  i32.const 2
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 197
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/date/Date#getUTCDay|inlined.9 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i64.const -62183116800000
+   call $~lib/date/Date#constructor
+   local.tee $108
+   i32.store offset=208
+   local.get $108
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   local.get $108
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:month
+   local.get $108
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:day
+   call $~lib/date/dayOfWeek
+   br $~lib/date/Date#getUTCDay|inlined.9
+  end
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 198
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/date/Date#getUTCDay|inlined.10 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i64.const 0
+   call $~lib/date/Date#constructor
+   local.tee $109
+   i32.store offset=212
+   local.get $109
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   local.get $109
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:month
+   local.get $109
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:day
+   call $~lib/date/dayOfWeek
+   br $~lib/date/Date#getUTCDay|inlined.10
+  end
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 199
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/date/Date#getUTCDay|inlined.11 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i64.const 1709164800000
+   call $~lib/date/Date#constructor
+   local.tee $110
+   i32.store offset=216
+   local.get $110
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   local.get $110
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:month
+   local.get $110
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:day
+   call $~lib/date/dayOfWeek
+   br $~lib/date/Date#getUTCDay|inlined.11
+  end
+  i32.const 4
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 200
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  block $~lib/date/Date#getUTCDay|inlined.12 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i64.const 8640000000000000
+   call $~lib/date/Date#constructor
+   local.tee $111
+   i32.store offset=220
+   local.get $111
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   local.get $111
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:month
+   local.get $111
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:day
+   call $~lib/date/dayOfWeek
+   br $~lib/date/Date#getUTCDay|inlined.12
+  end
+  i32.const 6
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 201
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 7899943856218720
   call $~lib/date/Date#constructor
-  local.tee $107
-  i32.store offset=204
+  local.tee $112
+  i32.store offset=224
   block $~lib/date/Date#getUTCMonth|inlined.5 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $108
-   i32.store offset=208
-   local.get $108
-   local.set $164
+   local.get $112
+   local.tee $113
+   i32.store offset=228
+   local.get $113
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -11370,17 +11552,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 201
+   i32.const 207
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $107
-  local.set $164
+  local.get $112
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 10
   i32.const 1
   global.set $~argumentsLength
@@ -11388,15 +11570,15 @@
   call $~lib/date/Date#setUTCMonth@varargs
   block $~lib/date/Date#getUTCMonth|inlined.6 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $109
-   i32.store offset=212
-   local.get $109
-   local.set $164
+   local.get $112
+   local.tee $114
+   i32.store offset=232
+   local.get $114
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -11408,17 +11590,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 203
+   i32.const 209
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $107
-  local.set $164
+  local.get $112
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 2
   i32.const 1
   global.set $~argumentsLength
@@ -11426,15 +11608,15 @@
   call $~lib/date/Date#setUTCMonth@varargs
   block $~lib/date/Date#getUTCMonth|inlined.7 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $110
-   i32.store offset=216
-   local.get $110
-   local.set $164
+   local.get $112
+   local.tee $115
+   i32.store offset=236
+   local.get $115
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -11446,22 +11628,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 205
+   i32.const 211
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getTime|inlined.21 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $111
-   i32.store offset=220
-   local.get $111
-   local.set $164
+   local.get $112
+   local.tee $116
+   i32.store offset=240
+   local.get $116
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.21
   end
@@ -11471,17 +11653,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 206
+   i32.const 212
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $107
-  local.set $164
+  local.get $112
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 0
   i32.const 1
   global.set $~argumentsLength
@@ -11489,15 +11671,15 @@
   call $~lib/date/Date#setUTCMonth@varargs
   block $~lib/date/Date#getTime|inlined.22 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $112
-   i32.store offset=224
    local.get $112
-   local.set $164
+   local.tee $117
+   i32.store offset=244
+   local.get $117
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.22
   end
@@ -11507,17 +11689,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 209
+   i32.const 215
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $107
-  local.set $164
+  local.get $112
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 11
   i32.const 1
   global.set $~argumentsLength
@@ -11525,15 +11707,15 @@
   call $~lib/date/Date#setUTCMonth@varargs
   block $~lib/date/Date#getTime|inlined.23 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $113
-   i32.store offset=228
-   local.get $113
-   local.set $164
+   local.get $112
+   local.tee $118
+   i32.store offset=248
+   local.get $118
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.23
   end
@@ -11543,17 +11725,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 211
+   i32.const 217
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $107
-  local.set $164
+  local.get $112
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const -1
   i32.const 1
   global.set $~argumentsLength
@@ -11561,15 +11743,15 @@
   call $~lib/date/Date#setUTCMonth@varargs
   block $~lib/date/Date#getUTCMonth|inlined.8 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $114
-   i32.store offset=232
-   local.get $114
-   local.set $164
+   local.get $112
+   local.tee $119
+   i32.store offset=252
+   local.get $119
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -11581,22 +11763,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 215
+   i32.const 221
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getTime|inlined.24 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $115
-   i32.store offset=236
-   local.get $115
-   local.set $164
+   local.get $112
+   local.tee $120
+   i32.store offset=256
+   local.get $120
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.24
   end
@@ -11606,17 +11788,17 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 216
+   i32.const 222
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $107
-  local.set $164
+  local.get $112
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 12
   i32.const 1
   global.set $~argumentsLength
@@ -11624,15 +11806,15 @@
   call $~lib/date/Date#setUTCMonth@varargs
   block $~lib/date/Date#getUTCMonth|inlined.9 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $116
-   i32.store offset=240
-   local.get $116
-   local.set $164
+   local.get $112
+   local.tee $121
+   i32.store offset=260
+   local.get $121
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -11644,22 +11826,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 218
+   i32.const 224
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getTime|inlined.25 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $107
-   local.tee $117
-   i32.store offset=244
-   local.get $117
-   local.set $164
+   local.get $112
+   local.tee $122
+   i32.store offset=264
+   local.get $122
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.25
   end
@@ -11669,7 +11851,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 219
+   i32.const 225
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -11678,122 +11860,23 @@
   i32.const 0
   i64.const 7941202527925698
   call $~lib/date/Date#constructor
-  local.tee $118
-  i32.store offset=248
+  local.tee $123
+  i32.store offset=268
   block $~lib/date/Date#getUTCFullYear|inlined.3 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $118
-   local.tee $119
-   i32.store offset=252
-   local.get $119
-   local.set $164
+   local.get $123
+   local.tee $124
+   i32.store offset=272
+   local.get $124
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.3
   end
   i32.const 253616
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 225
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $118
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  i32.const 1976
-  call $~lib/date/Date#setUTCFullYear
-  block $~lib/date/Date#getUTCFullYear|inlined.4 (result i32)
-   global.get $~lib/memory/__stack_pointer
-   local.get $118
-   local.tee $120
-   i32.store offset=256
-   local.get $120
-   local.set $164
-   global.get $~lib/memory/__stack_pointer
-   local.get $164
-   i32.store offset=8
-   local.get $164
-   call $~lib/date/Date#get:year
-   br $~lib/date/Date#getUTCFullYear|inlined.4
-  end
-  i32.const 1976
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 227
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $118
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  i32.const 20212
-  call $~lib/date/Date#setUTCFullYear
-  block $~lib/date/Date#getUTCFullYear|inlined.5 (result i32)
-   global.get $~lib/memory/__stack_pointer
-   local.get $118
-   local.tee $121
-   i32.store offset=260
-   local.get $121
-   local.set $164
-   global.get $~lib/memory/__stack_pointer
-   local.get $164
-   i32.store offset=8
-   local.get $164
-   call $~lib/date/Date#get:year
-   br $~lib/date/Date#getUTCFullYear|inlined.5
-  end
-  i32.const 20212
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 229
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $118
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  i32.const 71
-  call $~lib/date/Date#setUTCFullYear
-  block $~lib/date/Date#getUTCFullYear|inlined.6 (result i32)
-   global.get $~lib/memory/__stack_pointer
-   local.get $118
-   local.tee $122
-   i32.store offset=264
-   local.get $122
-   local.set $164
-   global.get $~lib/memory/__stack_pointer
-   local.get $164
-   i32.store offset=8
-   local.get $164
-   call $~lib/date/Date#get:year
-   br $~lib/date/Date#getUTCFullYear|inlined.6
-  end
-  i32.const 71
   i32.eq
   i32.eqz
   if
@@ -11804,26 +11887,96 @@
    call $~lib/builtins/abort
    unreachable
   end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i64.const -62167219200000
-  call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
   local.get $123
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toISOString
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 2672
-  call $~lib/string/String.__eq
+  local.get $169
+  i32.const 1976
+  call $~lib/date/Date#setUTCFullYear
+  block $~lib/date/Date#getUTCFullYear|inlined.4 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   local.get $123
+   local.tee $125
+   i32.store offset=276
+   local.get $125
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   br $~lib/date/Date#getUTCFullYear|inlined.4
+  end
+  i32.const 1976
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 233
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $123
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 20212
+  call $~lib/date/Date#setUTCFullYear
+  block $~lib/date/Date#getUTCFullYear|inlined.5 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   local.get $123
+   local.tee $126
+   i32.store offset=280
+   local.get $126
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   br $~lib/date/Date#getUTCFullYear|inlined.5
+  end
+  i32.const 20212
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 235
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $123
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 71
+  call $~lib/date/Date#setUTCFullYear
+  block $~lib/date/Date#getUTCFullYear|inlined.6 (result i32)
+   global.get $~lib/memory/__stack_pointer
+   local.get $123
+   local.tee $127
+   i32.store offset=284
+   local.get $127
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:year
+   br $~lib/date/Date#getUTCFullYear|inlined.6
+  end
+  i32.const 71
+  i32.eq
   i32.eqz
   if
    i32.const 0
@@ -11836,82 +11989,22 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const -62167219200000
-  i64.const 1
-  i64.sub
   call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 2752
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 239
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i64.const -62127219200000
-  call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toISOString
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  i32.const 2832
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 241
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i64.const 1231231231020
-  call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toISOString
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  i32.const 2912
+  local.get $169
+  i32.const 2672
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11924,23 +12017,25 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const 1231231231456
+  i64.const -62167219200000
+  i64.const 1
+  i64.sub
   call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 2992
+  local.get $169
+  i32.const 2752
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11953,23 +12048,23 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const 322331231231020
+  i64.const -62127219200000
   call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 3072
+  local.get $169
+  i32.const 2832
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -11982,23 +12077,23 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const 253402300799999
+  i64.const 1231231231020
   call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 3152
+  local.get $169
+  i32.const 2912
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12011,23 +12106,23 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const 253402300800000
+  i64.const 1231231231456
   call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 3232
+  local.get $169
+  i32.const 2992
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12040,23 +12135,23 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const -62847038769226
+  i64.const 322331231231020
   call $~lib/date/Date#constructor
-  local.tee $123
-  i32.store offset=268
-  local.get $123
-  local.set $164
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 3312
+  local.get $169
+  i32.const 3072
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12069,23 +12164,81 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const -61536067200000
+  i64.const 253402300799999
   call $~lib/date/Date#constructor
-  local.tee $124
-  i32.store offset=276
-  local.get $124
-  local.set $164
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toDateString
-  local.set $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toISOString
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 4240
+  local.get $169
+  i32.const 3152
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 255
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const 253402300800000
+  call $~lib/date/Date#constructor
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toISOString
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 3232
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 257
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i64.const -62847038769226
+  call $~lib/date/Date#constructor
+  local.tee $128
+  i32.store offset=288
+  local.get $128
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toISOString
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 3312
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12098,29 +12251,58 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
+  i64.const -61536067200000
+  call $~lib/date/Date#constructor
+  local.tee $129
+  i32.store offset=296
+  local.get $129
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toDateString
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 4240
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 265
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
   i64.const 1580601600000
   call $~lib/date/Date#constructor
-  local.tee $124
-  i32.store offset=276
-  local.get $124
-  local.set $164
+  local.tee $129
+  i32.store offset=296
+  local.get $129
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toDateString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 4304
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 261
+   i32.const 267
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12129,50 +12311,21 @@
   i32.const 0
   i64.const -62183116800000
   call $~lib/date/Date#constructor
-  local.tee $124
-  i32.store offset=276
-  local.get $124
-  local.set $164
+  local.tee $129
+  i32.store offset=296
+  local.get $129
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toDateString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 4368
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 264
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i64.const -61536067200000
-  call $~lib/date/Date#constructor
-  local.tee $125
-  i32.store offset=280
-  local.get $125
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toTimeString
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  i32.const 4480
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12185,52 +12338,52 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const 253402300799999
+  i64.const -61536067200000
   call $~lib/date/Date#constructor
-  local.tee $125
-  i32.store offset=280
-  local.get $125
-  local.set $164
+  local.tee $130
+  i32.store offset=300
+  local.get $130
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toTimeString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 4528
+  local.get $169
+  i32.const 4480
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 273
+   i32.const 276
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i64.const -61536067200000
+  i64.const 253402300799999
   call $~lib/date/Date#constructor
-  local.tee $126
-  i32.store offset=284
-  local.get $126
-  local.set $164
+  local.tee $130
+  i32.store offset=300
+  local.get $130
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toUTCString
-  local.set $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toTimeString
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 5424
+  local.get $169
+  i32.const 4528
   call $~lib/string/String.__eq
   i32.eqz
   if
@@ -12243,29 +12396,58 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
+  i64.const -61536067200000
+  call $~lib/date/Date#constructor
+  local.tee $131
+  i32.store offset=304
+  local.get $131
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toUTCString
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 5424
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 285
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
   i64.const 1580741613467
   call $~lib/date/Date#constructor
-  local.tee $126
-  i32.store offset=284
-  local.get $126
-  local.set $164
+  local.tee $131
+  i32.store offset=304
+  local.get $131
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toUTCString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 5504
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 281
+   i32.const 287
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12274,27 +12456,27 @@
   i32.const 0
   i64.const -62183116800000
   call $~lib/date/Date#constructor
-  local.tee $126
-  i32.store offset=284
-  local.get $126
-  local.set $164
+  local.tee $131
+  i32.store offset=304
+  local.get $131
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toUTCString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 5584
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 284
+   i32.const 290
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12302,19 +12484,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 5664
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.26 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $128
-   i32.store offset=292
-   local.get $128
-   local.set $164
+   local.get $132
+   local.tee $133
+   i32.store offset=312
+   local.get $133
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.26
   end
@@ -12324,7 +12506,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 291
+   i32.const 297
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12332,83 +12514,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 5936
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.27 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $129
-   i32.store offset=296
-   local.get $129
-   local.set $164
+   local.get $132
+   local.tee $134
+   i32.store offset=316
+   local.get $134
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.27
   end
   i64.const 192067200000
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 293
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 5984
-  call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.28 (result i64)
-   global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $130
-   i32.store offset=300
-   local.get $130
-   local.set $164
-   global.get $~lib/memory/__stack_pointer
-   local.get $164
-   i32.store offset=8
-   local.get $164
-   call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.28
-  end
-  i64.const 11860387200000
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 295
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 6032
-  call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.29 (result i64)
-   global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $131
-   i32.store offset=304
-   local.get $131
-   local.set $164
-   global.get $~lib/memory/__stack_pointer
-   local.get $164
-   i32.store offset=8
-   local.get $164
-   call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.29
-  end
-  i64.const 192112496000
   i64.eq
   i32.eqz
   if
@@ -12420,21 +12542,81 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 5984
+  call $~lib/date/Date.fromString
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.28 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $132
+   local.tee $135
+   i32.store offset=320
+   local.get $135
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.28
+  end
+  i64.const 11860387200000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 301
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6032
+  call $~lib/date/Date.fromString
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.29 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $132
+   local.tee $136
+   i32.store offset=324
+   local.get $136
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.29
+  end
+  i64.const 192112496000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 305
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
   i32.const 6096
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.30 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $132
-   i32.store offset=308
    local.get $132
-   local.set $164
+   local.tee $137
+   i32.store offset=328
+   local.get $137
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.30
   end
@@ -12444,7 +12626,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 303
+   i32.const 309
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12452,19 +12634,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6176
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.31 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $133
-   i32.store offset=312
-   local.get $133
-   local.set $164
+   local.get $132
+   local.tee $138
+   i32.store offset=332
+   local.get $138
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.31
   end
@@ -12474,7 +12656,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 307
+   i32.const 313
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12482,19 +12664,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6256
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.32 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $134
-   i32.store offset=316
-   local.get $134
-   local.set $164
+   local.get $132
+   local.tee $139
+   i32.store offset=336
+   local.get $139
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.32
   end
@@ -12504,7 +12686,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 311
+   i32.const 317
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12512,19 +12694,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6336
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.33 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $135
-   i32.store offset=320
-   local.get $135
-   local.set $164
+   local.get $132
+   local.tee $140
+   i32.store offset=340
+   local.get $140
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.33
   end
@@ -12534,7 +12716,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 315
+   i32.const 321
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12542,19 +12724,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6416
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.34 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $136
-   i32.store offset=324
-   local.get $136
-   local.set $164
+   local.get $132
+   local.tee $141
+   i32.store offset=344
+   local.get $141
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.34
   end
@@ -12564,7 +12746,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 319
+   i32.const 325
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12572,19 +12754,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6480
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.35 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $137
-   i32.store offset=328
-   local.get $137
-   local.set $164
+   local.get $132
+   local.tee $142
+   i32.store offset=348
+   local.get $142
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.35
   end
@@ -12594,7 +12776,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 323
+   i32.const 329
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12602,19 +12784,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6560
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.36 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $138
-   i32.store offset=332
-   local.get $138
-   local.set $164
+   local.get $132
+   local.tee $143
+   i32.store offset=352
+   local.get $143
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.36
   end
@@ -12624,7 +12806,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 327
+   i32.const 333
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12632,19 +12814,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6640
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.37 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $139
-   i32.store offset=336
-   local.get $139
-   local.set $164
+   local.get $132
+   local.tee $144
+   i32.store offset=356
+   local.get $144
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.37
   end
@@ -12654,7 +12836,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 331
+   i32.const 337
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12662,19 +12844,19 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6720
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.38 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $140
-   i32.store offset=340
-   local.get $140
-   local.set $164
+   local.get $132
+   local.tee $145
+   i32.store offset=360
+   local.get $145
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.38
   end
@@ -12684,7 +12866,7 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 335
+   i32.const 341
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -12692,83 +12874,23 @@
   global.get $~lib/memory/__stack_pointer
   i32.const 6800
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
+  local.tee $132
+  i32.store offset=308
   block $~lib/date/Date#getTime|inlined.39 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $141
-   i32.store offset=344
-   local.get $141
-   local.set $164
+   local.get $132
+   local.tee $146
+   i32.store offset=364
+   local.get $146
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.39
   end
   i64.const 192112496456
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 339
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 6896
-  call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.40 (result i64)
-   global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $142
-   i32.store offset=348
-   local.get $142
-   local.set $164
-   global.get $~lib/memory/__stack_pointer
-   local.get $164
-   i32.store offset=8
-   local.get $164
-   call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.40
-  end
-  i64.const -62167219200000
-  i64.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 342
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 6928
-  call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.41 (result i64)
-   global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $143
-   i32.store offset=352
-   local.get $143
-   local.set $164
-   global.get $~lib/memory/__stack_pointer
-   local.get $164
-   i32.store offset=8
-   local.get $164
-   call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.41
-  end
-  i64.const -62135596800000
   i64.eq
   i32.eqz
   if
@@ -12780,25 +12902,25 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 6960
+  i32.const 6896
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.42 (result i64)
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.40 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $144
-   i32.store offset=356
-   local.get $144
-   local.set $164
+   local.get $132
+   local.tee $147
+   i32.store offset=368
+   local.get $147
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.42
+   br $~lib/date/Date#getTime|inlined.40
   end
-  i64.const 189302400000
+  i64.const -62167219200000
   i64.eq
   i32.eqz
   if
@@ -12810,25 +12932,25 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 6992
+  i32.const 6928
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.43 (result i64)
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.41 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $145
-   i32.store offset=360
-   local.get $145
-   local.set $164
+   local.get $132
+   local.tee $148
+   i32.store offset=372
+   local.get $148
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.43
+   br $~lib/date/Date#getTime|inlined.41
   end
-  i64.const 191980800000
+  i64.const -62135596800000
   i64.eq
   i32.eqz
   if
@@ -12840,25 +12962,25 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 5664
+  i32.const 6960
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.44 (result i64)
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.42 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $146
-   i32.store offset=364
-   local.get $146
-   local.set $164
+   local.get $132
+   local.tee $149
+   i32.store offset=376
+   local.get $149
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.44
+   br $~lib/date/Date#getTime|inlined.42
   end
-  i64.const 192067200000
+  i64.const 189302400000
   i64.eq
   i32.eqz
   if
@@ -12870,25 +12992,25 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 7040
+  i32.const 6992
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.45 (result i64)
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.43 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $147
-   i32.store offset=368
-   local.get $147
-   local.set $164
+   local.get $132
+   local.tee $150
+   i32.store offset=380
+   local.get $150
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.45
+   br $~lib/date/Date#getTime|inlined.43
   end
-  i64.const 192112440000
+  i64.const 191980800000
   i64.eq
   i32.eqz
   if
@@ -12900,25 +13022,25 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
-  i32.const 6032
+  i32.const 5664
   call $~lib/date/Date.fromString
-  local.tee $127
-  i32.store offset=288
-  block $~lib/date/Date#getTime|inlined.46 (result i64)
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.44 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $127
-   local.tee $148
-   i32.store offset=372
-   local.get $148
-   local.set $164
+   local.get $132
+   local.tee $151
+   i32.store offset=384
+   local.get $151
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
-   br $~lib/date/Date#getTime|inlined.46
+   br $~lib/date/Date#getTime|inlined.44
   end
-  i64.const 192112496000
+  i64.const 192067200000
   i64.eq
   i32.eqz
   if
@@ -12930,28 +13052,88 @@
    unreachable
   end
   global.get $~lib/memory/__stack_pointer
+  i32.const 7040
+  call $~lib/date/Date.fromString
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.45 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $132
+   local.tee $152
+   i32.store offset=388
+   local.get $152
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.45
+  end
+  i64.const 192112440000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 363
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 6032
+  call $~lib/date/Date.fromString
+  local.tee $132
+  i32.store offset=308
+  block $~lib/date/Date#getTime|inlined.46 (result i64)
+   global.get $~lib/memory/__stack_pointer
+   local.get $132
+   local.tee $153
+   i32.store offset=392
+   local.get $153
+   local.set $169
+   global.get $~lib/memory/__stack_pointer
+   local.get $169
+   i32.store offset=8
+   local.get $169
+   call $~lib/date/Date#get:epochMillis
+   br $~lib/date/Date#getTime|inlined.46
+  end
+  i64.const 192112496000
+  i64.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 366
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const -8640000000000000
   call $~lib/date/Date#constructor
-  local.tee $149
-  i32.store offset=376
+  local.tee $154
+  i32.store offset=396
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const 8640000000000000
   call $~lib/date/Date#constructor
-  local.tee $150
-  i32.store offset=380
+  local.tee $155
+  i32.store offset=400
   block $~lib/date/Date#getTime|inlined.47 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $149
-   local.tee $151
-   i32.store offset=384
-   local.get $151
-   local.set $164
+   local.get $154
+   local.tee $156
+   i32.store offset=404
+   local.get $156
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.47
   end
@@ -12961,22 +13143,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 378
+   i32.const 384
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getTime|inlined.48 (result i64)
    global.get $~lib/memory/__stack_pointer
-   local.get $150
-   local.tee $152
-   i32.store offset=388
-   local.get $152
-   local.set $164
+   local.get $155
+   local.tee $157
+   i32.store offset=408
+   local.get $157
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:epochMillis
    br $~lib/date/Date#getTime|inlined.48
   end
@@ -12986,22 +13168,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 379
+   i32.const 385
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCFullYear|inlined.7 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $149
-   local.tee $153
-   i32.store offset=392
-   local.get $153
-   local.set $164
+   local.get $154
+   local.tee $158
+   i32.store offset=412
+   local.get $158
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.7
   end
@@ -13011,22 +13193,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 381
+   i32.const 387
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCFullYear|inlined.8 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $150
-   local.tee $154
-   i32.store offset=396
-   local.get $154
-   local.set $164
+   local.get $155
+   local.tee $159
+   i32.store offset=416
+   local.get $159
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.8
   end
@@ -13036,22 +13218,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 382
+   i32.const 388
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCMonth|inlined.10 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $149
-   local.tee $155
-   i32.store offset=400
-   local.get $155
-   local.set $164
+   local.get $154
+   local.tee $160
+   i32.store offset=420
+   local.get $160
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -13063,22 +13245,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 384
+   i32.const 390
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCMonth|inlined.11 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $150
-   local.tee $156
-   i32.store offset=404
-   local.get $156
-   local.set $164
+   local.get $155
+   local.tee $161
+   i32.store offset=424
+   local.get $161
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -13090,22 +13272,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 385
+   i32.const 391
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCDate|inlined.5 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $149
-   local.tee $157
-   i32.store offset=408
-   local.get $157
-   local.set $164
+   local.get $154
+   local.tee $162
+   i32.store offset=428
+   local.get $162
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.5
   end
@@ -13115,22 +13297,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 387
+   i32.const 393
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCDate|inlined.6 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $150
-   local.tee $158
-   i32.store offset=412
-   local.get $158
-   local.set $164
+   local.get $155
+   local.tee $163
+   i32.store offset=432
+   local.get $163
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.6
   end
@@ -13140,53 +13322,53 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 388
+   i32.const 394
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $149
-  local.set $164
+  local.get $154
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 7104
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 390
+   i32.const 396
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $150
-  local.set $164
+  local.get $155
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
+  local.get $169
+  i32.store offset=292
+  local.get $169
   call $~lib/date/Date#toISOString
-  local.set $164
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
+  local.get $169
   i32.const 7184
   call $~lib/string/String.__eq
   i32.eqz
   if
    i32.const 0
    i32.const 128
-   i32.const 391
+   i32.const 397
    i32.const 3
    call $~lib/builtins/abort
    unreachable
@@ -13197,27 +13379,27 @@
   i64.const 1
   i64.sub
   call $~lib/date/Date#constructor
-  local.tee $159
-  i32.store offset=416
+  local.tee $164
+  i32.store offset=436
   global.get $~lib/memory/__stack_pointer
   i32.const 0
   i64.const -8640000000000000
   i64.const 1
   i64.add
   call $~lib/date/Date#constructor
-  local.tee $160
-  i32.store offset=420
+  local.tee $165
+  i32.store offset=440
   block $~lib/date/Date#getUTCFullYear|inlined.9 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $160
-   local.tee $161
-   i32.store offset=424
-   local.get $161
-   local.set $164
+   local.get $165
+   local.tee $166
+   i32.store offset=444
+   local.get $166
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:year
    br $~lib/date/Date#getUTCFullYear|inlined.9
   end
@@ -13227,22 +13409,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 396
+   i32.const 402
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCMonth|inlined.12 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $160
-   local.tee $162
-   i32.store offset=428
-   local.get $162
-   local.set $164
+   local.get $165
+   local.tee $167
+   i32.store offset=448
+   local.get $167
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:month
    i32.const 1
    i32.sub
@@ -13254,22 +13436,22 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 397
+   i32.const 403
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
   block $~lib/date/Date#getUTCDate|inlined.7 (result i32)
    global.get $~lib/memory/__stack_pointer
-   local.get $160
-   local.tee $163
-   i32.store offset=432
-   local.get $163
-   local.set $164
+   local.get $165
+   local.tee $168
+   i32.store offset=452
+   local.get $168
+   local.set $169
    global.get $~lib/memory/__stack_pointer
-   local.get $164
+   local.get $169
    i32.store offset=8
-   local.get $164
+   local.get $169
    call $~lib/date/Date#get:day
    br $~lib/date/Date#getUTCDate|inlined.7
   end
@@ -13279,120 +13461,20 @@
   if
    i32.const 0
    i32.const 128
-   i32.const 398
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $160
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  call $~lib/date/Date#getUTCHours
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 399
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $160
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  call $~lib/date/Date#getUTCMinutes
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 400
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $160
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  call $~lib/date/Date#getUTCSeconds
-  i32.const 0
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 401
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $160
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  call $~lib/date/Date#getUTCMilliseconds
-  i32.const 1
-  i32.eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
-   i32.const 402
-   i32.const 3
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $159
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toISOString
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=8
-  local.get $164
-  i32.const 7264
-  call $~lib/string/String.__eq
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 128
    i32.const 404
    i32.const 3
    call $~lib/builtins/abort
    unreachable
   end
-  local.get $160
-  local.set $164
+  local.get $165
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  local.get $164
-  i32.store offset=272
-  local.get $164
-  call $~lib/date/Date#toISOString
-  local.set $164
-  global.get $~lib/memory/__stack_pointer
-  local.get $164
+  local.get $169
   i32.store offset=8
-  local.get $164
-  i32.const 7344
-  call $~lib/string/String.__eq
+  local.get $169
+  call $~lib/date/Date#getUTCHours
+  i32.const 0
+  i32.eq
   i32.eqz
   if
    i32.const 0
@@ -13402,8 +13484,108 @@
    call $~lib/builtins/abort
    unreachable
   end
+  local.get $165
+  local.set $169
   global.get $~lib/memory/__stack_pointer
-  i32.const 436
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  call $~lib/date/Date#getUTCMinutes
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 406
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $165
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  call $~lib/date/Date#getUTCSeconds
+  i32.const 0
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 407
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $165
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  call $~lib/date/Date#getUTCMilliseconds
+  i32.const 1
+  i32.eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 408
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $164
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toISOString
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 7264
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 410
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  local.get $165
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=292
+  local.get $169
+  call $~lib/date/Date#toISOString
+  local.set $169
+  global.get $~lib/memory/__stack_pointer
+  local.get $169
+  i32.store offset=8
+  local.get $169
+  i32.const 7344
+  call $~lib/string/String.__eq
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 128
+   i32.const 411
+   i32.const 3
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 456
   i32.add
   global.set $~lib/memory/__stack_pointer
  )

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -309,7 +309,6 @@
   (local $dm1 i32)
   (local $n1 i32)
   (local $year i32)
-  (local $mo i32)
   block $~lib/date/floorDiv<i64>|inlined.0 (result i64)
    local.get $ms
    local.set $a
@@ -398,10 +397,6 @@
   i32.add
   local.set $year
   local.get $n1
-  i32.const 16
-  i32.shr_u
-  local.set $mo
-  local.get $n1
   i32.const 65535
   i32.and
   i32.const 2141
@@ -409,22 +404,29 @@
   i32.const 1
   i32.add
   global.set $~lib/date/_day
+  local.get $n1
+  i32.const 16
+  i32.shr_u
   local.get $dm1
   i32.const 306
   i32.ge_u
-  if
-   local.get $mo
+  if (result i32)
    i32.const 12
-   i32.sub
-   local.set $mo
-   local.get $year
-   i32.const 1
-   i32.add
-   local.set $year
+  else
+   i32.const 0
   end
-  local.get $mo
+  i32.sub
   global.set $~lib/date/_month
   local.get $year
+  local.get $dm1
+  i32.const 306
+  i32.ge_u
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 0
+  end
+  i32.add
   return
  )
  (func $~lib/date/Date#set:year (param $this i32) (param $year i32)

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -2746,11 +2746,11 @@
   i32.const 2
   i32.shr_s
   local.get $century
+  i32.sub
+  local.get $century
   i32.const 2
   i32.shr_s
   i32.add
-  local.get $century
-  i32.sub
   i32.add
   local.set $year
   i32.const 556

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -171,21 +171,21 @@
  (elem $0 (i32.const 1))
  (export "memory" (memory $0))
  (export "_start" (func $~start))
- (func $~lib/date/daysSinceEpoch (param $y i32) (param $m i32) (param $d i32) (result i64)
+ (func $~lib/date/daysSinceEpoch (param $year i32) (param $month i32) (param $day i32) (result i64)
   (local $a i32)
   (local $b i32)
   (local $era i32)
   (local $yoe i32)
   (local $doy i32)
   (local $doe i32)
-  local.get $y
-  local.get $m
+  local.get $year
+  local.get $month
   i32.const 2
   i32.le_s
   i32.sub
-  local.set $y
+  local.set $year
   block $~lib/date/floorDiv<i32>|inlined.0 (result i32)
-   local.get $y
+   local.get $year
    local.set $a
    i32.const 400
    local.set $b
@@ -206,15 +206,15 @@
    br $~lib/date/floorDiv<i32>|inlined.0
   end
   local.set $era
-  local.get $y
+  local.get $year
   local.get $era
   i32.const 400
   i32.mul
   i32.sub
   local.set $yoe
   i32.const 153
-  local.get $m
-  local.get $m
+  local.get $month
+  local.get $month
   i32.const 2
   i32.gt_s
   if (result i32)
@@ -228,7 +228,7 @@
   i32.add
   i32.const 5
   i32.div_u
-  local.get $d
+  local.get $day
   i32.add
   i32.const 1
   i32.sub
@@ -2705,14 +2705,14 @@
  (func $~lib/date/dayOfWeek (param $year i32) (param $month i32) (param $day i32) (result i32)
   (local $a i32)
   (local $b i32)
-  (local $century i32)
+  (local $cent i32)
   (local $a|6 i32)
   (local $b|7 i32)
   (local $m i32)
   local.get $year
   local.get $month
-  i32.const 3
-  i32.lt_s
+  i32.const 2
+  i32.le_s
   i32.sub
   local.set $year
   block $~lib/date/floorDiv<i32>|inlined.2 (result i32)
@@ -2740,14 +2740,14 @@
    i32.div_s
    br $~lib/date/floorDiv<i32>|inlined.2
   end
-  local.set $century
+  local.set $cent
   local.get $year
   local.get $year
   i32.const 2
   i32.shr_s
-  local.get $century
+  local.get $cent
   i32.sub
-  local.get $century
+  local.get $cent
   i32.const 2
   i32.shr_s
   i32.add
@@ -3853,7 +3853,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 131
+   i32.const 130
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -3907,7 +3907,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 143
+   i32.const 142
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -7971,7 +7971,7 @@
   if
    i32.const 32
    i32.const 80
-   i32.const 50
+   i32.const 49
    i32.const 33
    call $~lib/builtins/abort
    unreachable
@@ -8100,7 +8100,7 @@
         if
          i32.const 32
          i32.const 80
-         i32.const 74
+         i32.const 73
          i32.const 13
          call $~lib/builtins/abort
          unreachable
@@ -8283,7 +8283,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 96
+    i32.const 95
     i32.const 21
     call $~lib/builtins/abort
     unreachable
@@ -8810,7 +8810,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 36
+    i32.const 35
     i32.const 26
     call $~lib/builtins/abort
     unreachable
@@ -8876,7 +8876,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 36
+    i32.const 35
     i32.const 26
     call $~lib/builtins/abort
     unreachable
@@ -8942,7 +8942,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 36
+    i32.const 35
     i32.const 26
     call $~lib/builtins/abort
     unreachable
@@ -9008,7 +9008,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 36
+    i32.const 35
     i32.const 26
     call $~lib/builtins/abort
     unreachable
@@ -9074,7 +9074,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 36
+    i32.const 35
     i32.const 26
     call $~lib/builtins/abort
     unreachable
@@ -9140,7 +9140,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 36
+    i32.const 35
     i32.const 26
     call $~lib/builtins/abort
     unreachable
@@ -9206,7 +9206,7 @@
    if
     i32.const 32
     i32.const 80
-    i32.const 36
+    i32.const 35
     i32.const 26
     call $~lib/builtins/abort
     unreachable

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -4363,12 +4363,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=8
-  i32.const 7
-  i32.const 0
-  local.get $4
-  i32.const 1579
-  i32.add
-  i32.load8_u
   local.get $0
   i32.load
   local.tee $6
@@ -4389,14 +4383,21 @@
   i32.sub
   i32.const 25
   i32.div_s
-  local.tee $1
-  i32.const 2
-  i32.shr_s
-  local.get $8
+  local.set $1
+  i32.const 7
+  i32.const 0
+  local.get $4
+  i32.const 1579
   i32.add
+  i32.load8_u
+  local.get $7
+  local.get $8
   local.get $1
   i32.sub
-  local.get $7
+  local.get $1
+  i32.const 2
+  i32.shr_s
+  i32.add
   i32.add
   i32.add
   local.get $5
@@ -4691,12 +4692,6 @@
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=8
-  i32.const 7
-  i32.const 0
-  local.get $1
-  i32.const 1579
-  i32.add
-  i32.load8_u
   local.get $0
   i32.load
   local.tee $0
@@ -4717,14 +4712,21 @@
   i32.sub
   i32.const 25
   i32.div_s
-  local.tee $2
-  i32.const 2
-  i32.shr_s
-  local.get $7
+  local.set $2
+  i32.const 7
+  i32.const 0
+  local.get $1
+  i32.const 1579
   i32.add
+  i32.load8_u
+  local.get $6
+  local.get $7
   local.get $2
   i32.sub
-  local.get $6
+  local.get $2
+  i32.const 2
+  i32.shr_s
+  i32.add
   i32.add
   i32.add
   local.get $5
@@ -6807,6 +6809,8 @@
   (local $1 i64)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 456
   i32.sub
@@ -8336,7 +8340,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8346,6 +8349,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8355,31 +8376,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8411,7 +8414,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8421,6 +8423,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8430,31 +8450,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8486,7 +8488,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8496,6 +8497,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8505,31 +8524,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8561,7 +8562,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8571,6 +8571,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8580,31 +8598,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8636,7 +8636,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8646,6 +8645,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8655,31 +8672,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8711,7 +8710,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8721,6 +8719,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8730,31 +8746,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8786,7 +8784,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8796,6 +8793,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8805,31 +8820,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8861,7 +8858,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8871,6 +8867,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8880,31 +8894,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -8934,7 +8930,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -8944,6 +8939,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -8953,31 +8966,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -9009,7 +9004,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9019,6 +9013,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -9028,31 +9040,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -9084,7 +9078,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9094,6 +9087,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -9103,31 +9114,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -9159,7 +9152,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9169,6 +9161,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -9178,31 +9188,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add
@@ -9234,7 +9226,6 @@
    i32.store offset=8
    local.get $0
    i32.load
-   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9244,6 +9235,24 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $2
+   i32.const 2
+   i32.shr_s
+   local.tee $4
+   i32.const 24
+   i32.const 0
+   local.get $4
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.set $5
    i32.const 7
    i32.const 0
    local.get $0
@@ -9253,31 +9262,13 @@
    i32.add
    i32.load8_u
    local.get $2
-   local.get $3
-   i32.const 3
-   i32.lt_s
+   local.get $4
+   local.get $5
    i32.sub
-   local.tee $0
+   local.get $5
    i32.const 2
    i32.shr_s
-   local.tee $2
-   i32.const 24
-   i32.const 0
-   local.get $2
-   i32.const 0
-   i32.lt_s
-   select
-   i32.sub
-   i32.const 25
-   i32.div_s
-   local.tee $3
-   i32.const 2
-   i32.shr_s
-   local.get $2
    i32.add
-   local.get $3
-   i32.sub
-   local.get $0
    i32.add
    i32.add
    i32.add

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -317,7 +317,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 131
+   i32.const 130
    i32.const 35
    call $~lib/builtins/abort
    unreachable
@@ -529,7 +529,7 @@
    if
     i32.const 1056
     i32.const 1104
-    i32.const 50
+    i32.const 49
     i32.const 33
     call $~lib/builtins/abort
     unreachable
@@ -666,7 +666,7 @@
         if
          i32.const 1056
          i32.const 1104
-         i32.const 74
+         i32.const 73
          i32.const 13
          call $~lib/builtins/abort
          unreachable
@@ -798,7 +798,7 @@
     if
      i32.const 1056
      i32.const 1104
-     i32.const 96
+     i32.const 95
      i32.const 21
      call $~lib/builtins/abort
      unreachable
@@ -2820,7 +2820,7 @@
   if
    i32.const 1056
    i32.const 1104
-   i32.const 143
+   i32.const 142
    i32.const 28
    call $~lib/builtins/abort
    unreachable
@@ -4367,8 +4367,8 @@
   i32.load
   local.tee $6
   local.get $4
-  i32.const 3
-  i32.lt_s
+  i32.const 2
+  i32.le_s
   i32.sub
   local.tee $7
   i32.const 2
@@ -4696,8 +4696,8 @@
   i32.load
   local.tee $0
   local.get $1
-  i32.const 3
-  i32.lt_s
+  i32.const 2
+  i32.le_s
   i32.sub
   local.tee $6
   i32.const 2
@@ -8350,8 +8350,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8424,8 +8424,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8498,8 +8498,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8572,8 +8572,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8646,8 +8646,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8720,8 +8720,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8794,8 +8794,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8868,8 +8868,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -8940,8 +8940,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -9014,8 +9014,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -9088,8 +9088,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -9162,8 +9162,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -9236,8 +9236,8 @@
    local.get $0
    i32.store offset=8
    local.get $3
-   i32.const 3
-   i32.lt_s
+   i32.const 2
+   i32.le_s
    i32.sub
    local.tee $2
    i32.const 2
@@ -10907,7 +10907,7 @@
   end
   i32.const 1056
   i32.const 1104
-  i32.const 36
+  i32.const 35
   i32.const 26
   call $~lib/builtins/abort
   unreachable

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -5395,7 +5395,6 @@
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 i32)
   local.get $0
   i64.const 86399999
   i64.const 0
@@ -5413,19 +5412,19 @@
   i32.add
   i32.const 3
   i32.or
-  local.tee $1
+  local.tee $2
   i32.const 146096
   i32.const 0
-  local.get $1
+  local.get $2
   i32.const 0
   i32.lt_s
   select
   i32.sub
   i32.const 146097
   i32.div_s
-  local.set $2
-  local.get $1
+  local.set $1
   local.get $2
+  local.get $1
   i32.const 146097
   i32.mul
   i32.sub
@@ -5438,26 +5437,12 @@
   i32.wrap_i64
   i32.const 11758980
   i32.div_u
-  local.tee $4
+  local.tee $2
   i32.const 2141
   i32.mul
   i32.const 197913
   i32.add
-  local.set $3
-  local.get $0
-  i64.const 32
-  i64.shr_u
-  i32.wrap_i64
-  local.get $2
-  i32.const 100
-  i32.mul
-  i32.add
-  local.set $1
-  local.get $3
-  i32.const 16
-  i32.shr_u
-  local.set $2
-  local.get $3
+  local.tee $3
   i32.const 65535
   i32.and
   i32.const 2141
@@ -5465,22 +5450,28 @@
   i32.const 1
   i32.add
   global.set $~lib/date/_day
-  local.get $4
+  local.get $3
+  i32.const 16
+  i32.shr_u
+  i32.const 12
+  i32.const 0
+  local.get $2
   i32.const 306
   i32.ge_u
-  if
-   local.get $2
-   i32.const 12
-   i32.sub
-   local.set $2
-   local.get $1
-   i32.const 1
-   i32.add
-   local.set $1
-  end
-  local.get $2
+  local.tee $2
+  select
+  i32.sub
   global.set $~lib/date/_month
+  local.get $0
+  i64.const 32
+  i64.shr_u
+  i32.wrap_i64
   local.get $1
+  i32.const 100
+  i32.mul
+  i32.add
+  local.get $2
+  i32.add
  )
  (func $~lib/date/Date#toTimeString (param $0 i32) (result i32)
   (local $1 i32)

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -607,7 +607,7 @@
       global.get $~lib/memory/__stack_pointer
       local.get $2
       i32.store
-      block $__inlined_func$~lib/string/String#charCodeAt$386
+      block $__inlined_func$~lib/string/String#charCodeAt$401
        local.get $3
        local.get $2
        i32.const 20
@@ -623,7 +623,7 @@
         global.set $~lib/memory/__stack_pointer
         i32.const -1
         local.set $0
-        br $__inlined_func$~lib/string/String#charCodeAt$386
+        br $__inlined_func$~lib/string/String#charCodeAt$401
        end
        local.get $2
        local.get $3
@@ -895,7 +895,7 @@
       global.get $~lib/memory/__stack_pointer
       local.get $2
       i32.store
-      block $__inlined_func$~lib/string/String#substr$387 (result i32)
+      block $__inlined_func$~lib/string/String#substr$402 (result i32)
        i32.const 3
        local.get $2
        i32.const 20
@@ -937,7 +937,7 @@
         i32.add
         global.set $~lib/memory/__stack_pointer
         i32.const 3456
-        br $__inlined_func$~lib/string/String#substr$387
+        br $__inlined_func$~lib/string/String#substr$402
        end
        global.get $~lib/memory/__stack_pointer
        local.get $8
@@ -987,7 +987,7 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1872
       i32.store
-      block $__inlined_func$~lib/string/String#padEnd$388
+      block $__inlined_func$~lib/string/String#padEnd$403
        i32.const 1868
        i32.load
        i32.const -2
@@ -1003,7 +1003,7 @@
         i32.const 8
         i32.add
         global.set $~lib/memory/__stack_pointer
-        br $__inlined_func$~lib/string/String#padEnd$388
+        br $__inlined_func$~lib/string/String#padEnd$403
        end
        global.get $~lib/memory/__stack_pointer
        i32.const 6
@@ -1562,7 +1562,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1872
    i32.store
-   block $__inlined_func$~lib/string/String#padStart$384
+   block $__inlined_func$~lib/string/String#padStart$399
     i32.const 1868
     i32.load
     i32.const -2
@@ -1581,7 +1581,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/string/String#padStart$384
+     br $__inlined_func$~lib/string/String#padStart$399
     end
     global.get $~lib/memory/__stack_pointer
     local.get $5
@@ -1761,7 +1761,7 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    block $__inlined_func$~lib/string/String#concat$385
+    block $__inlined_func$~lib/string/String#concat$400
      local.get $4
      i32.const 20
      i32.sub
@@ -1780,7 +1780,7 @@
       global.set $~lib/memory/__stack_pointer
       i32.const 3456
       local.set $1
-      br $__inlined_func$~lib/string/String#concat$385
+      br $__inlined_func$~lib/string/String#concat$400
      end
      global.get $~lib/memory/__stack_pointer
      local.get $1
@@ -3975,7 +3975,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$376
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$391
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -3999,7 +3999,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$376
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$391
    end
    local.get $0
    i32.load offset=8
@@ -4308,6 +4308,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 76
   i32.sub
@@ -4331,99 +4332,90 @@
   i32.const 28
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $1
+  local.tee $2
   i32.const 5824
   i32.const 28
   memory.copy
-  local.get $1
+  local.get $2
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 48
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $3
   i32.const 6256
   i32.const 48
   memory.copy
-  local.get $2
+  local.get $3
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=8
   local.get $0
   i32.load offset=4
-  local.set $3
+  local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=8
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=8
   i32.const 7
   i32.const 0
-  local.get $3
+  local.get $4
   i32.const 1579
   i32.add
   i32.load8_u
   local.get $0
   i32.load
-  local.tee $5
-  local.get $3
-  i32.const 3
-  i32.lt_s
-  i32.sub
   local.tee $6
+  local.get $4
   i32.const 3
+  i32.lt_s
+  i32.sub
+  local.tee $7
+  i32.const 2
+  i32.shr_s
+  local.tee $8
+  i32.const 24
   i32.const 0
-  local.get $6
+  local.get $8
   i32.const 0
   i32.lt_s
-  local.tee $7
   select
   i32.sub
-  i32.const 4
+  i32.const 25
   i32.div_s
-  local.get $6
-  i32.const 99
-  i32.const 0
+  local.tee $1
+  i32.const 2
+  i32.shr_s
+  local.get $8
+  i32.add
+  local.get $1
+  i32.sub
   local.get $7
-  select
-  i32.sub
-  i32.const 100
-  i32.div_s
-  i32.sub
-  local.get $6
-  i32.const 399
-  i32.const 0
-  local.get $7
-  select
-  i32.sub
-  i32.const 400
-  i32.div_s
-  i32.add
-  local.get $6
   i32.add
   i32.add
-  local.get $4
+  local.get $5
   i32.add
   i32.const 7
   i32.rem_s
-  local.tee $6
+  local.tee $1
   i32.const 0
   i32.lt_s
   select
-  local.get $6
+  local.get $1
   i32.add
-  local.set $6
+  local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $6
   i32.const 31
   i32.shr_s
   local.tee $7
-  local.get $5
+  local.get $6
   local.get $7
   i32.add
   i32.xor
@@ -4432,25 +4424,25 @@
   local.tee $7
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $3
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $2
   local.get $3
+  local.get $4
   i32.const 1
   i32.sub
   i32.const 2
   i32.shl
   i32.add
   i32.load
-  local.tee $2
+  local.tee $3
   i32.store offset=16
   global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $2
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
+  local.get $2
   local.get $1
-  local.get $6
   i32.const 2
   i32.shl
   i32.add
@@ -4458,10 +4450,10 @@
   local.tee $1
   i32.store offset=20
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $5
   i32.const 2
   call $~lib/date/stringify
-  local.tee $3
+  local.tee $2
   i32.store offset=24
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -4481,7 +4473,7 @@
   call $~lib/date/Date#getUTCMinutes
   i32.const 2
   call $~lib/date/stringify
-  local.tee $6
+  local.tee $5
   i32.store offset=32
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -4497,19 +4489,19 @@
   local.get $1
   i32.store offset=40
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=44
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $3
   i32.store offset=48
   global.get $~lib/memory/__stack_pointer
   i32.const 1616
   i32.const 3456
-  local.get $5
+  local.get $6
   i32.const 0
   i32.lt_s
   select
-  local.tee $5
+  local.tee $6
   i32.store offset=52
   global.get $~lib/memory/__stack_pointer
   local.get $7
@@ -4518,7 +4510,7 @@
   local.get $4
   i32.store offset=60
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $5
   i32.store offset=64
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -4540,39 +4532,39 @@
   i32.const 6368
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $2
   i32.store offset=72
   i32.const 6372
-  local.get $3
+  local.get $2
   i32.store
   i32.const 6368
-  local.get $3
+  local.get $2
   i32.const 1
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   i32.const 6368
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $3
   i32.store offset=72
   i32.const 6376
-  local.get $2
+  local.get $3
   i32.store
   i32.const 6368
-  local.get $2
+  local.get $3
   i32.const 1
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   i32.const 6368
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $5
+  local.get $6
   i32.store offset=72
   i32.const 6380
-  local.get $5
+  local.get $6
   i32.store
   i32.const 6368
-  local.get $5
+  local.get $6
   i32.const 1
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
@@ -4605,13 +4597,13 @@
   i32.const 6368
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $6
+  local.get $5
   i32.store offset=72
   i32.const 6400
-  local.get $6
+  local.get $5
   i32.store
   i32.const 6368
-  local.get $6
+  local.get $5
   i32.const 1
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
@@ -4644,6 +4636,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 52
   i32.sub
@@ -4667,21 +4660,21 @@
   i32.const 28
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $2
+  local.tee $3
   i32.const 4640
   i32.const 28
   memory.copy
-  local.get $2
+  local.get $3
   i32.store
   global.get $~lib/memory/__stack_pointer
   i32.const 48
   i32.const 5
   call $~lib/rt/itcms/__new
-  local.tee $3
+  local.tee $4
   i32.const 5072
   i32.const 48
   memory.copy
-  local.get $3
+  local.get $4
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
@@ -4694,7 +4687,7 @@
   i32.store offset=8
   local.get $0
   i32.load offset=8
-  local.set $4
+  local.set $5
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=8
@@ -4711,49 +4704,40 @@
   i32.const 3
   i32.lt_s
   i32.sub
-  local.tee $5
-  i32.const 3
+  local.tee $6
+  i32.const 2
+  i32.shr_s
+  local.tee $7
+  i32.const 24
   i32.const 0
-  local.get $5
+  local.get $7
   i32.const 0
   i32.lt_s
-  local.tee $6
   select
   i32.sub
-  i32.const 4
+  i32.const 25
   i32.div_s
-  local.get $5
-  i32.const 99
-  i32.const 0
+  local.tee $2
+  i32.const 2
+  i32.shr_s
+  local.get $7
+  i32.add
+  local.get $2
+  i32.sub
   local.get $6
-  select
-  i32.sub
-  i32.const 100
-  i32.div_s
-  i32.sub
-  local.get $5
-  i32.const 399
-  i32.const 0
-  local.get $6
-  select
-  i32.sub
-  i32.const 400
-  i32.div_s
+  i32.add
   i32.add
   local.get $5
-  i32.add
-  i32.add
-  local.get $4
   i32.add
   i32.const 7
   i32.rem_s
-  local.tee $5
+  local.tee $2
   i32.const 0
   i32.lt_s
   select
-  local.get $5
+  local.get $2
   i32.add
-  local.set $5
+  local.set $2
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.const 31
@@ -4768,10 +4752,10 @@
   local.tee $6
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $4
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $3
+  local.get $4
   local.get $1
   i32.const 1
   i32.sub
@@ -4782,11 +4766,11 @@
   local.tee $1
   i32.store offset=16
   global.get $~lib/memory/__stack_pointer
-  local.get $2
+  local.get $3
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
+  local.get $3
   local.get $2
-  local.get $5
   i32.const 2
   i32.shl
   i32.add
@@ -4794,7 +4778,7 @@
   local.tee $2
   i32.store offset=20
   global.get $~lib/memory/__stack_pointer
-  local.get $4
+  local.get $5
   i32.const 2
   call $~lib/date/stringify
   local.tee $3
@@ -5653,7 +5637,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$363
+   block $__inlined_func$~lib/rt/itcms/__renew$378
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -5696,7 +5680,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$363
+     br $__inlined_func$~lib/rt/itcms/__renew$378
     end
     local.get $3
     local.get $4
@@ -6824,7 +6808,7 @@
   (local $2 i32)
   (local $3 i32)
   global.get $~lib/memory/__stack_pointer
-  i32.const 436
+  i32.const 456
   i32.sub
   global.set $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
@@ -6840,7 +6824,7 @@
   end
   global.get $~lib/memory/__stack_pointer
   i32.const 0
-  i32.const 436
+  i32.const 456
   memory.fill
   block $folding-inner0
    i32.const 1970
@@ -8376,34 +8360,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -8460,34 +8435,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -8544,34 +8510,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -8628,34 +8585,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -8712,34 +8660,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -8796,34 +8735,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -8880,34 +8810,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -8964,34 +8885,25 @@
    i32.lt_s
    i32.sub
    local.tee $0
-   i32.const 3
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
    i32.const 0
-   local.get $0
+   local.get $2
    i32.const 0
    i32.lt_s
-   local.tee $2
    select
    i32.sub
-   i32.const 4
+   i32.const 25
    i32.div_s
-   local.get $0
-   i32.const 99
-   i32.const 0
+   local.tee $3
+   i32.const 2
+   i32.shr_s
    local.get $2
-   select
-   i32.sub
-   i32.const 100
-   i32.div_s
-   i32.sub
-   local.get $0
-   i32.const 399
-   i32.const 0
-   local.get $2
-   select
-   i32.sub
-   i32.const 400
-   i32.div_s
    i32.add
+   local.get $3
+   i32.sub
    local.get $0
    i32.add
    i32.add
@@ -9013,13 +8925,388 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i64.const 7899943856218720
+   i64.const -8640000000000000
    call $~lib/date/Date#constructor
    local.tee $0
    i32.store offset=204
    global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=4
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 7
+   i32.const 0
+   local.get $0
+   i32.load offset=8
+   local.get $3
+   i32.const 1579
+   i32.add
+   i32.load8_u
+   local.get $2
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $0
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
+   i32.const 0
+   local.get $2
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.tee $3
+   i32.const 2
+   i32.shr_s
+   local.get $2
+   i32.add
+   local.get $3
+   i32.sub
+   local.get $0
+   i32.add
+   i32.add
+   i32.add
+   i32.const 7
+   i32.rem_s
+   local.tee $0
+   i32.const 0
+   i32.lt_s
+   select
+   local.get $0
+   i32.add
+   i32.const 2
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 197
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i64.const -62183116800000
+   call $~lib/date/Date#constructor
+   local.tee $0
    i32.store offset=208
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=4
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 7
+   i32.const 0
+   local.get $0
+   i32.load offset=8
+   local.get $3
+   i32.const 1579
+   i32.add
+   i32.load8_u
+   local.get $2
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $0
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
+   i32.const 0
+   local.get $2
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.tee $3
+   i32.const 2
+   i32.shr_s
+   local.get $2
+   i32.add
+   local.get $3
+   i32.sub
+   local.get $0
+   i32.add
+   i32.add
+   i32.add
+   i32.const 7
+   i32.rem_s
+   local.tee $0
+   i32.const 0
+   i32.lt_s
+   select
+   local.get $0
+   i32.add
+   i32.const 4
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 198
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   call $~lib/date/Date#constructor
+   local.tee $0
+   i32.store offset=212
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=4
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 7
+   i32.const 0
+   local.get $0
+   i32.load offset=8
+   local.get $3
+   i32.const 1579
+   i32.add
+   i32.load8_u
+   local.get $2
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $0
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
+   i32.const 0
+   local.get $2
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.tee $3
+   i32.const 2
+   i32.shr_s
+   local.get $2
+   i32.add
+   local.get $3
+   i32.sub
+   local.get $0
+   i32.add
+   i32.add
+   i32.add
+   i32.const 7
+   i32.rem_s
+   local.tee $0
+   i32.const 0
+   i32.lt_s
+   select
+   local.get $0
+   i32.add
+   i32.const 4
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 199
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i64.const 1709164800000
+   call $~lib/date/Date#constructor
+   local.tee $0
+   i32.store offset=216
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=4
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 7
+   i32.const 0
+   local.get $0
+   i32.load offset=8
+   local.get $3
+   i32.const 1579
+   i32.add
+   i32.load8_u
+   local.get $2
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $0
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
+   i32.const 0
+   local.get $2
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.tee $3
+   i32.const 2
+   i32.shr_s
+   local.get $2
+   i32.add
+   local.get $3
+   i32.sub
+   local.get $0
+   i32.add
+   i32.add
+   i32.add
+   i32.const 7
+   i32.rem_s
+   local.tee $0
+   i32.const 0
+   i32.lt_s
+   select
+   local.get $0
+   i32.add
+   i32.const 4
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 200
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i64.const 8640000000000000
+   call $~lib/date/Date#constructor
+   local.tee $0
+   i32.store offset=220
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=4
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 7
+   i32.const 0
+   local.get $0
+   i32.load offset=8
+   local.get $3
+   i32.const 1579
+   i32.add
+   i32.load8_u
+   local.get $2
+   local.get $3
+   i32.const 3
+   i32.lt_s
+   i32.sub
+   local.tee $0
+   i32.const 2
+   i32.shr_s
+   local.tee $2
+   i32.const 24
+   i32.const 0
+   local.get $2
+   i32.const 0
+   i32.lt_s
+   select
+   i32.sub
+   i32.const 25
+   i32.div_s
+   local.tee $3
+   i32.const 2
+   i32.shr_s
+   local.get $2
+   i32.add
+   local.get $3
+   i32.sub
+   local.get $0
+   i32.add
+   i32.add
+   i32.add
+   i32.const 7
+   i32.rem_s
+   local.tee $0
+   i32.const 0
+   i32.lt_s
+   select
+   local.get $0
+   i32.add
+   i32.const 6
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 201
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i64.const 7899943856218720
+   call $~lib/date/Date#constructor
+   local.tee $0
+   i32.store offset=224
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=228
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9030,7 +9317,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 201
+    i32.const 207
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9045,7 +9332,7 @@
    call $~lib/date/Date#setUTCMonth@varargs
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=212
+   i32.store offset=232
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9053,76 +9340,6 @@
    i32.load offset=4
    i32.const 11
    i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 203
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   i32.const 1
-   global.set $~argumentsLength
-   local.get $0
-   i32.const 2
-   call $~lib/date/Date#setUTCMonth@varargs
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=216
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.load offset=4
-   i32.const 3
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 205
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=220
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 7899941177818720
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 206
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   i32.const 1
-   global.set $~argumentsLength
-   local.get $0
-   i32.const 0
-   call $~lib/date/Date#setUTCMonth@varargs
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=224
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 7899936080218720
-   i64.ne
    if
     i32.const 0
     i32.const 1152
@@ -9137,11 +9354,81 @@
    i32.const 1
    global.set $~argumentsLength
    local.get $0
+   i32.const 2
+   call $~lib/date/Date#setUTCMonth@varargs
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=236
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=4
+   i32.const 3
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 211
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=240
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 7899941177818720
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 212
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
+   i32.const 0
+   call $~lib/date/Date#setUTCMonth@varargs
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=244
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 7899936080218720
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 215
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   i32.const 1
+   global.set $~argumentsLength
+   local.get $0
    i32.const 11
    call $~lib/date/Date#setUTCMonth@varargs
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=228
+   i32.store offset=248
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9152,7 +9439,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 211
+    i32.const 217
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9167,7 +9454,7 @@
    call $~lib/date/Date#setUTCMonth@varargs
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=232
+   i32.store offset=252
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9178,14 +9465,14 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 215
+    i32.const 221
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=236
+   i32.store offset=256
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9196,7 +9483,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 216
+    i32.const 222
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9211,7 +9498,7 @@
    call $~lib/date/Date#setUTCMonth@varargs
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=240
+   i32.store offset=260
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9222,14 +9509,14 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 218
+    i32.const 224
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=244
+   i32.store offset=264
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9240,7 +9527,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 219
+    i32.const 225
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9249,10 +9536,10 @@
    i64.const 7941202527925698
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=248
+   i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=252
+   i32.store offset=272
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9263,79 +9550,79 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 225
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.const 1976
-   call $~lib/date/Date#setUTCFullYear
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=256
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.load
-   i32.const 1976
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 227
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.const 20212
-   call $~lib/date/Date#setUTCFullYear
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=260
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.load
-   i32.const 20212
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 229
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.const 71
-   call $~lib/date/Date#setUTCFullYear
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=264
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i32.load
-   i32.const 71
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
     i32.const 231
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.const 1976
+   call $~lib/date/Date#setUTCFullYear
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=276
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   i32.const 1976
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 233
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.const 20212
+   call $~lib/date/Date#setUTCFullYear
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=280
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   i32.const 20212
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 235
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.const 71
+   call $~lib/date/Date#setUTCFullYear
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=284
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load
+   i32.const 71
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 237
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9344,10 +9631,10 @@
    i64.const -62167219200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9361,7 +9648,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 237
+    i32.const 243
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9370,10 +9657,10 @@
    i64.const -62167219200001
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9387,7 +9674,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 239
+    i32.const 245
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9396,10 +9683,10 @@
    i64.const -62127219200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9413,7 +9700,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 241
+    i32.const 247
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9422,10 +9709,10 @@
    i64.const 1231231231020
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9439,7 +9726,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 243
+    i32.const 249
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9448,10 +9735,10 @@
    i64.const 1231231231456
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9465,7 +9752,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 245
+    i32.const 251
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9474,10 +9761,10 @@
    i64.const 322331231231020
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9491,7 +9778,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 247
+    i32.const 253
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9500,10 +9787,10 @@
    i64.const 253402300799999
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9517,7 +9804,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 249
+    i32.const 255
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9526,10 +9813,10 @@
    i64.const 253402300800000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9543,7 +9830,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 251
+    i32.const 257
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9552,10 +9839,10 @@
    i64.const -62847038769226
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=268
+   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -9569,7 +9856,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 253
+    i32.const 259
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9578,10 +9865,10 @@
    i64.const -61536067200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=276
+   i32.store offset=296
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toDateString
    local.set $0
@@ -9595,7 +9882,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 259
+    i32.const 265
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9604,10 +9891,10 @@
    i64.const 1580601600000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=276
+   i32.store offset=296
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toDateString
    local.set $0
@@ -9621,7 +9908,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 261
+    i32.const 267
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9630,10 +9917,10 @@
    i64.const -62183116800000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=276
+   i32.store offset=296
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toDateString
    local.set $0
@@ -9647,7 +9934,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 264
+    i32.const 270
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9656,10 +9943,10 @@
    i64.const -61536067200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=280
+   i32.store offset=300
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toTimeString
    local.set $0
@@ -9673,7 +9960,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 270
+    i32.const 276
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9682,10 +9969,10 @@
    i64.const 253402300799999
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=280
+   i32.store offset=300
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toTimeString
    local.set $0
@@ -9699,7 +9986,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 273
+    i32.const 279
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9708,10 +9995,10 @@
    i64.const -61536067200000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=284
+   i32.store offset=304
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toUTCString
    local.set $0
@@ -9725,7 +10012,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 279
+    i32.const 285
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9734,10 +10021,10 @@
    i64.const 1580741613467
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=284
+   i32.store offset=304
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toUTCString
    local.set $0
@@ -9751,7 +10038,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 281
+    i32.const 287
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9760,10 +10047,10 @@
    i64.const -62183116800000
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=284
+   i32.store offset=304
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toUTCString
    local.set $0
@@ -9777,7 +10064,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 284
+    i32.const 290
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9786,10 +10073,10 @@
    i32.const 6688
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=288
+   i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=292
+   i32.store offset=312
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -9800,7 +10087,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 291
+    i32.const 297
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -9809,62 +10096,16 @@
    i32.const 6960
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=288
+   i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=296
+   i32.store offset=316
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
    local.get $0
    i64.load offset=16
    i64.const 192067200000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 293
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7008
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=300
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 11860387200000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 295
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7056
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=304
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496000
    i64.ne
    if
     i32.const 0
@@ -9875,79 +10116,10 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 7120
+   i32.const 7008
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
    i32.store offset=308
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496456
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 303
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7200
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=312
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496456
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 307
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7280
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=316
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192141296456
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 311
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7360
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=320
@@ -9956,288 +10128,12 @@
    i32.store offset=8
    local.get $0
    i64.load offset=16
-   i64.const 192092696456
+   i64.const 11860387200000
    i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 315
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7440
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=324
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496450
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 319
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7504
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=328
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496450
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 323
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7584
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=332
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496450
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 327
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7664
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=336
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496456
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 331
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7744
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=340
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496456
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 335
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7824
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=344
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112496456
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 339
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7920
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=348
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const -62167219200000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 342
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7952
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=352
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const -62135596800000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 345
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 7984
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=356
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 189302400000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 348
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8016
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=360
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 191980800000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 351
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 6688
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=364
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192067200000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 354
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8064
-   call $~lib/date/Date.fromString
-   local.tee $0
-   i32.store offset=288
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=368
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=8
-   local.get $0
-   i64.load offset=16
-   i64.const 192112440000
-   i64.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 357
+    i32.const 301
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10246,10 +10142,10 @@
    i32.const 7056
    call $~lib/date/Date.fromString
    local.tee $0
-   i32.store offset=288
+   i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=372
+   i32.store offset=324
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -10260,21 +10156,338 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 360
+    i32.const 305
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i64.const -8640000000000000
-   call $~lib/date/Date#constructor
+   i32.const 7120
+   call $~lib/date/Date.fromString
    local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=328
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 309
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7200
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=332
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 313
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7280
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=336
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192141296456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 317
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7360
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=340
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192092696456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 321
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7440
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=344
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496450
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 325
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7504
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=348
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496450
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 329
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7584
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=352
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496450
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 333
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7664
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=356
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 337
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7744
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=360
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 341
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7824
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=364
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 192112496456
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 345
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7920
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=368
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const -62167219200000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 348
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7952
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=372
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const -62135596800000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 351
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7984
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.store offset=376
    global.get $~lib/memory/__stack_pointer
-   i64.const 8640000000000000
-   call $~lib/date/Date#constructor
-   local.tee $2
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 189302400000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 354
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8016
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.store offset=380
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i64.load offset=16
+   i64.const 191980800000
+   i64.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 357
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 6688
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=384
@@ -10283,34 +10496,44 @@
    i32.store offset=8
    local.get $0
    i64.load offset=16
-   i64.const -8640000000000000
+   i64.const 192067200000
    i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 378
+    i32.const 360
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   i32.const 8064
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.store offset=388
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=8
-   local.get $2
+   local.get $0
    i64.load offset=16
-   i64.const 8640000000000000
+   i64.const 192112440000
    i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 379
+    i32.const 363
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 7056
+   call $~lib/date/Date.fromString
+   local.tee $0
+   i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=392
@@ -10318,45 +10541,37 @@
    local.get $0
    i32.store offset=8
    local.get $0
-   i32.load
-   i32.const -271821
-   i32.ne
+   i64.load offset=16
+   i64.const 192112496000
+   i64.ne
    if
     i32.const 0
     i32.const 1152
-    i32.const 381
+    i32.const 366
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   i64.const -8640000000000000
+   call $~lib/date/Date#constructor
+   local.tee $0
    i32.store offset=396
    global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=8
-   local.get $2
-   i32.load
-   i32.const 275760
-   i32.ne
-   if
-    i32.const 0
-    i32.const 1152
-    i32.const 382
-    i32.const 3
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
+   i64.const 8640000000000000
+   call $~lib/date/Date#constructor
+   local.tee $2
    i32.store offset=400
    global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store offset=404
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.store offset=8
    local.get $0
-   i32.load offset=4
-   i32.const 4
-   i32.ne
+   i64.load offset=16
+   i64.const -8640000000000000
+   i64.ne
    if
     i32.const 0
     i32.const 1152
@@ -10367,14 +10582,14 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=404
+   i32.store offset=408
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
    local.get $2
-   i32.load offset=4
-   i32.const 9
-   i32.ne
+   i64.load offset=16
+   i64.const 8640000000000000
+   i64.ne
    if
     i32.const 0
     i32.const 1152
@@ -10385,13 +10600,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=408
+   i32.store offset=412
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
    local.get $0
-   i32.load offset=8
-   i32.const 20
+   i32.load
+   i32.const -271821
    i32.ne
    if
     i32.const 0
@@ -10403,13 +10618,13 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=412
+   i32.store offset=416
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
    local.get $2
-   i32.load offset=8
-   i32.const 13
+   i32.load
+   i32.const 275760
    i32.ne
    if
     i32.const 0
@@ -10421,7 +10636,79 @@
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=420
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=4
+   i32.const 4
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 390
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=424
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   i32.load offset=4
+   i32.const 9
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 391
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=428
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.load offset=8
+   i32.const 20
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 393
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=432
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
+   i32.load offset=8
+   i32.const 13
+   i32.ne
+   if
+    i32.const 0
+    i32.const 1152
+    i32.const 394
+    i32.const 3
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -10435,14 +10722,14 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 390
+    i32.const 396
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=272
+   i32.store offset=292
    local.get $2
    call $~lib/date/Date#toISOString
    local.set $0
@@ -10456,7 +10743,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 391
+    i32.const 397
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10465,15 +10752,15 @@
    i64.const 8639999999999999
    call $~lib/date/Date#constructor
    local.tee $0
-   i32.store offset=416
+   i32.store offset=436
    global.get $~lib/memory/__stack_pointer
    i64.const -8639999999999999
    call $~lib/date/Date#constructor
    local.tee $2
-   i32.store offset=420
+   i32.store offset=440
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=424
+   i32.store offset=444
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10484,14 +10771,14 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 396
+    i32.const 402
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=428
+   i32.store offset=448
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10502,14 +10789,14 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 397
+    i32.const 403
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=432
+   i32.store offset=452
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=8
@@ -10520,7 +10807,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 398
+    i32.const 404
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10533,7 +10820,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 399
+    i32.const 405
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10546,7 +10833,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 400
+    i32.const 406
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10559,7 +10846,7 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 401
+    i32.const 407
     i32.const 3
     call $~lib/builtins/abort
     unreachable
@@ -10574,14 +10861,14 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 402
+    i32.const 408
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=272
+   i32.store offset=292
    local.get $0
    call $~lib/date/Date#toISOString
    local.set $0
@@ -10595,14 +10882,14 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 404
+    i32.const 410
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=272
+   i32.store offset=292
    local.get $2
    call $~lib/date/Date#toISOString
    local.set $0
@@ -10616,13 +10903,13 @@
    if
     i32.const 0
     i32.const 1152
-    i32.const 405
+    i32.const 411
     i32.const 3
     call $~lib/builtins/abort
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   i32.const 436
+   i32.const 456
    i32.add
    global.set $~lib/memory/__stack_pointer
    return

--- a/tests/compiler/std/date.ts
+++ b/tests/compiler/std/date.ts
@@ -177,7 +177,7 @@
   assert(date.getTime() == 314240591274);
 }
 
-// Date#setUTCDay //////////////////////////////////////////////////////////////////////////////////
+// Date#getUTCDay //////////////////////////////////////////////////////////////////////////////////
 {
   // tests from test262
   const july6: i64 = 1467763200000;
@@ -193,6 +193,12 @@
   assert(new Date(july9 - 1).getUTCDay() == 5);
   assert(new Date(july9 + dayMs - 1).getUTCDay() == 6);
   assert(new Date(july9 + dayMs    ).getUTCDay() == 0);
+
+  assert(new Date(-8640000000000000).getUTCDay() == 2); // -271821-04-20
+  assert(new Date(-62183116800000).getUTCDay() == 4);   // -000001-07-01
+  assert(new Date(0).getUTCDay() == 4);                 // 1970-01-01
+  assert(new Date(1709164800000).getUTCDay() == 4);     // 2024-02-29
+  assert(new Date(8640000000000000).getUTCDay() == 6);  // +275760-09-13
 }
 
 // Date#setUTCMonth ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
```ts
floorDiv(year, 400)  ->  floorDiv(floorDiv(year, 100), 4) 
```

Since arithmetic shift `year >> 2` is equal to `floorDiv(year, 4)`:

```ts
century = floorDiv(year, 100)
floorDiv(century, 4)  ->  century >> 2
```

And full simplifcation:

```ts
floorDiv(year, 4) - floorDiv(year, 100) + floorDiv(year, 400)
```
 -> 
 ```ts
(year >> 2) - century + (century >> 2)
```

Also added couple of tests

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
