### PR TITLE
feat: optimize the active init operation of zero-initialized memory of `makeFieldInitializationInConstructor`

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -63,6 +63,7 @@ under the licensing terms detailed in LICENSE:
 * Mopsgamer <79159094+Mopsgamer@users.noreply.github.com>
 * EDM115 <github@edm115.dev>
 * Weixie Cui <cuiweixie@gmail.com>
+* Rui Jin <jinrui_0322@163.com>
 
 Portions of this software are derived from third-party works licensed under
 the following terms:

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -58,7 +58,8 @@ import {
   isConstExpressionNaN,
   ensureType,
   createType,
-  getConstValueInteger
+  getConstValueInteger,
+  isConstZero
 } from "./module";
 
 import {
@@ -10118,6 +10119,13 @@ export class Compiler extends DiagnosticEmitter {
 
   // === Specialized code generation ==============================================================
 
+  /** Check if possible to optimize the active initialization away if it's zero */
+  canOptimizeZeroInitialization(valueExpr: ExpressionRef): bool {
+    const runtime = this.options.runtime;
+    // Memory will be filled with 0 on itcms.__new
+    return runtime == Runtime.Incremental ? isConstZero(valueExpr) : false;
+  }
+
   /** Makes a constant zero of the specified type. */
   makeZero(type: Type): ExpressionRef {
     let module = this.module;
@@ -10465,6 +10473,7 @@ export class Compiler extends DiagnosticEmitter {
       let parameterIndex = fieldPrototype.parameterIndex;
 
       // Defer non-parameter fields until parameter fields are initialized
+      // Since non-parameter may depend on parameter fields
       if (parameterIndex < 0) {
         if (!nonParameterFields) nonParameterFields = new Array();
         nonParameterFields.push(property);
@@ -10493,6 +10502,7 @@ export class Compiler extends DiagnosticEmitter {
 
     // Initialize deferred non-parameter fields
     if (nonParameterFields) {
+      const unmanagedClass = classInstance.type.isUnmanaged;
       for (let i = 0, k = nonParameterFields.length; i < k; ++i) {
         let field = unchecked(nonParameterFields[i]);
         let fieldType = field.type;
@@ -10500,16 +10510,32 @@ export class Compiler extends DiagnosticEmitter {
         let initializerNode = fieldPrototype.initializerNode;
         assert(fieldPrototype.parameterIndex < 0);
         let setterInstance = assert(field.setterInstance);
-        let expr = this.makeCallDirect(setterInstance, [
-          module.local_get(thisLocalIndex, sizeTypeRef),
-          initializerNode // use initializer if present, otherwise initialize with zero
-            ? this.compileExpression(initializerNode, fieldType, Constraints.ConvImplicit)
-            : this.makeZero(fieldType)
-        ], field.identifierNode, true);
-        if (this.currentType != Type.void) { // in case
-          expr = module.drop(expr);
+
+        if (initializerNode){
+          const valueExpr: ExpressionRef = this.compileExpression(initializerNode, fieldType, Constraints.ConvImplicit);
+          if(unmanagedClass || !this.canOptimizeZeroInitialization(valueExpr)) {
+            let expr = this.makeCallDirect(setterInstance, [
+              module.local_get(thisLocalIndex, sizeTypeRef),
+              valueExpr
+            ], field.identifierNode, true);
+            if (this.currentType != Type.void) { // in case
+              expr = module.drop(expr);
+            }
+            stmts.push(expr);
+          }
+        } else {
+          if(unmanagedClass || (this.options.runtime != Runtime.Incremental)) {
+            let expr = this.makeCallDirect(setterInstance, [
+              module.local_get(thisLocalIndex, sizeTypeRef),
+              // Create only when necessary since makeZero will allocte persistent memory by Binaryen.
+              this.makeZero(fieldType)
+            ], field.identifierNode, true);
+            if (this.currentType != Type.void) { // in case
+              expr = module.drop(expr);
+            }
+            stmts.push(expr);
+          }
         }
-        stmts.push(expr);
       }
     }
 

--- a/tests/compiler/assignment-chain.debug.wat
+++ b/tests/compiler/assignment-chain.debug.wat
@@ -2253,34 +2253,29 @@
   local.get $ptr
   return
  )
+ (func $assignment-chain/A#set:y (param $this i32) (param $y i64)
+  local.get $this
+  local.get $y
+  i64.store offset=8
+ )
  (func $assignment-chain/A#set:x (param $this i32) (param $x i64)
   local.get $this
   local.get $x
   i64.store
  )
- (func $assignment-chain/A#set:y (param $this i32) (param $y i64)
+ (func $assignment-chain/B#get:_setter_cnt (param $this i32) (result i32)
   local.get $this
-  local.get $y
-  i64.store offset=8
+  i32.load
  )
  (func $assignment-chain/B#set:_setter_cnt (param $this i32) (param $_setter_cnt i32)
   local.get $this
   local.get $_setter_cnt
   i32.store
  )
- (func $assignment-chain/B#set:_getter_cnt (param $this i32) (param $_getter_cnt i32)
-  local.get $this
-  local.get $_getter_cnt
-  i32.store offset=4
- )
  (func $assignment-chain/B#set:_y (param $this i32) (param $_y f64)
   local.get $this
   local.get $_y
   f64.store offset=8
- )
- (func $assignment-chain/B#get:_setter_cnt (param $this i32) (result i32)
-  local.get $this
-  i32.load
  )
  (func $assignment-chain/B#get:_getter_cnt (param $this i32) (result i32)
   local.get $this
@@ -2437,22 +2432,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $assignment-chain/A#set:x
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $assignment-chain/A#set:y
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -2552,30 +2531,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $assignment-chain/B#set:_setter_cnt
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $assignment-chain/B#set:_getter_cnt
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $assignment-chain/B#set:_y
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/assignment-chain.release.wat
+++ b/tests/compiler/assignment-chain.release.wat
@@ -77,7 +77,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$129
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$124
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -101,7 +101,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$129
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$124
     end
     local.get $1
     i32.load offset=8
@@ -1396,24 +1396,6 @@
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   f64.const 0
-   f64.store offset=8
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
@@ -1514,18 +1496,6 @@
    call $~lib/object/Object#constructor
    local.tee $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i64.const 0
-   i64.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add

--- a/tests/compiler/bindings/esm.debug.wat
+++ b/tests/compiler/bindings/esm.debug.wat
@@ -1,23 +1,20 @@
 (module
- (type $0 (func (param i32 i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (param i32 i32)))
  (type $2 (func (param i32 i32) (result i32)))
  (type $3 (func (param i32)))
  (type $4 (func))
  (type $5 (func (param i32 i32 i32)))
  (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
- (type $8 (func (param i32 i64)))
- (type $9 (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $10 (func (param f64) (result f64)))
- (type $11 (func (param i64 i64) (result i64)))
- (type $12 (func (result i64)))
- (type $13 (func (param i32 i32 i64) (result i32)))
- (type $14 (func (param i32 f32)))
- (type $15 (func (param i32 f64)))
- (type $16 (func (param i32 i32 i32) (result i32)))
- (type $17 (func (param i32 i32 i64)))
- (type $18 (func (param i32 i32) (result f32)))
+ (type $8 (func (param i32 i32 f64 f64 f64 f64 f64)))
+ (type $9 (func (param f64) (result f64)))
+ (type $10 (func (param i64 i64) (result i64)))
+ (type $11 (func (result i64)))
+ (type $12 (func (param i32 i32 i64) (result i32)))
+ (type $13 (func (param i32 i32 i32) (result i32)))
+ (type $14 (func (param i32 i32 i64)))
+ (type $15 (func (param i32 i32) (result f32)))
  (import "env" "Math.E" (global $~lib/bindings/dom/Math.E f64))
  (import "env" "globalThis" (global $bindings/esm/immutableGlobal externref))
  (import "env" "globalThis.globalThis" (global $bindings/esm/immutableGlobalNested externref))
@@ -2629,105 +2626,23 @@
   local.get $this
   i32.load offset=4
  )
+ (func $bindings/esm/PlainObject#get:a (param $this i32) (result i32)
+  local.get $this
+  i32.load8_s
+ )
  (func $bindings/esm/PlainObject#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
   i32.store8
  )
+ (func $bindings/esm/PlainObject#get:b (param $this i32) (result i32)
+  local.get $this
+  i32.load16_s offset=2
+ )
  (func $bindings/esm/PlainObject#set:b (param $this i32) (param $b i32)
   local.get $this
   local.get $b
   i32.store16 offset=2
- )
- (func $bindings/esm/PlainObject#set:c (param $this i32) (param $c i32)
-  local.get $this
-  local.get $c
-  i32.store offset=4
- )
- (func $bindings/esm/PlainObject#set:d (param $this i32) (param $d i64)
-  local.get $this
-  local.get $d
-  i64.store offset=8
- )
- (func $bindings/esm/PlainObject#set:e (param $this i32) (param $e i32)
-  local.get $this
-  local.get $e
-  i32.store8 offset=16
- )
- (func $bindings/esm/PlainObject#set:f (param $this i32) (param $f i32)
-  local.get $this
-  local.get $f
-  i32.store16 offset=18
- )
- (func $bindings/esm/PlainObject#set:g (param $this i32) (param $g i32)
-  local.get $this
-  local.get $g
-  i32.store offset=20
- )
- (func $bindings/esm/PlainObject#set:h (param $this i32) (param $h i64)
-  local.get $this
-  local.get $h
-  i64.store offset=24
- )
- (func $bindings/esm/PlainObject#set:i (param $this i32) (param $i i32)
-  local.get $this
-  local.get $i
-  i32.store offset=32
- )
- (func $bindings/esm/PlainObject#set:j (param $this i32) (param $j i32)
-  local.get $this
-  local.get $j
-  i32.store offset=36
- )
- (func $bindings/esm/PlainObject#set:k (param $this i32) (param $k i32)
-  local.get $this
-  local.get $k
-  i32.store8 offset=40
- )
- (func $bindings/esm/PlainObject#set:l (param $this i32) (param $l f32)
-  local.get $this
-  local.get $l
-  f32.store offset=44
- )
- (func $bindings/esm/PlainObject#set:m (param $this i32) (param $m f64)
-  local.get $this
-  local.get $m
-  f64.store offset=48
- )
- (func $bindings/esm/PlainObject#set:n (param $this i32) (param $n i32)
-  local.get $this
-  local.get $n
-  i32.store offset=56
-  local.get $this
-  local.get $n
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $bindings/esm/PlainObject#set:o (param $this i32) (param $o i32)
-  local.get $this
-  local.get $o
-  i32.store offset=60
-  local.get $this
-  local.get $o
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $bindings/esm/PlainObject#set:p (param $this i32) (param $p i32)
-  local.get $this
-  local.get $p
-  i32.store offset=64
-  local.get $this
-  local.get $p
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $bindings/esm/PlainObject#get:a (param $this i32) (result i32)
-  local.get $this
-  i32.load8_s
- )
- (func $bindings/esm/PlainObject#get:b (param $this i32) (result i32)
-  local.get $this
-  i32.load16_s offset=2
  )
  (func $bindings/esm/newInternref (result i32)
   i32.const 0
@@ -3402,30 +3317,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -3447,7 +3338,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -3456,7 +3347,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -3469,7 +3360,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -3477,7 +3368,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
@@ -4095,38 +3986,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -4156,7 +4015,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -4165,7 +4024,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -4178,7 +4037,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
@@ -4186,7 +4045,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
@@ -4194,7 +4053,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i32>#set:length_
@@ -4623,38 +4482,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -4684,7 +4511,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -4693,7 +4520,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -4706,7 +4533,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<~lib/string/String>#set:dataStart
@@ -4714,7 +4541,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<~lib/string/String>#set:byteLength
@@ -4722,7 +4549,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<~lib/string/String>#set:length_
@@ -5064,134 +4891,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:b
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:c
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $bindings/esm/PlainObject#set:d
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:e
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:f
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:g
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $bindings/esm/PlainObject#set:h
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:i
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:j
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:k
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f32.const 0
-  call $bindings/esm/PlainObject#set:l
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $bindings/esm/PlainObject#set:m
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:n
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:o
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:p
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/bindings/esm.release.wat
+++ b/tests/compiler/bindings/esm.release.wat
@@ -458,6 +458,35 @@
   memory.fill
   local.get $1
  )
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  local.get $0
+  i32.load offset=12
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
@@ -516,35 +545,6 @@
     end
    end
   end
- )
- (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2276
-  i32.lt_s
-  if
-   i32.const 35072
-   i32.const 35120
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  i32.load offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/rt/itcms/step (result i32)
   (local $0 i32)
@@ -2163,7 +2163,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$269
+   block $__inlined_func$~lib/rt/itcms/__renew$242
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2206,7 +2206,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$269
+     br $__inlined_func$~lib/rt/itcms/__renew$242
     end
     local.get $3
     local.get $4
@@ -2563,7 +2563,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$284
+   block $__inlined_func$~lib/string/String#concat$257
     local.get $1
     i32.const 20
     i32.sub
@@ -2582,7 +2582,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$284
+     br $__inlined_func$~lib/string/String#concat$257
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2978,7 +2978,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   block $__inlined_func$bindings/esm/staticarrayFunction$1 (result i32)
+   block $__inlined_func$bindings/esm/staticarrayFunction (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 12
     i32.sub
@@ -3134,7 +3134,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $4
-     br $__inlined_func$bindings/esm/staticarrayFunction$1
+     br $__inlined_func$bindings/esm/staticarrayFunction
     end
     br $folding-inner1
    end
@@ -3154,15 +3154,16 @@
  (func $export:bindings/esm/objectFunction (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 2276
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -3176,7 +3177,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 2276
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -3184,207 +3185,94 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$bindings/esm/PlainObject#constructor$4 (result i32)
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    block $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 68
-     i32.const 13
-     call $~lib/rt/itcms/__new
-     local.tee $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     i32.store
-     local.get $2
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 0
-      i32.const 0
-      call $~lib/rt/itcms/__new
-      local.tee $2
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=2
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=16
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=18
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=20
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=24
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=32
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=36
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=40
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f32.const 0
-     f32.store offset=44
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f64.const 0
-     f64.store offset=48
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=56
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=60
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=64
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     br $__inlined_func$bindings/esm/PlainObject#constructor$4
-    end
-    br $folding-inner1
-   end
-   local.tee $2
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   local.get $0
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 68
+   i32.const 13
+   call $~lib/rt/itcms/__new
+   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store
    local.get $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.const 0
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
    i32.load8_s
    local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $0
    local.get $3
    local.get $1
    i32.load8_s
    i32.add
    i32.store8
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=8
-   local.get $0
+   local.get $2
    i32.load16_s offset=2
-   local.set $0
+   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   local.get $2
    local.get $0
+   local.get $2
    local.get $1
    i32.load16_s offset=2
    i32.add
@@ -3397,7 +3285,7 @@
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    return
   end
   i32.const 35072
@@ -3549,258 +3437,34 @@
   unreachable
  )
  (func $export:bindings/esm/arrayOfStringsFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2276
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2276
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/array/Array<i32>#get:length
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   call $~lib/array/Array<i32>#get:length
-   local.get $4
-   i32.add
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2276
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 12
-   call $~lib/rt/itcms/__new
-   local.tee $5
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store
-   local.get $5
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store offset=12
-   local.get $4
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1248
-    i32.const 1920
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $4
-   local.get $4
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 2
-   i32.shl
-   local.tee $6
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
    i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $3
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=12
-   local.get $5
-   local.get $3
-   i32.store
-   local.get $5
-   local.get $3
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   local.get $3
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   local.get $6
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   local.get $4
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   loop $for-loop|0
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store
-    local.get $0
-    call $~lib/array/Array<i32>#get:length
-    local.get $2
-    i32.gt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=12
-     local.get $0
-     local.get $2
-     call $~lib/array/Array<~lib/string/String>#__get
-     local.set $3
-     global.get $~lib/memory/__stack_pointer
-     local.get $3
-     i32.store offset=8
-     local.get $5
-     local.get $2
-     local.get $3
-     call $~lib/array/Array<~lib/string/String>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|0
-    end
-   end
-   i32.const 0
-   local.set $2
-   loop $for-loop|1
-    global.get $~lib/memory/__stack_pointer
-    local.get $1
-    i32.store
-    local.get $1
-    call $~lib/array/Array<i32>#get:length
-    local.get $2
-    i32.gt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=12
-     local.get $0
-     call $~lib/array/Array<i32>#get:length
-     local.get $2
-     i32.add
-     local.set $3
-     global.get $~lib/memory/__stack_pointer
-     local.get $1
-     i32.store offset=12
-     local.get $1
-     local.get $2
-     call $~lib/array/Array<~lib/string/String>#__get
-     local.set $4
-     global.get $~lib/memory/__stack_pointer
-     local.get $4
-     i32.store offset=8
-     local.get $5
-     local.get $3
-     local.get $4
-     call $~lib/array/Array<~lib/string/String>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|1
-    end
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $5
-   return
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 35072
-  i32.const 35120
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  call $bindings/esm/arrayOfStringsFunction
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $export:bindings/esm/arrayFunction (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3808,6 +3472,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -3838,20 +3503,20 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store
+   local.get $0
    call $~lib/array/Array<i32>#get:length
-   local.set $4
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
    local.get $1
    call $~lib/array/Array<i32>#get:length
-   local.get $4
+   local.get $3
    i32.add
-   local.set $5
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.sub
@@ -3870,37 +3535,9 @@
    i32.const 16
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $6
+   local.tee $4
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
+   local.get $3
    i32.const 268435455
    i32.gt_u
    if
@@ -3913,54 +3550,54 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $3
+   local.get $3
    i32.const 8
    i32.le_u
    select
    i32.const 2
    i32.shl
-   local.tee $3
+   local.tee $7
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $4
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $5
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $4
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
    i32.store offset=12
-   local.get $6
    local.get $4
+   local.get $5
    i32.store
-   local.get $6
    local.get $4
+   local.get $5
    i32.const 0
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
    local.get $4
+   i32.store offset=8
+   local.get $4
+   local.get $5
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $3
+   local.get $4
+   i32.store offset=8
+   local.get $4
+   local.get $7
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
+   local.get $4
+   i32.store offset=8
+   local.get $4
+   local.get $3
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $4
    i32.store offset=4
    loop $for-loop|0
     global.get $~lib/memory/__stack_pointer
@@ -3972,12 +3609,12 @@
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $4
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=8
-     local.get $6
+     local.get $4
      local.get $2
      local.get $0
      local.get $2
@@ -4002,7 +3639,7 @@
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $4
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
@@ -4015,7 +3652,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=8
-     local.get $6
+     local.get $4
      local.get $3
      local.get $1
      local.get $2
@@ -4036,7 +3673,7 @@
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $4
    return
   end
   i32.const 35072
@@ -4049,19 +3686,20 @@
  (func $bindings/esm/typedarrayFunction (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f32)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 f32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 2276
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -4069,150 +3707,121 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store
+   local.get $0
    call $~lib/typedarray/Int16Array#get:length
-   local.set $5
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/typedarray/Uint64Array#constructor (result i32)
-    local.get $1
-    call $~lib/typedarray/Float32Array#get:length
-    local.get $5
-    i32.add
-    local.set $5
+   local.get $1
+   call $~lib/typedarray/Float32Array#get:length
+   local.get $3
+   i32.add
+   local.set $6
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.const 7
+   call $~lib/rt/itcms/__new
+   local.tee $3
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   local.get $3
+   i32.eqz
+   if
     global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    block $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12
-     i32.const 7
-     call $~lib/rt/itcms/__new
-     local.tee $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 16
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store offset=8
-     local.get $2
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 12
-      i32.const 3
-      call $~lib/rt/itcms/__new
-      local.tee $2
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=8
-     local.get $5
-     i32.const 134217727
-     i32.gt_u
-     if
-      i32.const 1248
-      i32.const 1296
-      i32.const 19
-      i32.const 57
-      call $~lib/builtins/abort
-      unreachable
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.const 3
-     i32.shl
-     local.tee $7
-     i32.const 1
-     call $~lib/rt/itcms/__new
-     local.tee $5
-     i32.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.store offset=12
-     local.get $2
-     local.get $5
-     i32.store
-     local.get $2
-     local.get $5
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     local.get $5
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     local.get $7
-     i32.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     i32.const 16
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     br $__inlined_func$~lib/typedarray/Uint64Array#constructor
-    end
-    br $folding-inner1
+    i32.const 12
+    i32.const 3
+    call $~lib/rt/itcms/__new
+    local.tee $3
+    i32.store
    end
-   local.tee $2
+   local.get $6
+   i32.const 134217727
+   i32.gt_u
+   if
+    i32.const 1248
+    i32.const 1296
+    i32.const 19
+    i32.const 57
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.const 3
+   i32.shl
+   local.tee $8
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $6
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.store offset=12
+   local.get $3
+   local.get $6
+   i32.store
+   local.get $3
+   local.get $6
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $6
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $8
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
    i32.store offset=4
    loop $for-loop|0
     global.get $~lib/memory/__stack_pointer
@@ -4220,11 +3829,11 @@
     i32.store
     local.get $0
     call $~lib/typedarray/Int16Array#get:length
-    local.get $3
+    local.get $2
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $2
+     local.get $3
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
@@ -4236,14 +3845,14 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 2276
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
-     local.get $3
+     local.get $2
      local.get $0
      i32.load offset=8
      i32.const 1
@@ -4262,50 +3871,50 @@
      i32.store
      local.get $0
      i32.load offset=4
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
      i32.load16_s
-     local.set $5
+     local.set $4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $2
      local.get $3
-     local.get $5
+     local.get $2
+     local.get $4
      i64.extend_i32_s
      call $~lib/typedarray/Uint64Array#__set
-     local.get $3
+     local.get $2
      i32.const 1
      i32.add
-     local.set $3
+     local.set $2
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $3
+   local.set $2
    loop $for-loop|1
     global.get $~lib/memory/__stack_pointer
     local.get $1
     i32.store
     local.get $1
     call $~lib/typedarray/Float32Array#get:length
-    local.get $3
+    local.get $2
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $2
+     local.get $3
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=8
      local.get $0
      call $~lib/typedarray/Int16Array#get:length
-     local.get $3
+     local.get $2
      i32.add
-     local.set $5
+     local.set $4
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=8
@@ -4316,14 +3925,14 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 2276
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store
-     local.get $3
+     local.get $2
      local.get $1
      i32.load offset=8
      i32.const 2
@@ -4342,25 +3951,25 @@
      i32.store
      local.get $1
      i32.load offset=4
-     local.get $3
+     local.get $2
      i32.const 2
      i32.shl
      i32.add
      f32.load
-     local.set $4
+     local.set $5
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $2
-     local.get $5
+     local.get $3
      local.get $4
+     local.get $5
      i64.trunc_sat_f32_u
      call $~lib/typedarray/Uint64Array#__set
-     local.get $3
+     local.get $2
      i32.const 1
      i32.add
-     local.set $3
+     local.set $2
      br $for-loop|1
     end
    end
@@ -4368,7 +3977,7 @@
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $3
    return
   end
   i32.const 35072
@@ -4425,5 +4034,214 @@
  )
  (func $bindings/esm/getMaxUnsigned32 (result i32)
   i32.const -1
+ )
+ (func $bindings/esm/arrayOfStringsFunction (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 16
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   call $~lib/array/Array<i32>#get:length
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
+   call $~lib/array/Array<i32>#get:length
+   local.get $3
+   i32.add
+   local.set $7
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/itcms/__new
+   local.tee $3
+   i32.store
+   local.get $7
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1248
+    i32.const 1920
+    i32.const 70
+    i32.const 60
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   local.get $7
+   local.get $7
+   i32.const 8
+   i32.le_u
+   select
+   i32.const 2
+   i32.shl
+   local.tee $4
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $5
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store offset=12
+   local.get $3
+   local.get $5
+   i32.store
+   local.get $3
+   local.get $5
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $5
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $4
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $7
+   i32.store offset=12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=4
+   loop $for-loop|0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    local.get $0
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $3
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     local.get $4
+     i32.store offset=8
+     local.get $3
+     local.get $2
+     local.get $4
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|0
+    end
+   end
+   i32.const 0
+   local.set $2
+   loop $for-loop|1
+    global.get $~lib/memory/__stack_pointer
+    local.get $1
+    i32.store
+    local.get $1
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $3
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $0
+     call $~lib/array/Array<i32>#get:length
+     local.get $2
+     i32.add
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store offset=12
+     local.get $1
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=8
+     local.get $3
+     local.get $4
+     local.get $5
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|1
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   return
+  end
+  i32.const 35072
+  i32.const 35120
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
  )
 )

--- a/tests/compiler/bindings/noExportRuntime.debug.wat
+++ b/tests/compiler/bindings/noExportRuntime.debug.wat
@@ -2606,30 +2606,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -2651,7 +2627,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -2660,7 +2636,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -2673,7 +2649,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -2681,7 +2657,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength

--- a/tests/compiler/bindings/noExportRuntime.release.wat
+++ b/tests/compiler/bindings/noExportRuntime.release.wat
@@ -1,9 +1,9 @@
 (module
  (type $0 (func (result i32)))
  (type $1 (func (param i32)))
- (type $2 (func (param i32 i32)))
- (type $3 (func))
- (type $4 (func (param i32 i32) (result i32)))
+ (type $2 (func))
+ (type $3 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32)))
  (type $5 (func (param i32 i32 i32 i32)))
  (type $6 (func (param i32 i32 i64)))
  (type $7 (func (param i32) (result i32)))
@@ -821,7 +821,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$132
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$130
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -845,7 +845,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$132
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$130
    end
    local.get $0
    i32.load offset=8
@@ -1437,61 +1437,6 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#set:buffer (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $1
-  if
-   local.get $0
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1264
-    i32.const 295
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/rt/itcms/white
-   local.get $1
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.eq
-   if
-    local.get $0
-    i32.const 20
-    i32.sub
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.tee $0
-    global.get $~lib/rt/itcms/white
-    i32.eqz
-    i32.eq
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-     local.get $0
-     i32.const 3
-     i32.eq
-     i32.and
-     if
-      local.get $1
-      call $~lib/rt/itcms/Object#makeGray
-     end
-    end
-   end
-  end
- )
  (func $export:bindings/noExportRuntime/takesNonPlainObject (param $0 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -1520,6 +1465,8 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   global.get $~started
   if
    return
@@ -1562,7 +1509,7 @@
   i32.const 4
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $__inlined_func$start:bindings/noExportRuntime
+  block $__inlined_func$start:bindings/noExportRuntime$1
    block $folding-inner0
     global.get $~lib/memory/__stack_pointer
     i32.const 1780
@@ -1629,47 +1576,79 @@
      i32.store
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=4
-    local.get $0
-    i32.const 0
-    call $~lib/arraybuffer/ArrayBufferView#set:buffer
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=4
-    local.get $0
-    i32.const 0
-    i32.store offset=4
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=4
-    local.get $0
-    i32.const 0
-    i32.store offset=8
-    global.get $~lib/memory/__stack_pointer
     i32.const 0
     i32.const 1
     call $~lib/rt/itcms/__new
     local.tee $1
-    i32.store offset=8
+    i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=4
+    i32.store offset=8
     global.get $~lib/memory/__stack_pointer
     local.get $1
     i32.store offset=12
     local.get $0
     local.get $1
-    call $~lib/arraybuffer/ArrayBufferView#set:buffer
+    i32.store
+    local.get $1
+    if
+     local.get $0
+     i32.eqz
+     if
+      i32.const 0
+      i32.const 1264
+      i32.const 295
+      i32.const 14
+      call $~lib/builtins/abort
+      unreachable
+     end
+     global.get $~lib/rt/itcms/white
+     local.get $1
+     i32.const 20
+     i32.sub
+     local.tee $2
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     i32.eq
+     if
+      local.get $0
+      i32.const 20
+      i32.sub
+      i32.load offset=4
+      i32.const 3
+      i32.and
+      local.tee $4
+      global.get $~lib/rt/itcms/white
+      i32.eqz
+      i32.eq
+      if
+       local.get $2
+       call $~lib/rt/itcms/Object#makeGray
+      else
+       global.get $~lib/rt/itcms/state
+       i32.const 1
+       i32.eq
+       local.get $4
+       i32.const 3
+       i32.eq
+       i32.and
+       if
+        local.get $2
+        call $~lib/rt/itcms/Object#makeGray
+       end
+      end
+     end
+    end
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=4
+    i32.store offset=8
     local.get $0
     local.get $1
     i32.store offset=4
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    i32.store offset=4
+    i32.store offset=8
     local.get $0
     i32.const 0
     i32.store offset=8
@@ -1685,7 +1664,7 @@
     global.set $~lib/memory/__stack_pointer
     local.get $0
     global.set $bindings/noExportRuntime/isTypedArray
-    br $__inlined_func$start:bindings/noExportRuntime
+    br $__inlined_func$start:bindings/noExportRuntime$1
    end
    i32.const 34576
    i32.const 34624

--- a/tests/compiler/bindings/raw.debug.wat
+++ b/tests/compiler/bindings/raw.debug.wat
@@ -1,23 +1,20 @@
 (module
- (type $0 (func (param i32 i32)))
- (type $1 (func (param i32) (result i32)))
+ (type $0 (func (param i32) (result i32)))
+ (type $1 (func (param i32 i32)))
  (type $2 (func (param i32 i32) (result i32)))
  (type $3 (func (param i32)))
  (type $4 (func))
  (type $5 (func (param i32 i32 i32)))
  (type $6 (func (result i32)))
  (type $7 (func (param i32 i32 i32 i32)))
- (type $8 (func (param i32 i64)))
- (type $9 (func (param i32 i32 f64 f64 f64 f64 f64)))
- (type $10 (func (param f64) (result f64)))
- (type $11 (func (param i64 i64) (result i64)))
- (type $12 (func (result i64)))
- (type $13 (func (param i32 i32 i64) (result i32)))
- (type $14 (func (param i32 f32)))
- (type $15 (func (param i32 f64)))
- (type $16 (func (param i32 i32 i32) (result i32)))
- (type $17 (func (param i32 i32 i64)))
- (type $18 (func (param i32 i32) (result f32)))
+ (type $8 (func (param i32 i32 f64 f64 f64 f64 f64)))
+ (type $9 (func (param f64) (result f64)))
+ (type $10 (func (param i64 i64) (result i64)))
+ (type $11 (func (result i64)))
+ (type $12 (func (param i32 i32 i64) (result i32)))
+ (type $13 (func (param i32 i32 i32) (result i32)))
+ (type $14 (func (param i32 i32 i64)))
+ (type $15 (func (param i32 i32) (result f32)))
  (import "env" "Math.E" (global $~lib/bindings/dom/Math.E f64))
  (import "env" "globalThis" (global $bindings/esm/immutableGlobal externref))
  (import "env" "globalThis.globalThis" (global $bindings/esm/immutableGlobalNested externref))
@@ -2632,105 +2629,23 @@
   local.get $this
   i32.load offset=4
  )
+ (func $bindings/esm/PlainObject#get:a (param $this i32) (result i32)
+  local.get $this
+  i32.load8_s
+ )
  (func $bindings/esm/PlainObject#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
   i32.store8
  )
+ (func $bindings/esm/PlainObject#get:b (param $this i32) (result i32)
+  local.get $this
+  i32.load16_s offset=2
+ )
  (func $bindings/esm/PlainObject#set:b (param $this i32) (param $b i32)
   local.get $this
   local.get $b
   i32.store16 offset=2
- )
- (func $bindings/esm/PlainObject#set:c (param $this i32) (param $c i32)
-  local.get $this
-  local.get $c
-  i32.store offset=4
- )
- (func $bindings/esm/PlainObject#set:d (param $this i32) (param $d i64)
-  local.get $this
-  local.get $d
-  i64.store offset=8
- )
- (func $bindings/esm/PlainObject#set:e (param $this i32) (param $e i32)
-  local.get $this
-  local.get $e
-  i32.store8 offset=16
- )
- (func $bindings/esm/PlainObject#set:f (param $this i32) (param $f i32)
-  local.get $this
-  local.get $f
-  i32.store16 offset=18
- )
- (func $bindings/esm/PlainObject#set:g (param $this i32) (param $g i32)
-  local.get $this
-  local.get $g
-  i32.store offset=20
- )
- (func $bindings/esm/PlainObject#set:h (param $this i32) (param $h i64)
-  local.get $this
-  local.get $h
-  i64.store offset=24
- )
- (func $bindings/esm/PlainObject#set:i (param $this i32) (param $i i32)
-  local.get $this
-  local.get $i
-  i32.store offset=32
- )
- (func $bindings/esm/PlainObject#set:j (param $this i32) (param $j i32)
-  local.get $this
-  local.get $j
-  i32.store offset=36
- )
- (func $bindings/esm/PlainObject#set:k (param $this i32) (param $k i32)
-  local.get $this
-  local.get $k
-  i32.store8 offset=40
- )
- (func $bindings/esm/PlainObject#set:l (param $this i32) (param $l f32)
-  local.get $this
-  local.get $l
-  f32.store offset=44
- )
- (func $bindings/esm/PlainObject#set:m (param $this i32) (param $m f64)
-  local.get $this
-  local.get $m
-  f64.store offset=48
- )
- (func $bindings/esm/PlainObject#set:n (param $this i32) (param $n i32)
-  local.get $this
-  local.get $n
-  i32.store offset=56
-  local.get $this
-  local.get $n
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $bindings/esm/PlainObject#set:o (param $this i32) (param $o i32)
-  local.get $this
-  local.get $o
-  i32.store offset=60
-  local.get $this
-  local.get $o
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $bindings/esm/PlainObject#set:p (param $this i32) (param $p i32)
-  local.get $this
-  local.get $p
-  i32.store offset=64
-  local.get $this
-  local.get $p
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $bindings/esm/PlainObject#get:a (param $this i32) (result i32)
-  local.get $this
-  i32.load8_s
- )
- (func $bindings/esm/PlainObject#get:b (param $this i32) (result i32)
-  local.get $this
-  i32.load16_s offset=2
  )
  (func $bindings/esm/newInternref (result i32)
   i32.const 0
@@ -3405,30 +3320,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -3450,7 +3341,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -3459,7 +3350,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -3472,7 +3363,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -3480,7 +3371,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
@@ -4098,38 +3989,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -4159,7 +4018,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -4168,7 +4027,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -4181,7 +4040,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
@@ -4189,7 +4048,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
@@ -4197,7 +4056,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i32>#set:length_
@@ -4626,38 +4485,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -4687,7 +4514,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -4696,7 +4523,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -4709,7 +4536,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<~lib/string/String>#set:dataStart
@@ -4717,7 +4544,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<~lib/string/String>#set:byteLength
@@ -4725,7 +4552,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<~lib/string/String>#set:length_
@@ -5067,134 +4894,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:b
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:c
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $bindings/esm/PlainObject#set:d
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:e
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:f
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:g
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $bindings/esm/PlainObject#set:h
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:i
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:j
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:k
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f32.const 0
-  call $bindings/esm/PlainObject#set:l
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $bindings/esm/PlainObject#set:m
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:n
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:o
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $bindings/esm/PlainObject#set:p
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/bindings/raw.release.wat
+++ b/tests/compiler/bindings/raw.release.wat
@@ -458,6 +458,35 @@
   memory.fill
   local.get $1
  )
+ (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
+   i32.const 1
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  local.get $0
+  i32.load offset=12
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+ )
  (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
   (local $3 i32)
   local.get $1
@@ -516,35 +545,6 @@
     end
    end
   end
- )
- (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  global.get $~lib/memory/__stack_pointer
-  i32.const 2276
-  i32.lt_s
-  if
-   i32.const 35072
-   i32.const 35120
-   i32.const 1
-   i32.const 1
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/memory/__stack_pointer
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store
-  local.get $0
-  i32.load offset=12
-  global.get $~lib/memory/__stack_pointer
-  i32.const 4
-  i32.add
-  global.set $~lib/memory/__stack_pointer
  )
  (func $~lib/rt/itcms/step (result i32)
   (local $0 i32)
@@ -2163,7 +2163,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$270
+   block $__inlined_func$~lib/rt/itcms/__renew$243
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2206,7 +2206,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$270
+     br $__inlined_func$~lib/rt/itcms/__renew$243
     end
     local.get $3
     local.get $4
@@ -2563,7 +2563,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$285
+   block $__inlined_func$~lib/string/String#concat$258
     local.get $1
     i32.const 20
     i32.sub
@@ -2582,7 +2582,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1760
      local.set $2
-     br $__inlined_func$~lib/string/String#concat$285
+     br $__inlined_func$~lib/string/String#concat$258
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2978,7 +2978,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   block $__inlined_func$bindings/esm/staticarrayFunction$1 (result i32)
+   block $__inlined_func$bindings/esm/staticarrayFunction (result i32)
     global.get $~lib/memory/__stack_pointer
     i32.const 12
     i32.sub
@@ -3134,7 +3134,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      local.get $4
-     br $__inlined_func$bindings/esm/staticarrayFunction$1
+     br $__inlined_func$bindings/esm/staticarrayFunction
     end
     br $folding-inner1
    end
@@ -3154,15 +3154,16 @@
  (func $export:bindings/esm/objectFunction (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
+  (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 2276
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -3176,7 +3177,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 2276
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -3184,207 +3185,94 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$bindings/esm/PlainObject#constructor$4 (result i32)
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    block $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 68
-     i32.const 13
-     call $~lib/rt/itcms/__new
-     local.tee $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     i32.store
-     local.get $2
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 0
-      i32.const 0
-      call $~lib/rt/itcms/__new
-      local.tee $2
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
-     i32.const 4
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=2
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=16
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store16 offset=18
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=20
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i64.const 0
-     i64.store offset=24
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=32
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=36
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store8 offset=40
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f32.const 0
-     f32.store offset=44
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     f64.const 0
-     f64.store offset=48
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=56
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=60
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=64
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     br $__inlined_func$bindings/esm/PlainObject#constructor$4
-    end
-    br $folding-inner1
-   end
-   local.tee $2
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   local.get $0
+   local.set $2
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 68
+   i32.const 13
+   call $~lib/rt/itcms/__new
+   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=8
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store
    local.get $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 0
+    i32.const 0
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
    i32.load8_s
    local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $0
    local.get $3
    local.get $1
    i32.load8_s
    i32.add
    i32.store8
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=8
-   local.get $0
+   local.get $2
    i32.load16_s offset=2
-   local.set $0
+   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=8
-   local.get $2
    local.get $0
+   local.get $2
    local.get $1
    i32.load16_s offset=2
    i32.add
@@ -3397,7 +3285,7 @@
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    return
   end
   i32.const 35072
@@ -3549,258 +3437,34 @@
   unreachable
  )
  (func $export:bindings/esm/arrayOfStringsFunction (param $0 i32) (param $1 i32) (result i32)
-  (local $2 i32)
-  (local $3 i32)
-  (local $4 i32)
-  (local $5 i32)
-  (local $6 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2276
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2276
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   call $~lib/array/Array<i32>#get:length
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   call $~lib/array/Array<i32>#get:length
-   local.get $4
-   i32.add
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 2276
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 12
-   call $~lib/rt/itcms/__new
-   local.tee $5
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store
-   local.get $5
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   i32.const 0
-   i32.store offset=12
-   local.get $4
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1248
-    i32.const 1920
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $4
-   local.get $4
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 2
-   i32.shl
-   local.tee $6
+  global.get $~lib/memory/__stack_pointer
+  i32.const 2276
+  i32.lt_s
+  if
+   i32.const 35072
+   i32.const 35120
    i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $3
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=12
-   local.get $5
-   local.get $3
-   i32.store
-   local.get $5
-   local.get $3
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   local.get $3
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   local.get $6
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   local.get $5
-   local.get $4
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $5
-   i32.store offset=4
-   loop $for-loop|0
-    global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store
-    local.get $0
-    call $~lib/array/Array<i32>#get:length
-    local.get $2
-    i32.gt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=12
-     local.get $0
-     local.get $2
-     call $~lib/array/Array<~lib/string/String>#__get
-     local.set $3
-     global.get $~lib/memory/__stack_pointer
-     local.get $3
-     i32.store offset=8
-     local.get $5
-     local.get $2
-     local.get $3
-     call $~lib/array/Array<~lib/string/String>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|0
-    end
-   end
-   i32.const 0
-   local.set $2
-   loop $for-loop|1
-    global.get $~lib/memory/__stack_pointer
-    local.get $1
-    i32.store
-    local.get $1
-    call $~lib/array/Array<i32>#get:length
-    local.get $2
-    i32.gt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=12
-     local.get $0
-     call $~lib/array/Array<i32>#get:length
-     local.get $2
-     i32.add
-     local.set $3
-     global.get $~lib/memory/__stack_pointer
-     local.get $1
-     i32.store offset=12
-     local.get $1
-     local.get $2
-     call $~lib/array/Array<~lib/string/String>#__get
-     local.set $4
-     global.get $~lib/memory/__stack_pointer
-     local.get $4
-     i32.store offset=8
-     local.get $5
-     local.get $3
-     local.get $4
-     call $~lib/array/Array<~lib/string/String>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|1
-    end
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $5
-   return
+   i32.const 1
+   call $~lib/builtins/abort
+   unreachable
   end
-  i32.const 35072
-  i32.const 35120
-  i32.const 1
-  i32.const 1
-  call $~lib/builtins/abort
-  unreachable
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
+  i32.store
+  global.get $~lib/memory/__stack_pointer
+  local.get $1
+  i32.store offset=4
+  local.get $0
+  local.get $1
+  call $bindings/esm/arrayOfStringsFunction
+  global.get $~lib/memory/__stack_pointer
+  i32.const 8
+  i32.add
+  global.set $~lib/memory/__stack_pointer
  )
  (func $export:bindings/esm/arrayFunction (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -3808,6 +3472,7 @@
   (local $4 i32)
   (local $5 i32)
   (local $6 i32)
+  (local $7 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.sub
@@ -3838,20 +3503,20 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store
+   local.get $0
    call $~lib/array/Array<i32>#get:length
-   local.set $4
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
    local.get $1
    call $~lib/array/Array<i32>#get:length
-   local.get $4
+   local.get $3
    i32.add
-   local.set $5
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.sub
@@ -3870,37 +3535,9 @@
    i32.const 16
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $6
+   local.tee $4
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
+   local.get $3
    i32.const 268435455
    i32.gt_u
    if
@@ -3913,54 +3550,54 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $3
+   local.get $3
    i32.const 8
    i32.le_u
    select
    i32.const 2
    i32.shl
-   local.tee $3
+   local.tee $7
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $4
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $5
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $4
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
    i32.store offset=12
-   local.get $6
    local.get $4
+   local.get $5
    i32.store
-   local.get $6
    local.get $4
+   local.get $5
    i32.const 0
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
    local.get $4
+   i32.store offset=8
+   local.get $4
+   local.get $5
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $3
+   local.get $4
+   i32.store offset=8
+   local.get $4
+   local.get $7
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
+   local.get $4
+   i32.store offset=8
+   local.get $4
+   local.get $3
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $4
    i32.store offset=4
    loop $for-loop|0
     global.get $~lib/memory/__stack_pointer
@@ -3972,12 +3609,12 @@
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $4
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=8
-     local.get $6
+     local.get $4
      local.get $2
      local.get $0
      local.get $2
@@ -4002,7 +3639,7 @@
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $4
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
@@ -4015,7 +3652,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=8
-     local.get $6
+     local.get $4
      local.get $3
      local.get $1
      local.get $2
@@ -4036,7 +3673,7 @@
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $4
    return
   end
   i32.const 35072
@@ -4049,19 +3686,20 @@
  (func $bindings/esm/typedarrayFunction (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
-  (local $4 f32)
-  (local $5 i32)
+  (local $4 i32)
+  (local $5 f32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 2276
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -4069,150 +3707,121 @@
    i32.const 0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
+   i32.store
+   local.get $0
    call $~lib/typedarray/Int16Array#get:length
-   local.set $5
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/typedarray/Uint64Array#constructor (result i32)
-    local.get $1
-    call $~lib/typedarray/Float32Array#get:length
-    local.get $5
-    i32.add
-    local.set $5
+   local.get $1
+   call $~lib/typedarray/Float32Array#get:length
+   local.get $3
+   i32.add
+   local.set $6
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.const 7
+   call $~lib/rt/itcms/__new
+   local.tee $3
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   local.get $3
+   i32.eqz
+   if
     global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    block $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12
-     i32.const 7
-     call $~lib/rt/itcms/__new
-     local.tee $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 16
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 2276
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store offset=8
-     local.get $2
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 12
-      i32.const 3
-      call $~lib/rt/itcms/__new
-      local.tee $2
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store
-     local.get $2
-     i32.const 0
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=8
-     local.get $5
-     i32.const 134217727
-     i32.gt_u
-     if
-      i32.const 1248
-      i32.const 1296
-      i32.const 19
-      i32.const 57
-      call $~lib/builtins/abort
-      unreachable
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.const 3
-     i32.shl
-     local.tee $7
-     i32.const 1
-     call $~lib/rt/itcms/__new
-     local.tee $5
-     i32.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $5
-     i32.store offset=12
-     local.get $2
-     local.get $5
-     i32.store
-     local.get $2
-     local.get $5
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     local.get $5
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     local.get $7
-     i32.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     i32.const 16
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $2
-     br $__inlined_func$~lib/typedarray/Uint64Array#constructor
-    end
-    br $folding-inner1
+    i32.const 12
+    i32.const 3
+    call $~lib/rt/itcms/__new
+    local.tee $3
+    i32.store
    end
-   local.tee $2
+   local.get $6
+   i32.const 134217727
+   i32.gt_u
+   if
+    i32.const 1248
+    i32.const 1296
+    i32.const 19
+    i32.const 57
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.const 3
+   i32.shl
+   local.tee $8
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $6
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $6
+   i32.store offset=12
+   local.get $3
+   local.get $6
+   i32.store
+   local.get $3
+   local.get $6
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $6
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $8
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
    i32.store offset=4
    loop $for-loop|0
     global.get $~lib/memory/__stack_pointer
@@ -4220,11 +3829,11 @@
     i32.store
     local.get $0
     call $~lib/typedarray/Int16Array#get:length
-    local.get $3
+    local.get $2
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $2
+     local.get $3
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
@@ -4236,14 +3845,14 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 2276
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
-     local.get $3
+     local.get $2
      local.get $0
      i32.load offset=8
      i32.const 1
@@ -4262,50 +3871,50 @@
      i32.store
      local.get $0
      i32.load offset=4
-     local.get $3
+     local.get $2
      i32.const 1
      i32.shl
      i32.add
      i32.load16_s
-     local.set $5
+     local.set $4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $2
      local.get $3
-     local.get $5
+     local.get $2
+     local.get $4
      i64.extend_i32_s
      call $~lib/typedarray/Uint64Array#__set
-     local.get $3
+     local.get $2
      i32.const 1
      i32.add
-     local.set $3
+     local.set $2
      br $for-loop|0
     end
    end
    i32.const 0
-   local.set $3
+   local.set $2
    loop $for-loop|1
     global.get $~lib/memory/__stack_pointer
     local.get $1
     i32.store
     local.get $1
     call $~lib/typedarray/Float32Array#get:length
-    local.get $3
+    local.get $2
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $2
+     local.get $3
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=8
      local.get $0
      call $~lib/typedarray/Int16Array#get:length
-     local.get $3
+     local.get $2
      i32.add
-     local.set $5
+     local.set $4
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=8
@@ -4316,14 +3925,14 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 2276
      i32.lt_s
-     br_if $folding-inner1
+     br_if $folding-inner0
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store
-     local.get $3
+     local.get $2
      local.get $1
      i32.load offset=8
      i32.const 2
@@ -4342,25 +3951,25 @@
      i32.store
      local.get $1
      i32.load offset=4
-     local.get $3
+     local.get $2
      i32.const 2
      i32.shl
      i32.add
      f32.load
-     local.set $4
+     local.set $5
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
-     local.get $2
-     local.get $5
+     local.get $3
      local.get $4
+     local.get $5
      i64.trunc_sat_f32_u
      call $~lib/typedarray/Uint64Array#__set
-     local.get $3
+     local.get $2
      i32.const 1
      i32.add
-     local.set $3
+     local.set $2
      br $for-loop|1
     end
    end
@@ -4368,7 +3977,7 @@
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $3
    return
   end
   i32.const 35072
@@ -4425,5 +4034,214 @@
  )
  (func $bindings/esm/getMaxUnsigned32 (result i32)
   i32.const -1
+ )
+ (func $bindings/esm/arrayOfStringsFunction (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 16
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   local.get $0
+   call $~lib/array/Array<i32>#get:length
+   local.set $3
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store
+   local.get $1
+   call $~lib/array/Array<i32>#get:length
+   local.get $3
+   i32.add
+   local.set $7
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 2276
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.const 12
+   call $~lib/rt/itcms/__new
+   local.tee $3
+   i32.store
+   local.get $7
+   i32.const 268435455
+   i32.gt_u
+   if
+    i32.const 1248
+    i32.const 1920
+    i32.const 70
+    i32.const 60
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   local.get $7
+   local.get $7
+   i32.const 8
+   i32.le_u
+   select
+   i32.const 2
+   i32.shl
+   local.tee $4
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $5
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $5
+   i32.store offset=12
+   local.get $3
+   local.get $5
+   i32.store
+   local.get $3
+   local.get $5
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $5
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $4
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=8
+   local.get $3
+   local.get $7
+   i32.store offset=12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=4
+   loop $for-loop|0
+    global.get $~lib/memory/__stack_pointer
+    local.get $0
+    i32.store
+    local.get $0
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $3
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $0
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     local.get $4
+     i32.store offset=8
+     local.get $3
+     local.get $2
+     local.get $4
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|0
+    end
+   end
+   i32.const 0
+   local.set $2
+   loop $for-loop|1
+    global.get $~lib/memory/__stack_pointer
+    local.get $1
+    i32.store
+    local.get $1
+    call $~lib/array/Array<i32>#get:length
+    local.get $2
+    i32.gt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $3
+     i32.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $0
+     call $~lib/array/Array<i32>#get:length
+     local.get $2
+     i32.add
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store offset=12
+     local.get $1
+     local.get $2
+     call $~lib/array/Array<~lib/string/String>#__get
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=8
+     local.get $3
+     local.get $4
+     local.get $5
+     call $~lib/array/Array<~lib/string/String>#__set
+     local.get $2
+     i32.const 1
+     i32.add
+     local.set $2
+     br $for-loop|1
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $3
+   return
+  end
+  i32.const 35072
+  i32.const 35120
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
  )
 )

--- a/tests/compiler/call-rest.debug.wat
+++ b/tests/compiler/call-rest.debug.wat
@@ -3064,14 +3064,6 @@
   local.get $7
   i32.store offset=4
   local.get $7
-  i32.const 0
-  call $call-rest/Foo#set:values
-  local.get $this
-  local.set $7
-  global.get $~lib/memory/__stack_pointer
-  local.get $7
-  i32.store offset=4
-  local.get $7
   global.get $~lib/memory/__stack_pointer
   i32.const 2
   i32.const 2

--- a/tests/compiler/call-rest.release.wat
+++ b/tests/compiler/call-rest.release.wat
@@ -2,8 +2,8 @@
  (type $0 (func (param i32 i32 i32) (result i32)))
  (type $1 (func (param i32 i32) (result i32)))
  (type $2 (func (param i32)))
- (type $3 (func (param i32 i32)))
- (type $4 (func (param i32) (result i32)))
+ (type $3 (func (param i32) (result i32)))
+ (type $4 (func (param i32 i32)))
  (type $5 (func))
  (type $6 (func (param i32 i32 i32 i32)))
  (type $7 (func (param i32 i32 i64)))
@@ -477,60 +477,6 @@
   local.get $0
   memory.fill
   local.get $1
- )
- (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
-  local.get $1
-  i32.eqz
-  if
-   return
-  end
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1264
-   i32.const 295
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/rt/itcms/white
-  local.get $1
-  i32.const 20
-  i32.sub
-  local.tee $1
-  i32.load offset=4
-  i32.const 3
-  i32.and
-  i32.eq
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.tee $0
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
-   else
-    global.get $~lib/rt/itcms/state
-    i32.const 1
-    i32.eq
-    local.get $0
-    i32.const 3
-    i32.eq
-    i32.and
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
  )
  (func $~lib/array/Array<i32>#get:length (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
@@ -1048,6 +994,60 @@
   i32.or
   i32.store offset=4
  )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1264
+   i32.const 295
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.tee $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   local.tee $0
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $1
+    call $~lib/rt/itcms/Object#makeGray
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    local.get $0
+    i32.const 3
+    i32.eq
+    i32.and
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1071,7 +1071,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$160
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$159
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1095,7 +1095,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$160
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$159
    end
    local.get $0
    i32.load offset=8
@@ -1502,15 +1502,6 @@
    call $~lib/rt/itcms/__new
    local.tee $2
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=4
-   local.get $2
-   i32.const 0
-   i32.store
-   local.get $2
-   i32.const 0
-   call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=4
@@ -2046,7 +2037,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$154
+   block $__inlined_func$~lib/rt/itcms/__renew$153
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -2089,7 +2080,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$154
+     br $__inlined_func$~lib/rt/itcms/__renew$153
     end
     local.get $3
     local.get $4

--- a/tests/compiler/class.debug.wat
+++ b/tests/compiler/class.debug.wat
@@ -2685,38 +2685,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -2746,7 +2714,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -2755,7 +2723,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -2768,7 +2736,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
@@ -2776,7 +2744,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
@@ -2784,7 +2752,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i32>#set:length_

--- a/tests/compiler/class.release.wat
+++ b/tests/compiler/class.release.wat
@@ -792,7 +792,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$136
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -816,7 +816,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$136
    end
    local.get $0
    i32.load offset=8
@@ -965,61 +965,6 @@
    return
   end
   unreachable
- )
- (func $~lib/array/Array<i32>#set:buffer (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $1
-  if
-   local.get $0
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 295
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/rt/itcms/white
-   local.get $1
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.eq
-   if
-    local.get $0
-    i32.const 20
-    i32.sub
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.tee $0
-    global.get $~lib/rt/itcms/white
-    i32.eqz
-    i32.eq
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-     local.get $0
-     i32.const 3
-     i32.eq
-     i32.and
-     if
-      local.get $1
-      call $~lib/rt/itcms/Object#makeGray
-     end
-    end
-   end
-  end
  )
  (func $~lib/rt/tlsf/searchBlock (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
@@ -1387,6 +1332,61 @@
     i32.and
     local.set $0
     br $while-continue|0
+   end
+  end
+ )
+ (func $~lib/array/Array<i32>#set:buffer (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $1
+  if
+   local.get $0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 295
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/rt/itcms/white
+   local.get $1
+   i32.const 20
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.eq
+   if
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    local.tee $0
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+     local.get $0
+     i32.const 3
+     i32.eq
+     i32.and
+     if
+      local.get $1
+      call $~lib/rt/itcms/Object#makeGray
+     end
+    end
    end
   end
  )
@@ -1851,38 +1851,14 @@
    local.tee $2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=4
-   local.get $2
-   i32.const 0
-   call $~lib/array/Array<i32>#set:buffer
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=4
-   local.get $2
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=4
-   local.get $2
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=4
-   local.get $2
-   i32.const 0
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
    i32.const 32
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $1
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=4
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=12
@@ -1891,19 +1867,19 @@
    call $~lib/array/Array<i32>#set:buffer
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=4
+   i32.store offset=8
    local.get $2
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=4
+   i32.store offset=8
    local.get $2
    i32.const 32
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $2
-   i32.store offset=4
+   i32.store offset=8
    local.get $2
    i32.const 0
    i32.store offset=12

--- a/tests/compiler/constructor.debug.wat
+++ b/tests/compiler/constructor.debug.wat
@@ -2263,22 +2263,12 @@
   local.get $a
   i32.store
  )
- (func $constructor/EmptyCtorWithFieldNoInit#set:a (param $this i32) (param $a i32)
-  local.get $this
-  local.get $a
-  i32.store
- )
  (func $constructor/EmptyCtorWithFieldAccess#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
   i32.store
  )
  (func $constructor/JustFieldInit#set:a (param $this i32) (param $a i32)
-  local.get $this
-  local.get $a
-  i32.store
- )
- (func $constructor/JustFieldNoInit#set:a (param $this i32) (param $a i32)
   local.get $this
   local.get $a
   i32.store
@@ -2543,42 +2533,6 @@
   global.set $~lib/memory/__stack_pointer
   local.get $1
  )
- (func $constructor/EmptyCtorWithFieldNoInit#constructor (param $this i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $this
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 6
-   call $~lib/rt/itcms/__new
-   local.tee $this
-   i32.store
-  end
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $constructor/EmptyCtorWithFieldNoInit#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
- )
  (func $constructor/EmptyCtorWithFieldAccess#constructor (param $this i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -2599,14 +2553,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $constructor/EmptyCtorWithFieldAccess#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -2737,14 +2683,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $constructor/JustFieldNoInit#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3138,6 +3076,34 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 4
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store
+  end
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $constructor/EmptyCtorWithFieldNoInit#constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.const 6
    call $~lib/rt/itcms/__new
    local.tee $this
    i32.store

--- a/tests/compiler/constructor.release.wat
+++ b/tests/compiler/constructor.release.wat
@@ -82,7 +82,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$153
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$150
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -106,7 +106,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$153
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$150
     end
     local.get $1
     i32.load offset=8
@@ -1578,7 +1578,7 @@
    local.get $0
    global.set $constructor/emptyCtorWithFieldInit
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -1586,8 +1586,8 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 6
@@ -1595,13 +1595,7 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
@@ -1622,12 +1616,6 @@
    i32.const 7
    call $~lib/rt/itcms/__new
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -1733,12 +1721,6 @@
    local.get $0
    call $~lib/object/Object#constructor
    local.tee $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8

--- a/tests/compiler/duplicate-fields.debug.wat
+++ b/tests/compiler/duplicate-fields.debug.wat
@@ -2360,26 +2360,6 @@
   local.get $this
   i32.load
  )
- (func $duplicate-fields/A3#set:prot (param $this i32) (param $prot i32)
-  local.get $this
-  local.get $prot
-  i32.store
- )
- (func $duplicate-fields/A3#set:pub (param $this i32) (param $pub i32)
-  local.get $this
-  local.get $pub
-  i32.store offset=4
- )
- (func $duplicate-fields/B3#set:prot (param $this i32) (param $prot i32)
-  local.get $this
-  local.get $prot
-  i32.store
- )
- (func $duplicate-fields/B3#set:pub (param $this i32) (param $pub i32)
-  local.get $this
-  local.get $pub
-  i32.store offset=4
- )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
   global.get $duplicate-fields/foo
@@ -2529,14 +2509,6 @@
   local.get $2
   i32.store offset=4
   local.get $2
-  i32.const 0
-  call $duplicate-fields/A#set:bar
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   local.get $bar
   call $duplicate-fields/A#set:bar
   local.get $this
@@ -2567,14 +2539,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $duplicate-fields/B#set:bar
   global.get $~lib/memory/__stack_pointer
   local.get $this
   local.set $2
@@ -2631,14 +2595,6 @@
   local.get $2
   i32.store offset=4
   local.get $2
-  i32.const 0
-  call $duplicate-fields/A2#set:bar
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   local.get $bar
   local.set $2
   global.get $~lib/memory/__stack_pointer
@@ -2677,14 +2633,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $duplicate-fields/B2#set:bar
   global.get $~lib/memory/__stack_pointer
   local.get $this
   local.set $2
@@ -2748,14 +2696,6 @@
   local.get $2
   i32.store offset=4
   local.get $2
-  i32.const 0
-  call $duplicate-fields/Foo#set:foo
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   local.get $foo
   call $duplicate-fields/Foo#set:foo
   local.get $this
@@ -2799,22 +2739,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $duplicate-fields/A3#set:prot
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $duplicate-fields/A3#set:pub
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -2850,22 +2774,6 @@
   call $duplicate-fields/A3#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $duplicate-fields/B3#set:prot
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $duplicate-fields/B3#set:pub
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/duplicate-fields.release.wat
+++ b/tests/compiler/duplicate-fields.release.wat
@@ -374,61 +374,6 @@
    global.set $~lib/rt/itcms/visitCount
   end
  )
- (func $duplicate-fields/A2#set:bar (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $1
-  if
-   local.get $0
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1120
-    i32.const 295
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/rt/itcms/white
-   local.get $1
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.eq
-   if
-    local.get $0
-    i32.const 20
-    i32.sub
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.tee $0
-    global.get $~lib/rt/itcms/white
-    i32.eqz
-    i32.eq
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-     local.get $0
-     i32.const 3
-     i32.eq
-     i32.and
-     if
-      local.get $1
-      call $~lib/rt/itcms/Object#makeGray
-     end
-    end
-   end
-  end
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -844,7 +789,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$132
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -868,7 +813,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$132
    end
    local.get $0
    i32.load offset=8
@@ -1377,6 +1322,61 @@
    end
   end
  )
+ (func $duplicate-fields/A2#set:bar (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $1
+  if
+   local.get $0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1120
+    i32.const 295
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/rt/itcms/white
+   local.get $1
+   i32.const 20
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.eq
+   if
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    local.tee $0
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+     local.get $0
+     i32.const 3
+     i32.eq
+     i32.and
+     if
+      local.get $1
+      call $~lib/rt/itcms/Object#makeGray
+     end
+    end
+   end
+  end
+ )
  (func $~start
   (local $0 i32)
   (local $1 i32)
@@ -1443,12 +1443,6 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -1473,12 +1467,6 @@
     local.tee $0
     i32.store
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -1540,12 +1528,6 @@
    local.get $1
    i32.store offset=4
    local.get $1
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
    i32.const 1
    i32.store
    global.get $~lib/memory/__stack_pointer
@@ -1575,12 +1557,6 @@
    call $~lib/rt/itcms/__new
    local.tee $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   call $duplicate-fields/A2#set:bar
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -1612,12 +1588,6 @@
     local.tee $0
     i32.store
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   call $duplicate-fields/A2#set:bar
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4
@@ -1743,35 +1713,11 @@
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add

--- a/tests/compiler/extends-baseaggregate.debug.wat
+++ b/tests/compiler/extends-baseaggregate.debug.wat
@@ -6,9 +6,8 @@
  (type $4 (func (param i32 i32) (result i32)))
  (type $5 (func (param i32 i32 i32)))
  (type $6 (func (param i32 i32 i32 i32)))
- (type $7 (func (param i32 f64)))
- (type $8 (func (param i32 i32 i64) (result i32)))
- (type $9 (func (result i32)))
+ (type $7 (func (param i32 i32 i64) (result i32)))
+ (type $8 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $extends-baseaggregate/poolB i32 (i32.const 64))
  (global $extends-baseaggregate/poolA i32 (i32.const 144))
@@ -2254,15 +2253,67 @@
   local.get $ptr
   return
  )
- (func $extends-baseaggregate/A1#set:padding0 (param $this i32) (param $padding0 f64)
+ (func $~lib/array/Array<extends-baseaggregate/A2>#get:length_ (param $this i32) (result i32)
   local.get $this
-  local.get $padding0
-  f64.store
+  i32.load offset=12
  )
- (func $extends-baseaggregate/A1#set:padding1 (param $this i32) (param $padding1 f64)
+ (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (param $this i32) (result i32)
   local.get $this
-  local.get $padding1
-  f64.store offset=8
+  i32.load offset=8
+ )
+ (func $~lib/arraybuffer/ArrayBufferView#get:buffer (param $this i32) (result i32)
+  local.get $this
+  i32.load
+ )
+ (func $~lib/rt/itcms/Object#get:rtSize (param $this i32) (result i32)
+  local.get $this
+  i32.load offset=16
+ )
+ (func $~lib/rt/itcms/__renew (param $oldPtr i32) (param $size i32) (result i32)
+  (local $oldObj i32)
+  (local $newPtr i32)
+  (local $4 i32)
+  (local $5 i32)
+  local.get $oldPtr
+  i32.const 20
+  i32.sub
+  local.set $oldObj
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/common/BLOCK#get:mmInfo
+  i32.const 3
+  i32.const -1
+  i32.xor
+  i32.and
+  i32.const 16
+  i32.sub
+  i32.le_u
+  if
+   local.get $oldObj
+   local.get $size
+   call $~lib/rt/itcms/Object#set:rtSize
+   local.get $oldPtr
+   return
+  end
+  local.get $size
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtId
+  call $~lib/rt/itcms/__new
+  local.set $newPtr
+  local.get $newPtr
+  local.get $oldPtr
+  local.get $size
+  local.tee $4
+  local.get $oldObj
+  call $~lib/rt/itcms/Object#get:rtSize
+  local.tee $5
+  local.get $4
+  local.get $5
+  i32.lt_u
+  select
+  memory.copy
+  local.get $newPtr
+  return
  )
  (func $~lib/rt/itcms/__link (param $parentPtr i32) (param $childPtr i32) (param $expectMultiple i32)
   (local $child i32)
@@ -2331,77 +2382,6 @@
     end
    end
   end
- )
- (func $extends-baseaggregate/A1#set:c1 (param $this i32) (param $c1 i32)
-  local.get $this
-  local.get $c1
-  i32.store offset=16
-  local.get $this
-  local.get $c1
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $~lib/array/Array<extends-baseaggregate/A2>#get:length_ (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=12
- )
- (func $~lib/arraybuffer/ArrayBufferView#get:byteLength (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=8
- )
- (func $~lib/arraybuffer/ArrayBufferView#get:buffer (param $this i32) (result i32)
-  local.get $this
-  i32.load
- )
- (func $~lib/rt/itcms/Object#get:rtSize (param $this i32) (result i32)
-  local.get $this
-  i32.load offset=16
- )
- (func $~lib/rt/itcms/__renew (param $oldPtr i32) (param $size i32) (result i32)
-  (local $oldObj i32)
-  (local $newPtr i32)
-  (local $4 i32)
-  (local $5 i32)
-  local.get $oldPtr
-  i32.const 20
-  i32.sub
-  local.set $oldObj
-  local.get $size
-  local.get $oldObj
-  call $~lib/rt/common/BLOCK#get:mmInfo
-  i32.const 3
-  i32.const -1
-  i32.xor
-  i32.and
-  i32.const 16
-  i32.sub
-  i32.le_u
-  if
-   local.get $oldObj
-   local.get $size
-   call $~lib/rt/itcms/Object#set:rtSize
-   local.get $oldPtr
-   return
-  end
-  local.get $size
-  local.get $oldObj
-  call $~lib/rt/itcms/Object#get:rtId
-  call $~lib/rt/itcms/__new
-  local.set $newPtr
-  local.get $newPtr
-  local.get $oldPtr
-  local.get $size
-  local.tee $4
-  local.get $oldObj
-  call $~lib/rt/itcms/Object#get:rtSize
-  local.tee $5
-  local.get $4
-  local.get $5
-  i32.lt_u
-  select
-  memory.copy
-  local.get $newPtr
-  return
  )
  (func $~lib/array/Array<extends-baseaggregate/A2>#get:dataStart (param $this i32) (result i32)
   local.get $this
@@ -2624,30 +2604,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $extends-baseaggregate/A1#set:padding0
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $extends-baseaggregate/A1#set:padding1
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $extends-baseaggregate/A1#set:c1
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/extends-baseaggregate.release.wat
+++ b/tests/compiler/extends-baseaggregate.release.wat
@@ -1,12 +1,11 @@
 (module
  (type $0 (func (param i32)))
- (type $1 (func))
- (type $2 (func (param i32 i32) (result i32)))
- (type $3 (func (param i32 i32)))
+ (type $1 (func (param i32 i32)))
+ (type $2 (func))
+ (type $3 (func (param i32 i32) (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
- (type $5 (func (param i32 i32 i32)))
- (type $6 (func (param i32 i32 i64)))
- (type $7 (func (result i32)))
+ (type $5 (func (param i32 i32 i64)))
+ (type $6 (func (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/total (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/threshold (mut i32) (i32.const 0))
@@ -776,65 +775,6 @@
   i32.or
   i32.store offset=4
  )
- (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $1
-  i32.eqz
-  if
-   return
-  end
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1280
-   i32.const 295
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/rt/itcms/white
-  local.get $1
-  i32.const 20
-  i32.sub
-  local.tee $1
-  i32.load offset=4
-  i32.const 3
-  i32.and
-  i32.eq
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   local.tee $0
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.tee $3
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $0
-    local.get $1
-    local.get $2
-    select
-    call $~lib/rt/itcms/Object#makeGray
-   else
-    global.get $~lib/rt/itcms/state
-    i32.const 1
-    i32.eq
-    local.get $3
-    i32.const 3
-    i32.eq
-    i32.and
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
- )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -858,7 +798,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$142
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$139
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -882,7 +822,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$142
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$139
    end
    local.get $0
    i32.load offset=8
@@ -1386,6 +1326,52 @@
    end
   end
  )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  (local $2 i32)
+  local.get $0
+  i32.eqz
+  if
+   return
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $0
+  i32.const 20
+  i32.sub
+  local.tee $0
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   i32.const 1152
+   i32.load
+   i32.const 3
+   i32.and
+   local.tee $2
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    i32.const 1148
+    local.get $0
+    local.get $1
+    select
+    call $~lib/rt/itcms/Object#makeGray
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    local.get $2
+    i32.const 3
+    i32.eq
+    i32.and
+    if
+     local.get $0
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
  (func $~lib/array/Array<extends-baseaggregate/B1>~visit (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1583,28 +1569,6 @@
    local.get $6
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   f64.const 0
-   f64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   f64.const 0
-   f64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=16
-   local.get $6
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
@@ -1674,7 +1638,7 @@
     global.get $~lib/memory/__stack_pointer
     i32.const 1168
     i32.store
-    block $__inlined_func$~lib/rt/itcms/__renew$141
+    block $__inlined_func$~lib/rt/itcms/__renew$138
      i32.const 1073741820
      local.get $0
      i32.const 1
@@ -1717,7 +1681,7 @@
       i32.store offset=16
       local.get $0
       local.set $1
-      br $__inlined_func$~lib/rt/itcms/__renew$141
+      br $__inlined_func$~lib/rt/itcms/__renew$138
      end
      local.get $3
      local.get $2
@@ -1745,7 +1709,6 @@
      i32.const 1172
      local.get $1
      i32.store
-     i32.const 1168
      local.get $1
      i32.const 0
      call $~lib/rt/itcms/__link
@@ -1769,7 +1732,6 @@
    i32.add
    local.get $6
    i32.store
-   i32.const 1168
    local.get $6
    i32.const 1
    call $~lib/rt/itcms/__link

--- a/tests/compiler/extends-recursive.debug.wat
+++ b/tests/compiler/extends-recursive.debug.wat
@@ -3,8 +3,8 @@
  (type $1 (func (param i32 i32)))
  (type $2 (func (param i32)))
  (type $3 (func))
- (type $4 (func (param i32 i32 i32)))
- (type $5 (func (param i32 i32) (result i32)))
+ (type $4 (func (param i32 i32) (result i32)))
+ (type $5 (func (param i32 i32 i32)))
  (type $6 (func (param i32 i32 i32 i32)))
  (type $7 (func (param i32 i32 i64) (result i32)))
  (type $8 (func (result i32)))
@@ -2244,83 +2244,6 @@
   local.get $ptr
   return
  )
- (func $~lib/rt/itcms/__link (param $parentPtr i32) (param $childPtr i32) (param $expectMultiple i32)
-  (local $child i32)
-  (local $parent i32)
-  (local $parentColor i32)
-  local.get $childPtr
-  i32.eqz
-  if
-   return
-  end
-  i32.const 1
-  drop
-  local.get $parentPtr
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 96
-   i32.const 295
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  local.get $childPtr
-  i32.const 20
-  i32.sub
-  local.set $child
-  local.get $child
-  call $~lib/rt/itcms/Object#get:color
-  global.get $~lib/rt/itcms/white
-  i32.eq
-  if
-   local.get $parentPtr
-   i32.const 20
-   i32.sub
-   local.set $parent
-   local.get $parent
-   call $~lib/rt/itcms/Object#get:color
-   local.set $parentColor
-   local.get $parentColor
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $expectMultiple
-    if
-     local.get $parent
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     local.get $child
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   else
-    local.get $parentColor
-    i32.const 3
-    i32.eq
-    if (result i32)
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-    else
-     i32.const 0
-    end
-    if
-     local.get $child
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
- )
- (func $extends-recursive/Parent#set:child (param $this i32) (param $child i32)
-  local.get $this
-  local.get $child
-  i32.store
-  local.get $this
-  local.get $child
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
  (func $start:extends-recursive
   memory.size
   i32.const 16
@@ -2462,14 +2385,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $extends-recursive/Parent#set:child
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/extends-recursive.release.wat
+++ b/tests/compiler/extends-recursive.release.wat
@@ -45,19 +45,19 @@
   local.get $0
   i32.const 20
   i32.sub
-  local.tee $0
+  local.tee $1
   i32.load offset=4
   i32.const 3
   i32.and
   i32.eq
   if
-   local.get $0
+   local.get $1
    global.get $~lib/rt/itcms/iter
    i32.eq
    if
-    local.get $0
+    local.get $1
     i32.load offset=8
-    local.tee $1
+    local.tee $0
     i32.eqz
     if
      i32.const 0
@@ -67,21 +67,21 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$116
-    local.get $0
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$114
+    local.get $1
     i32.load offset=4
     i32.const -4
     i32.and
-    local.tee $1
+    local.tee $0
     i32.eqz
     if
-     local.get $0
+     local.get $1
      i32.load offset=8
      i32.eqz
-     local.get $0
+     local.get $1
      i32.const 34236
      i32.lt_u
      i32.and
@@ -94,9 +94,9 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$116
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$114
     end
-    local.get $0
+    local.get $1
     i32.load offset=8
     local.tee $2
     i32.eqz
@@ -108,11 +108,11 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $0
     local.get $2
     i32.store offset=8
     local.get $2
-    local.get $1
+    local.get $0
     local.get $2
     i32.load offset=4
     i32.const 3
@@ -122,15 +122,15 @@
    end
    global.get $~lib/rt/itcms/toSpace
    local.set $2
-   local.get $0
+   local.get $1
    i32.load offset=12
-   local.tee $1
+   local.tee $0
    i32.const 2
    i32.le_u
    if (result i32)
     i32.const 1
    else
-    local.get $1
+    local.get $0
     i32.const 1440
     i32.load
     i32.gt_u
@@ -142,7 +142,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    local.get $1
+    local.get $0
     i32.const 2
     i32.shl
     i32.const 1444
@@ -154,8 +154,8 @@
    local.set $3
    local.get $2
    i32.load offset=8
-   local.set $1
-   local.get $0
+   local.set $0
+   local.get $1
    global.get $~lib/rt/itcms/white
    i32.eqz
    i32.const 2
@@ -164,19 +164,19 @@
    local.get $2
    i32.or
    i32.store offset=4
-   local.get $0
    local.get $1
+   local.get $0
    i32.store offset=8
-   local.get $1
    local.get $0
    local.get $1
+   local.get $0
    i32.load offset=4
    i32.const 3
    i32.and
    i32.or
    i32.store offset=4
    local.get $2
-   local.get $0
+   local.get $1
    i32.store offset=8
    global.get $~lib/rt/itcms/visitCount
    i32.const 1
@@ -1285,7 +1285,7 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
-  block $__inlined_func$start:extends-recursive$1
+  block $__inlined_func$start:extends-recursive
    memory.size
    i32.const 16
    i32.shl
@@ -1393,12 +1393,6 @@
     local.get $0
     i32.store
     global.get $~lib/memory/__stack_pointer
-    local.get $0
-    i32.store offset=4
-    local.get $0
-    i32.const 0
-    i32.store
-    global.get $~lib/memory/__stack_pointer
     i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
@@ -1408,7 +1402,7 @@
     i32.const 8
     i32.add
     global.set $~lib/memory/__stack_pointer
-    br $__inlined_func$start:extends-recursive$1
+    br $__inlined_func$start:extends-recursive
    end
    i32.const 34256
    i32.const 34304

--- a/tests/compiler/field-initialization.debug.wat
+++ b/tests/compiler/field-initialization.debug.wat
@@ -2264,11 +2264,6 @@
   local.get $this
   i32.load
  )
- (func $field-initialization/Value#set:a (param $this i32) (param $a i32)
-  local.get $this
-  local.get $a
-  i32.store
- )
  (func $field-initialization/Value#get:a (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -2367,23 +2362,9 @@
   local.get $this
   i32.load
  )
- (func $field-initialization/Nullable#set:a (param $this i32) (param $a i32)
-  local.get $this
-  local.get $a
-  i32.store
-  local.get $this
-  local.get $a
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
  (func $field-initialization/Nullable#get:a (param $this i32) (result i32)
   local.get $this
   i32.load
- )
- (func $field-initialization/Value_Ctor#set:a (param $this i32) (param $a i32)
-  local.get $this
-  local.get $a
-  i32.store
  )
  (func $field-initialization/Value_Ctor#get:a (param $this i32) (result i32)
   local.get $this
@@ -2446,15 +2427,6 @@
   local.get $this
   i32.load
  )
- (func $field-initialization/Nullable_Ctor#set:a (param $this i32) (param $a i32)
-  local.get $this
-  local.get $a
-  i32.store
-  local.get $this
-  local.get $a
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
  (func $field-initialization/Nullable_Ctor#get:a (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -2497,20 +2469,6 @@
  (func $field-initialization/Inherit_Base#get:a (param $this i32) (result i32)
   local.get $this
   i32.load
- )
- (func $field-initialization/SomeObject#set:a (param $this i32) (param $a i32)
-  local.get $this
-  local.get $a
-  i32.store
- )
- (func $field-initialization/SomeObject#set:b (param $this i32) (param $b i32)
-  local.get $this
-  local.get $b
-  i32.store offset=4
-  local.get $this
-  local.get $b
-  i32.const 0
-  call $~lib/rt/itcms/__link
  )
  (func $field-initialization/SomeObject#get:a (param $this i32) (result i32)
   local.get $this
@@ -2636,6 +2594,20 @@
   end
   i32.const 0
   return
+ )
+ (func $field-initialization/SomeObject#set:a (param $this i32) (param $a i32)
+  local.get $this
+  local.get $a
+  i32.store
+ )
+ (func $field-initialization/SomeObject#set:b (param $this i32) (param $b i32)
+  local.get $this
+  local.get $b
+  i32.store offset=4
+  local.get $this
+  local.get $b
+  i32.const 0
+  call $~lib/rt/itcms/__link
  )
  (func $field-initialization/SomeOtherObject#set:c (param $this i32) (param $c i32)
   local.get $this
@@ -3110,14 +3082,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/Value#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -3268,50 +3232,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/Nullable#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
- )
- (func $field-initialization/Value_Ctor#constructor (param $this i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $this
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 9
-   call $~lib/rt/itcms/__new
-   local.tee $this
-   i32.store
-  end
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/Value_Ctor#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -3373,14 +3293,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/Value_Ctor_Init#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3473,14 +3385,6 @@
   i32.store offset=4
   local.get $1
   i32.const 0
-  call $field-initialization/Ref_Ctor_Init#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $1
@@ -3540,42 +3444,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
   local.get $2
- )
- (func $field-initialization/Nullable_Ctor#constructor (param $this i32) (result i32)
-  (local $1 i32)
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.sub
-  global.set $~lib/memory/__stack_pointer
-  call $~stack_check
-  global.get $~lib/memory/__stack_pointer
-  i64.const 0
-  i64.store
-  local.get $this
-  i32.eqz
-  if
-   global.get $~lib/memory/__stack_pointer
-   i32.const 4
-   i32.const 15
-   call $~lib/rt/itcms/__new
-   local.tee $this
-   i32.store
-  end
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/Nullable_Ctor#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  i32.const 8
-  i32.add
-  global.set $~lib/memory/__stack_pointer
-  local.get $1
  )
  (func $field-initialization/Nullable_Init_Ctor#constructor (param $this i32) (result i32)
   (local $1 i32)
@@ -3646,14 +3514,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/Nullable_Ctor_Init#set:a
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3842,22 +3702,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/SomeObject#set:a
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/SomeObject#set:b
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -3992,14 +3836,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $field-initialization/SomeOtherObject#set:c
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -4028,14 +3864,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $field-initialization/Flow_Balanced#set:a
   local.get $cond
   if
    local.get $this
@@ -5041,14 +4869,6 @@
   i32.store offset=4
   local.get $34
   i32.const 0
-  call $field-initialization/Ref_InlineCtor_Init#set:a
-  local.get $32
-  local.set $34
-  global.get $~lib/memory/__stack_pointer
-  local.get $34
-  i32.store offset=4
-  local.get $34
-  i32.const 0
   i32.const 0
   call $~lib/arraybuffer/ArrayBuffer#constructor
   local.set $34
@@ -5151,5 +4971,61 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
   return
+ )
+ (func $field-initialization/Value_Ctor#constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.const 9
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store
+  end
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
+ )
+ (func $field-initialization/Nullable_Ctor#constructor (param $this i32) (result i32)
+  (local $1 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  call $~stack_check
+  global.get $~lib/memory/__stack_pointer
+  i32.const 0
+  i32.store
+  local.get $this
+  i32.eqz
+  if
+   global.get $~lib/memory/__stack_pointer
+   i32.const 4
+   i32.const 15
+   call $~lib/rt/itcms/__new
+   local.tee $this
+   i32.store
+  end
+  local.get $this
+  local.set $1
+  global.get $~lib/memory/__stack_pointer
+  i32.const 4
+  i32.add
+  global.set $~lib/memory/__stack_pointer
+  local.get $1
  )
 )

--- a/tests/compiler/field-initialization.release.wat
+++ b/tests/compiler/field-initialization.release.wat
@@ -563,7 +563,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$118
+   block $__inlined_func$~lib/util/string/compareImpl$107
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -583,7 +583,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$118
+      br_if $__inlined_func$~lib/util/string/compareImpl$107
       local.get $2
       i32.const 2
       i32.add
@@ -708,21 +708,6 @@
   call $~lib/object/Object#constructor
   local.tee $0
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
@@ -1144,7 +1129,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$241
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$229
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1168,7 +1153,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$241
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$229
    end
    local.get $0
    i32.load offset=8
@@ -1711,15 +1696,6 @@
   local.tee $0
   i32.store
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
-  local.get $0
-  i32.const 0
-  call $~lib/rt/itcms/__link
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -2178,12 +2154,6 @@
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
@@ -2355,15 +2325,6 @@
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
@@ -2384,7 +2345,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2392,8 +2353,8 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 9
@@ -2401,13 +2362,7 @@
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $1
@@ -2487,12 +2442,6 @@
    i32.const 11
    call $~lib/rt/itcms/__new
    local.tee $1
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -2600,15 +2549,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
    call $~lib/arraybuffer/ArrayBuffer#constructor
    local.set $2
    global.get $~lib/memory/__stack_pointer
@@ -2703,7 +2643,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.sub
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2711,8 +2651,8 @@
    i32.lt_s
    br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
+   i32.const 0
+   i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.const 15
@@ -2720,16 +2660,7 @@
    local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
+   i32.const 4
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $1
@@ -2823,15 +2754,6 @@
    call $~lib/rt/itcms/__new
    local.tee $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
@@ -3353,15 +3275,6 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
    call $~lib/arraybuffer/ArrayBuffer#constructor
    local.set $2
    global.get $~lib/memory/__stack_pointer
@@ -3437,15 +3350,6 @@
    call $~lib/rt/itcms/__new
    local.tee $1
    i32.store offset=136
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4

--- a/tests/compiler/infer-generic.debug.wat
+++ b/tests/compiler/infer-generic.debug.wat
@@ -2616,14 +2616,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $infer-generic/Ref#set:x
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer

--- a/tests/compiler/infer-generic.release.wat
+++ b/tests/compiler/infer-generic.release.wat
@@ -89,7 +89,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$138
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$137
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -113,7 +113,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$138
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$137
     end
     local.get $1
     i32.load offset=8
@@ -1585,12 +1585,6 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8

--- a/tests/compiler/inlining.debug.wat
+++ b/tests/compiler/inlining.debug.wat
@@ -2896,14 +2896,6 @@
   local.get $5
   i32.const 3
   call $inlining/Bar#set:d
-  local.get $this
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $inlining/Bar#set:e
   global.get $~lib/memory/__stack_pointer
   global.get $~lib/memory/__stack_pointer
   local.get $this
@@ -2929,14 +2921,6 @@
   local.get $5
   i32.const 1
   call $inlining/Baz#set:a
-  local.get $this|2
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $inlining/Baz#set:b
   local.get $this|2
   local.set $5
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/inlining.release.wat
+++ b/tests/compiler/inlining.release.wat
@@ -83,7 +83,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$125
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$123
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -107,7 +107,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$125
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$123
     end
     local.get $1
     i32.load offset=8
@@ -1810,12 +1810,6 @@
    i32.const 3
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=8
@@ -1835,12 +1829,6 @@
    local.get $0
    i32.const 1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store offset=4

--- a/tests/compiler/issues/1225.debug.wat
+++ b/tests/compiler/issues/1225.debug.wat
@@ -2480,22 +2480,6 @@
   local.get $2
   i32.store offset=4
   local.get $2
-  i32.const 0
-  call $issues/1225/X#set:normal
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $issues/1225/X#set:viaThis
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/issues/1225.release.wat
+++ b/tests/compiler/issues/1225.release.wat
@@ -75,7 +75,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$117
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -99,7 +99,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$117
     end
     local.get $1
     i32.load offset=8
@@ -1298,18 +1298,6 @@
   local.get $0
   i32.const 4
   i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4

--- a/tests/compiler/issues/1699.debug.wat
+++ b/tests/compiler/issues/1699.debug.wat
@@ -2548,38 +2548,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -2609,7 +2577,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -2618,7 +2586,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -2631,7 +2599,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:dataStart
@@ -2639,7 +2607,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:byteLength
@@ -2647,7 +2615,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<issues/1699/MultiAssignmentTest>#set:length_

--- a/tests/compiler/issues/1699.release.wat
+++ b/tests/compiler/issues/1699.release.wat
@@ -2,8 +2,8 @@
  (type $0 (func))
  (type $1 (func (param i32)))
  (type $2 (func (param i32 i32) (result i32)))
- (type $3 (func (param i32 i32 i32)))
- (type $4 (func (param i32 i32)))
+ (type $3 (func (param i32 i32)))
+ (type $4 (func (param i32 i32 i32)))
  (type $5 (func (result i32)))
  (type $6 (func (param i32 i32 i32 i32)))
  (type $7 (func (param i32 i32 i64)))
@@ -442,65 +442,6 @@
   global.set $~lib/memory/__stack_pointer
   local.get $0
  )
- (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $1
-  i32.eqz
-  if
-   return
-  end
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1216
-   i32.const 295
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/rt/itcms/white
-  local.get $1
-  i32.const 20
-  i32.sub
-  local.tee $1
-  i32.load offset=4
-  i32.const 3
-  i32.and
-  i32.eq
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   local.tee $0
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.tee $3
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $0
-    local.get $1
-    local.get $2
-    select
-    call $~lib/rt/itcms/Object#makeGray
-   else
-    global.get $~lib/rt/itcms/state
-    i32.const 1
-    i32.eq
-    local.get $3
-    i32.const 3
-    i32.eq
-    i32.and
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -893,6 +834,65 @@
   i32.or
   i32.store offset=4
  )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 295
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.tee $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.tee $0
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   local.tee $3
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $0
+    local.get $1
+    local.get $2
+    select
+    call $~lib/rt/itcms/Object#makeGray
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    local.get $3
+    i32.const 3
+    i32.eq
+    i32.and
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -916,7 +916,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$146
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$143
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -940,7 +940,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$146
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$143
    end
    local.get $0
    i32.load offset=8
@@ -1200,7 +1200,7 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
-     block $__inlined_func$~lib/rt/itcms/__renew$145
+     block $__inlined_func$~lib/rt/itcms/__renew$142
       i32.const 1073741820
       local.get $3
       i32.const 1
@@ -1243,7 +1243,7 @@
        i32.store offset=16
        local.get $3
        local.set $4
-       br $__inlined_func$~lib/rt/itcms/__renew$145
+       br $__inlined_func$~lib/rt/itcms/__renew$142
       end
       local.get $6
       local.get $5
@@ -2029,6 +2029,7 @@
   (local $0 i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
   memory.size
   i32.const 16
   i32.shl
@@ -2065,11 +2066,11 @@
   i32.const 28
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1740
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 28
@@ -2082,7 +2083,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1740
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2096,42 +2097,14 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
    i32.const 32
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $2
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $2
    i32.store offset=12
@@ -2144,19 +2117,19 @@
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    local.get $0
    local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    local.get $0
    i32.const 32
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    local.get $0
    i32.const 3
    i32.store offset=12
@@ -2209,7 +2182,7 @@
     global.get $~lib/memory/__stack_pointer
     i32.const 1740
     i32.lt_s
-    br_if $folding-inner1
+    br_if $folding-inner0
     global.get $~lib/memory/__stack_pointer
     i32.const 0
     i32.store

--- a/tests/compiler/issues/2322/index.debug.wat
+++ b/tests/compiler/issues/2322/index.debug.wat
@@ -2245,11 +2245,6 @@
   local.get $ptr
   return
  )
- (func $issues/2322/lib/Wrapper<i32>#set:v (param $this i32) (param $v i32)
-  local.get $this
-  local.get $v
-  i32.store
- )
  (func $issues/2322/lib/test<i32> (param $t i32)
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
@@ -2363,14 +2358,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $issues/2322/lib/Wrapper<i32>#set:v
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/issues/2322/index.release.wat
+++ b/tests/compiler/issues/2322/index.release.wat
@@ -71,7 +71,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$112
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$111
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -95,7 +95,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$112
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$111
     end
     local.get $1
     i32.load offset=8
@@ -1642,12 +1642,6 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8

--- a/tests/compiler/object-literal.debug.wat
+++ b/tests/compiler/object-literal.debug.wat
@@ -5,17 +5,14 @@
  (type $3 (func))
  (type $4 (func (param i32 i32) (result i32)))
  (type $5 (func (param i32 i32 i32)))
- (type $6 (func (param i32 f64)))
- (type $7 (func (param i32) (result f64)))
- (type $8 (func (param i32 i64)))
- (type $9 (func (param i32) (result i64)))
- (type $10 (func (param i32 i32 i32 i32)))
- (type $11 (func (param i32 i32 i64) (result i32)))
- (type $12 (func (result i32)))
- (type $13 (func (param i32 i32 i32 i32 i32) (result i32)))
- (type $14 (func (param i32 f32)))
- (type $15 (func (param i32) (result f32)))
- (type $16 (func (param i32 i32 i32) (result i32)))
+ (type $6 (func (param i32) (result f64)))
+ (type $7 (func (param i32) (result i64)))
+ (type $8 (func (param i32 i32 i32 i32)))
+ (type $9 (func (param i32 i32 i64) (result i32)))
+ (type $10 (func (result i32)))
+ (type $11 (func (param i32 i32 i32 i32 i32) (result i32)))
+ (type $12 (func (param i32) (result f32)))
+ (type $13 (func (param i32 i32 i32) (result i32)))
  (import "env" "abort" (func $~lib/builtins/abort (param i32 i32 i32 i32)))
  (global $~lib/rt/itcms/white (mut i32) (i32.const 0))
  (global $~lib/rt/itcms/iter (mut i32) (i32.const 0))
@@ -2501,76 +2498,6 @@
   local.get $this
   i32.load offset=4
  )
- (func $object-literal/OmittedTypes#set:int32 (param $this i32) (param $int32 i32)
-  local.get $this
-  local.get $int32
-  i32.store
- )
- (func $object-literal/OmittedTypes#set:uint32 (param $this i32) (param $uint32 i32)
-  local.get $this
-  local.get $uint32
-  i32.store offset=4
- )
- (func $object-literal/OmittedTypes#set:int64 (param $this i32) (param $int64 i64)
-  local.get $this
-  local.get $int64
-  i64.store offset=8
- )
- (func $object-literal/OmittedTypes#set:uint64 (param $this i32) (param $uint64 i64)
-  local.get $this
-  local.get $uint64
-  i64.store offset=16
- )
- (func $object-literal/OmittedTypes#set:float32 (param $this i32) (param $float32 f32)
-  local.get $this
-  local.get $float32
-  f32.store offset=24
- )
- (func $object-literal/OmittedTypes#set:float64 (param $this i32) (param $float64 f64)
-  local.get $this
-  local.get $float64
-  f64.store offset=32
- )
- (func $object-literal/OmittedTypes#set:int8 (param $this i32) (param $int8 i32)
-  local.get $this
-  local.get $int8
-  i32.store8 offset=40
- )
- (func $object-literal/OmittedTypes#set:uint8 (param $this i32) (param $uint8 i32)
-  local.get $this
-  local.get $uint8
-  i32.store8 offset=41
- )
- (func $object-literal/OmittedTypes#set:int16 (param $this i32) (param $int16 i32)
-  local.get $this
-  local.get $int16
-  i32.store16 offset=42
- )
- (func $object-literal/OmittedTypes#set:uint16 (param $this i32) (param $uint16 i32)
-  local.get $this
-  local.get $uint16
-  i32.store16 offset=44
- )
- (func $object-literal/OmittedTypes#set:intsize (param $this i32) (param $intsize i32)
-  local.get $this
-  local.get $intsize
-  i32.store offset=48
- )
- (func $object-literal/OmittedTypes#set:uintsize (param $this i32) (param $uintsize i32)
-  local.get $this
-  local.get $uintsize
-  i32.store offset=52
- )
- (func $object-literal/OmittedTypes#set:alias (param $this i32) (param $alias f64)
-  local.get $this
-  local.get $alias
-  f64.store offset=56
- )
- (func $object-literal/OmittedTypes#set:isTrue (param $this i32) (param $isTrue i32)
-  local.get $this
-  local.get $isTrue
-  i32.store8 offset=64
- )
  (func $object-literal/OmittedTypes#get:int32 (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -2641,11 +2568,6 @@
   i32.const 0
   call $~lib/rt/itcms/__link
  )
- (func $object-literal/MixedOmitted#set:anotherSimpleType (param $this i32) (param $anotherSimpleType f64)
-  local.get $this
-  local.get $anotherSimpleType
-  f64.store offset=8
- )
  (func $object-literal/MixedOmitted#get:simpleType (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -2675,65 +2597,6 @@
   local.get $baz
   i32.const 0
   call $~lib/rt/itcms/__link
- )
- (func $object-literal/OmittedFoo#set:quux (param $this i32) (param $quux i32)
-  local.get $this
-  local.get $quux
-  i32.store offset=8
-  local.get $this
-  local.get $quux
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $object-literal/OmittedFoo#set:quuz (param $this i32) (param $quuz i32)
-  local.get $this
-  local.get $quuz
-  i32.store offset=12
-  local.get $this
-  local.get $quuz
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $object-literal/OmittedFoo#set:corge (param $this i32) (param $corge i32)
-  local.get $this
-  local.get $corge
-  i32.store offset=16
-  local.get $this
-  local.get $corge
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $object-literal/OmittedFoo#set:grault (param $this i32) (param $grault i32)
-  local.get $this
-  local.get $grault
-  i32.store offset=20
-  local.get $this
-  local.get $grault
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $object-literal/OmittedFoo#set:garply (param $this i32) (param $garply i32)
-  local.get $this
-  local.get $garply
-  i32.store offset=24
-  local.get $this
-  local.get $garply
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $object-literal/OmittedFoo#set:waldo (param $this i32) (param $waldo i32)
-  local.get $this
-  local.get $waldo
-  i32.store offset=28
-  local.get $this
-  local.get $waldo
-  i32.const 0
-  call $~lib/rt/itcms/__link
- )
- (func $object-literal/OmittedFoo#set:fred (param $this i32) (param $fred i32)
-  local.get $this
-  local.get $fred
-  i32.store offset=32
  )
  (func $object-literal/OmittedFoo#set:qux (param $this i32) (param $qux i32)
   local.get $this
@@ -2997,22 +2860,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/Managed#set:bar
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/Managed#set:baz
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -3403,118 +3250,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:int32
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:uint32
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $object-literal/OmittedTypes#set:int64
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $object-literal/OmittedTypes#set:uint64
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f32.const 0
-  call $object-literal/OmittedTypes#set:float32
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $object-literal/OmittedTypes#set:float64
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:int8
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:uint8
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:int16
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:uint16
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:intsize
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:uintsize
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $object-literal/OmittedTypes#set:alias
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedTypes#set:isTrue
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -3828,30 +3563,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/MixedOmitted#set:simpleType
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/MixedOmitted#set:complexType
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  f64.const 0
-  call $object-literal/MixedOmitted#set:anotherSimpleType
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -3977,62 +3688,6 @@
   local.get $1
   i32.const 672
   call $object-literal/OmittedFoo#set:baz
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedFoo#set:quux
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedFoo#set:quuz
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedFoo#set:corge
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedFoo#set:grault
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedFoo#set:garply
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedFoo#set:waldo
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $object-literal/OmittedFoo#set:fred
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/object-literal.release.wat
+++ b/tests/compiler/object-literal.release.wat
@@ -72,60 +72,6 @@
    global.set $~lib/rt/itcms/visitCount
   end
  )
- (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
-  local.get $1
-  i32.eqz
-  if
-   return
-  end
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1104
-   i32.const 295
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/rt/itcms/white
-  local.get $1
-  i32.const 20
-  i32.sub
-  local.tee $1
-  i32.load offset=4
-  i32.const 3
-  i32.and
-  i32.eq
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.tee $0
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
-   else
-    global.get $~lib/rt/itcms/state
-    i32.const 1
-    i32.eq
-    local.get $0
-    i32.const 3
-    i32.eq
-    i32.and
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
- )
  (func $~lib/string/String.__eq (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
@@ -239,7 +185,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$83
+   block $__inlined_func$~lib/util/string/compareImpl$81
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -259,7 +205,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$83
+      br_if $__inlined_func$~lib/util/string/compareImpl$81
       local.get $2
       i32.const 2
       i32.add
@@ -614,6 +560,60 @@
    global.set $~lib/rt/itcms/state
   end
   i32.const 0
+ )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1104
+   i32.const 295
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.tee $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   local.tee $0
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $1
+    call $~lib/rt/itcms/Object#makeGray
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    local.get $0
+    i32.const 3
+    i32.eq
+    i32.and
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
  )
  (func $~lib/object/Object#constructor (param $0 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
@@ -1145,7 +1145,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$205
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$181
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1169,7 +1169,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$205
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$181
    end
    local.get $0
    i32.load offset=8
@@ -1877,11 +1877,11 @@
   i32.const 24
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.const 24
@@ -1926,7 +1926,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -1944,21 +1944,6 @@
    call $~lib/object/Object#constructor
    local.tee $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
@@ -1990,7 +1975,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2059,7 +2044,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2085,7 +2070,7 @@
    i32.const 1
    i32.shl
    local.set $3
-   block $__inlined_func$~lib/string/String#substring$210
+   block $__inlined_func$~lib/string/String#substring$186
     local.get $2
     i32.const 0
     local.get $2
@@ -2106,7 +2091,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1568
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$210
+     br $__inlined_func$~lib/string/String#substring$186
     end
     local.get $3
     i32.eqz
@@ -2123,7 +2108,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1056
      local.set $0
-     br $__inlined_func$~lib/string/String#substring$210
+     br $__inlined_func$~lib/string/String#substring$186
     end
     global.get $~lib/memory/__stack_pointer
     local.get $2
@@ -2155,7 +2140,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
@@ -2202,7 +2187,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2210,152 +2195,68 @@
    i32.const 65
    i32.const 5
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    call $~lib/object/Object#constructor
-   local.tee $0
+   local.tee $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i64.const 0
-   i64.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   f32.const 0
-   f32.store offset=24
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   f64.const 0
-   f64.store offset=32
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store8 offset=40
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store8 offset=41
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store16 offset=42
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store16 offset=44
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=48
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=52
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   f64.const 0
-   f64.store offset=56
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store8 offset=64
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=12
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=4
-   local.get $0
+   local.get $1
    i64.const 0
    i64.store offset=8
-   local.get $0
+   local.get $1
    i64.const 0
    i64.store offset=16
-   local.get $0
+   local.get $1
    f32.const 0
    f32.store offset=24
-   local.get $0
+   local.get $1
    f64.const 0
    f64.store offset=32
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store8 offset=40
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store8 offset=41
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store16 offset=42
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store16 offset=44
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=48
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=52
-   local.get $0
+   local.get $1
    f64.const 0
    f64.store offset=56
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store8 offset=64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $object-literal/testOmittedTypes
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -2365,7 +2266,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2383,27 +2284,6 @@
    call $~lib/object/Object#constructor
    local.tee $1
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   f64.const 0
-   f64.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
@@ -2438,7 +2318,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2502,7 +2382,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -2510,131 +2390,71 @@
    i32.const 40
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    call $~lib/object/Object#constructor
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1664
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1664
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1696
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1696
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=8
-   local.get $0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=12
-   local.get $0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=16
-   local.get $0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=20
-   local.get $0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=24
-   local.get $0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=28
-   local.get $0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=32
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const -1
    i32.store offset=36
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=20
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=8
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=12
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=16
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=20
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=24
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=28
-   local.get $0
+   local.get $1
    i32.const 0
    i32.store offset=32
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $object-literal/testOmittedFoo
    i32.const 34516
    global.set $~lib/memory/__stack_pointer

--- a/tests/compiler/resolve-access.debug.wat
+++ b/tests/compiler/resolve-access.debug.wat
@@ -3215,14 +3215,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i64.const 0
-  call $resolve-access/Container#set:foo
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer

--- a/tests/compiler/resolve-access.release.wat
+++ b/tests/compiler/resolve-access.release.wat
@@ -909,7 +909,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$143
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$142
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -933,7 +933,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$143
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$142
    end
    local.get $0
    i32.load offset=8
@@ -1759,12 +1759,6 @@
    global.set $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i64.const 0
-   i64.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add

--- a/tests/compiler/resolve-elementaccess.debug.wat
+++ b/tests/compiler/resolve-elementaccess.debug.wat
@@ -4436,30 +4436,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -4481,7 +4457,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -4490,7 +4466,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -4503,7 +4479,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -4511,7 +4487,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength

--- a/tests/compiler/resolve-elementaccess.release.wat
+++ b/tests/compiler/resolve-elementaccess.release.wat
@@ -2,8 +2,8 @@
  (type $0 (func (param i32 i32) (result i32)))
  (type $1 (func))
  (type $2 (func (param i32)))
- (type $3 (func (param i32 i32)))
- (type $4 (func (param i32 i32 i32)))
+ (type $3 (func (param i32 i32 i32)))
+ (type $4 (func (param i32 i32)))
  (type $5 (func (param i32 i32 i32 i32)))
  (type $6 (func (param i32 i32) (result f32)))
  (type $7 (func (param i32 i32 f32)))
@@ -640,7 +640,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$97
+   block $__inlined_func$~lib/util/string/compareImpl$95
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -660,7 +660,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$97
+      br_if $__inlined_func$~lib/util/string/compareImpl$95
       local.get $2
       i32.const 2
       i32.add
@@ -1308,7 +1308,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$153
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$151
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1332,7 +1332,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$153
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$151
    end
    local.get $0
    i32.load offset=8
@@ -1964,63 +1964,10 @@
    end
   end
  )
- (func $~lib/arraybuffer/ArrayBufferView#set:buffer (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $1
-  if
-   local.get $0
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1232
-    i32.const 295
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/rt/itcms/white
-   local.get $1
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.eq
-   if
-    local.get $0
-    i32.const 20
-    i32.sub
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.tee $0
-    global.get $~lib/rt/itcms/white
-    i32.eqz
-    i32.eq
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-     local.get $0
-     i32.const 3
-     i32.eq
-     i32.and
-     if
-      local.get $1
-      call $~lib/rt/itcms/Object#makeGray
-     end
-    end
-   end
-  end
- )
  (func $~lib/arraybuffer/ArrayBufferView#constructor (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 16
   i32.sub
@@ -2052,24 +1999,6 @@
    local.tee $0
    i32.store
   end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   i32.const 1073741820
   local.get $1
   i32.shr_u
@@ -2087,31 +2016,81 @@
   i32.const 2
   local.get $1
   i32.shl
-  local.tee $2
+  local.tee $1
   i32.const 1
   call $~lib/rt/itcms/__new
-  local.tee $1
+  local.tee $3
+  i32.store offset=4
+  global.get $~lib/memory/__stack_pointer
+  local.get $0
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
+  local.get $3
   i32.store offset=12
   local.get $0
-  local.get $1
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
+  local.get $3
+  i32.store
+  local.get $3
+  if
+   local.get $0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1232
+    i32.const 295
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/rt/itcms/white
+   local.get $3
+   i32.const 20
+   i32.sub
+   local.tee $4
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.eq
+   if
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    local.tee $2
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+    i32.eq
+    if
+     local.get $4
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+     local.get $2
+     i32.const 3
+     i32.eq
+     i32.and
+     if
+      local.get $4
+      call $~lib/rt/itcms/Object#makeGray
+     end
+    end
+   end
+  end
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   local.get $0
-  local.get $1
+  local.get $3
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   local.get $0
-  local.get $2
+  local.get $1
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   i32.const 16

--- a/tests/compiler/return-unreachable.debug.wat
+++ b/tests/compiler/return-unreachable.debug.wat
@@ -2484,38 +2484,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -2545,7 +2513,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -2554,7 +2522,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -2567,7 +2535,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
@@ -2575,7 +2543,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
@@ -2583,7 +2551,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i32>#set:length_

--- a/tests/compiler/return-unreachable.release.wat
+++ b/tests/compiler/return-unreachable.release.wat
@@ -1,7 +1,7 @@
 (module
  (type $0 (func (param i32)))
- (type $1 (func (param i32 i32)))
- (type $2 (func))
+ (type $1 (func))
+ (type $2 (func (param i32 i32)))
  (type $3 (func (param i32 i32) (result i32)))
  (type $4 (func (param i32 i32 i32 i32)))
  (type $5 (func (param i32 i32 i64)))
@@ -477,7 +477,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$121
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$118
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -501,7 +501,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$121
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$118
    end
    local.get $0
    i32.load offset=8
@@ -1325,61 +1325,6 @@
   memory.fill
   local.get $1
  )
- (func $~lib/array/Array<i32>#set:buffer (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $1
-  if
-   local.get $0
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1216
-    i32.const 295
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/rt/itcms/white
-   local.get $1
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.eq
-   if
-    local.get $0
-    i32.const 20
-    i32.sub
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.tee $0
-    global.get $~lib/rt/itcms/white
-    i32.eqz
-    i32.eq
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-     local.get $0
-     i32.const 3
-     i32.eq
-     i32.and
-     if
-      local.get $1
-      call $~lib/rt/itcms/Object#makeGray
-     end
-    end
-   end
-  end
- )
  (func $~start
   memory.size
   i32.const 16
@@ -1677,6 +1622,8 @@
  (func $return-unreachable/test (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
   i32.sub
@@ -1711,59 +1658,85 @@
    local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   call $~lib/array/Array<i32>#set:buffer
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
    i32.const 400
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $1
-   i32.store offset=8
+   i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=12
    local.get $0
    local.get $1
-   call $~lib/array/Array<i32>#set:buffer
+   i32.store
+   local.get $1
+   if
+    local.get $0
+    i32.eqz
+    if
+     i32.const 0
+     i32.const 1216
+     i32.const 295
+     i32.const 14
+     call $~lib/builtins/abort
+     unreachable
+    end
+    global.get $~lib/rt/itcms/white
+    local.get $1
+    i32.const 20
+    i32.sub
+    local.tee $2
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    i32.eq
+    if
+     local.get $0
+     i32.const 20
+     i32.sub
+     i32.load offset=4
+     i32.const 3
+     i32.and
+     local.tee $4
+     global.get $~lib/rt/itcms/white
+     i32.eqz
+     i32.eq
+     if
+      local.get $2
+      call $~lib/rt/itcms/Object#makeGray
+     else
+      global.get $~lib/rt/itcms/state
+      i32.const 1
+      i32.eq
+      local.get $4
+      i32.const 3
+      i32.eq
+      i32.and
+      if
+       local.get $2
+       call $~lib/rt/itcms/Object#makeGray
+      end
+     end
+    end
+   end
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    local.get $0
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    local.get $0
    i32.const 400
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $0
-   i32.store offset=4
+   i32.store offset=8
    local.get $0
    i32.const 100
    i32.store offset=12

--- a/tests/compiler/rt/issue-2719.debug.wat
+++ b/tests/compiler/rt/issue-2719.debug.wat
@@ -2245,11 +2245,6 @@
   local.get $ptr
   return
  )
- (func $rt/issue-2719/issue2719_T#set:v (param $this i32) (param $v i32)
-  local.get $this
-  local.get $v
-  i32.store
- )
  (func $~lib/rt/itcms/__collect
   i32.const 0
   drop
@@ -2295,6 +2290,11 @@
   drop
   i32.const 0
   drop
+ )
+ (func $rt/issue-2719/issue2719_T#set:v (param $this i32) (param $v i32)
+  local.get $this
+  local.get $v
+  i32.store
  )
  (func $rt/issue-2719/issue2719_T#get:v (param $this i32) (result i32)
   local.get $this
@@ -2395,14 +2395,6 @@
   call $~lib/object/Object#constructor
   local.tee $this
   i32.store
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $rt/issue-2719/issue2719_T#set:v
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/rt/issue-2719.release.wat
+++ b/tests/compiler/rt/issue-2719.release.wat
@@ -332,7 +332,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$119
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$118
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -356,7 +356,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$119
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$118
     end
     local.get $1
     i32.load offset=8
@@ -917,12 +917,6 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    local.get $0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8

--- a/tests/compiler/std/array.debug.wat
+++ b/tests/compiler/std/array.debug.wat
@@ -9477,38 +9477,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -9538,7 +9506,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -9547,7 +9515,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -9560,7 +9528,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
@@ -9568,7 +9536,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
@@ -9576,7 +9544,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i32>#set:length_
@@ -9648,30 +9616,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -9693,7 +9637,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -9702,7 +9646,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -9715,7 +9659,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -9723,7 +9667,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
@@ -15617,22 +15561,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $std/array/Dim#set:height
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $std/array/Dim#set:width
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -20234,38 +20162,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/array/Array<i32>>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/array/Array<i32>>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/array/Array<i32>>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/array/Array<i32>>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -20295,7 +20191,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -20304,7 +20200,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -20317,7 +20213,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<~lib/array/Array<i32>>#set:dataStart
@@ -20325,7 +20221,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<~lib/array/Array<i32>>#set:byteLength
@@ -20333,7 +20229,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<~lib/array/Array<i32>>#set:length_
@@ -21987,38 +21883,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<std/array/Proxy<i32>>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<std/array/Proxy<i32>>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<std/array/Proxy<i32>>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<std/array/Proxy<i32>>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -22048,7 +21912,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -22057,7 +21921,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -22070,7 +21934,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<std/array/Proxy<i32>>#set:dataStart
@@ -22078,7 +21942,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<std/array/Proxy<i32>>#set:byteLength
@@ -22086,7 +21950,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<std/array/Proxy<i32>>#set:length_
@@ -25619,38 +25483,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<~lib/string/String>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -25680,7 +25512,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -25689,7 +25521,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -25702,7 +25534,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<~lib/string/String>#set:dataStart
@@ -25710,7 +25542,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<~lib/string/String>#set:byteLength
@@ -25718,7 +25550,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<~lib/string/String>#set:length_

--- a/tests/compiler/std/array.release.wat
+++ b/tests/compiler/std/array.release.wat
@@ -11,9 +11,9 @@
  (type $9 (func (param i32 i32 i32 i32)))
  (type $10 (func (param i32 i32 i32 i32 i32)))
  (type $11 (func))
- (type $12 (func (result f64)))
- (type $13 (func (param i32 i32 i32 i32 i32 i32)))
- (type $14 (func (result i32)))
+ (type $12 (func (result i32)))
+ (type $13 (func (result f64)))
+ (type $14 (func (param i32 i32 i32 i32 i32 i32)))
  (type $15 (func (param i32 i64) (result i32)))
  (type $16 (func (param i32 f64) (result i32)))
  (type $17 (func (param i32 i32 i32) (result f32)))
@@ -1399,18 +1399,6 @@
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
@@ -1423,65 +1411,6 @@
   i32.const 1
   call $~lib/builtins/abort
   unreachable
- )
- (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
-  (local $3 i32)
-  local.get $1
-  i32.eqz
-  if
-   return
-  end
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1216
-   i32.const 295
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/rt/itcms/white
-  local.get $1
-  i32.const 20
-  i32.sub
-  local.tee $1
-  i32.load offset=4
-  i32.const 3
-  i32.and
-  i32.eq
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   local.tee $0
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.tee $3
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $0
-    local.get $1
-    local.get $2
-    select
-    call $~lib/rt/itcms/Object#makeGray
-   else
-    global.get $~lib/rt/itcms/state
-    i32.const 1
-    i32.eq
-    local.get $3
-    i32.const 3
-    i32.eq
-    i32.and
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
  )
  (func $~lib/rt/itcms/__visit (param $0 i32)
   local.get $0
@@ -1554,7 +1483,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$740
+   block $__inlined_func$~lib/string/String#concat$720
     local.get $1
     i32.const 20
     i32.sub
@@ -1573,7 +1502,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$740
+     br $__inlined_func$~lib/string/String#concat$720
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -1754,6 +1683,65 @@
   i32.const 8
   i32.add
   global.set $~lib/memory/__stack_pointer
+ )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1216
+   i32.const 295
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.tee $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   local.tee $0
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   local.tee $3
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $0
+    local.get $1
+    local.get $2
+    select
+    call $~lib/rt/itcms/Object#makeGray
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    local.get $3
+    i32.const 3
+    i32.eq
+    i32.and
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
  )
  (func $std/array/Ref#constructor (param $0 i32) (result i32)
   (local $1 i32)
@@ -3765,7 +3753,7 @@
     select
     local.set $1
    end
-   block $__inlined_func$~lib/rt/itcms/__renew$657
+   block $__inlined_func$~lib/rt/itcms/__renew$636
     local.get $3
     i32.const 20
     i32.sub
@@ -3783,7 +3771,7 @@
      i32.store offset=16
      local.get $3
      local.set $2
-     br $__inlined_func$~lib/rt/itcms/__renew$657
+     br $__inlined_func$~lib/rt/itcms/__renew$636
     end
     local.get $1
     local.get $4
@@ -4256,34 +4244,6 @@
   call $~lib/rt/itcms/__new
   local.tee $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store
-  local.get $1
-  i32.const 0
-  i32.const 0
-  call $~lib/rt/itcms/__link
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=12
   local.get $0
   i32.const 268435455
   i32.gt_u
@@ -4308,10 +4268,10 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $2
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store offset=12
@@ -4324,19 +4284,19 @@
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   local.get $1
   local.get $2
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   local.get $1
   local.get $3
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   local.get $1
   local.get $0
   i32.store offset=12
@@ -4401,7 +4361,7 @@
    local.get $2
    call $~lib/array/Array<u8>#get:length
    local.set $3
-   block $__inlined_func$std/array/isSorted<i32>$662 (result i32)
+   block $__inlined_func$std/array/isSorted<i32>$641 (result i32)
     loop $for-loop|0
      local.get $0
      local.get $3
@@ -4437,7 +4397,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<i32>$662
+       br $__inlined_func$std/array/isSorted<i32>$641
       end
       local.get $0
       i32.const 1
@@ -5034,7 +4994,7 @@
   i32.lt_s
   select
   local.set $0
-  block $__inlined_func$~lib/util/bytes/FILL<u32>$139
+  block $__inlined_func$~lib/util/bytes/FILL<u32>$132
    local.get $1
    i32.eqz
    local.get $1
@@ -5059,7 +5019,7 @@
      i32.shl
      memory.fill
     end
-    br $__inlined_func$~lib/util/bytes/FILL<u32>$139
+    br $__inlined_func$~lib/util/bytes/FILL<u32>$132
    end
    loop $for-loop|0
     local.get $0
@@ -5613,7 +5573,7 @@
   i32.lt_s
   select
   local.set $0
-  block $__inlined_func$~lib/util/bytes/FILL<f32>$148
+  block $__inlined_func$~lib/util/bytes/FILL<f32>$141
    local.get $1
    i32.reinterpret_f32
    i32.eqz
@@ -5635,7 +5595,7 @@
      i32.shl
      memory.fill
     end
-    br $__inlined_func$~lib/util/bytes/FILL<f32>$148
+    br $__inlined_func$~lib/util/bytes/FILL<f32>$141
    end
    loop $for-loop|0
     local.get $0
@@ -7057,7 +7017,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$735
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$715
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -7081,7 +7041,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$735
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$715
    end
    local.get $0
    i32.load offset=8
@@ -7832,7 +7792,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$747
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$727
     local.get $0
     i32.const 1
     i32.sub
@@ -7846,7 +7806,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$747
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$727
     end
     local.get $6
     i32.eqz
@@ -7859,7 +7819,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$747
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$727
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -7952,7 +7912,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$747
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$727
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -8650,7 +8610,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$742
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$722
     local.get $0
     i32.const 1
     i32.sub
@@ -8664,7 +8624,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$722
     end
     local.get $7
     i32.eqz
@@ -8677,7 +8637,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$722
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -8776,7 +8736,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$742
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$722
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -8912,7 +8872,7 @@
    local.get $5
    call $~lib/array/Array<u8>#get:length
    local.set $4
-   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$664 (result i32)
+   block $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$644 (result i32)
     loop $for-loop|0
      local.get $1
      local.get $4
@@ -8958,7 +8918,7 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$664
+       br $__inlined_func$std/array/isSorted<~lib/array/Array<i32>>$644
       end
       local.get $1
       i32.const 1
@@ -12286,7 +12246,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$743
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$723
     local.get $0
     i32.const 1
     i32.sub
@@ -12300,7 +12260,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$723
     end
     local.get $7
     i32.eqz
@@ -12313,7 +12273,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$723
     end
     global.get $~lib/memory/__stack_pointer
     local.get $1
@@ -12412,7 +12372,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$743
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$723
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -12864,7 +12824,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$744
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$724
     local.get $0
     i32.const 1
     i32.sub
@@ -12878,7 +12838,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$744
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$724
     end
     local.get $6
     i32.eqz
@@ -12891,7 +12851,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$744
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$724
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -12984,7 +12944,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$744
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$724
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -13690,7 +13650,7 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
-     block $__inlined_func$~lib/util/number/utoa64$485
+     block $__inlined_func$~lib/util/number/utoa64$464
       local.get $3
       i64.eqz
       if
@@ -13700,7 +13660,7 @@
        global.set $~lib/memory/__stack_pointer
        i32.const 7712
        local.set $1
-       br $__inlined_func$~lib/util/number/utoa64$485
+       br $__inlined_func$~lib/util/number/utoa64$464
       end
       local.get $3
       i64.const 4294967295
@@ -17175,6 +17135,243 @@
   i32.store16
   local.get $5
  )
+ (func $std/array/createRandomStringArray (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (local $2 i32)
+  (local $3 i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  global.get $~lib/memory/__stack_pointer
+  i32.const 12
+  i32.sub
+  global.set $~lib/memory/__stack_pointer
+  block $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16192
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.const 16
+   call $~lib/rt/itcms/__new
+   local.tee $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1600
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $2
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=12
+   local.get $0
+   local.get $2
+   i32.store
+   local.get $0
+   local.get $2
+   i32.const 0
+   call $~lib/rt/itcms/__link
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $2
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.const 1600
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.const 400
+   i32.store offset=12
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   loop $for-loop|0
+    local.get $3
+    i32.const 400
+    i32.lt_s
+    if
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=4
+     call $~lib/math/NativeMath.random
+     f64.const 32
+     f64.mul
+     i32.trunc_sat_f64_s
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     i32.const 12
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16192
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i32.const 0
+     i32.store offset=8
+     i32.const 11568
+     local.set $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 11568
+     i32.store
+     i32.const 0
+     local.set $4
+     loop $for-loop|00
+      local.get $4
+      local.get $6
+      i32.lt_s
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $2
+       i32.store offset=4
+       global.get $~lib/memory/__stack_pointer
+       call $~lib/math/NativeMath.random
+       i32.const 10028
+       i32.load
+       i32.const 1
+       i32.shr_u
+       f64.convert_i32_s
+       f64.mul
+       f64.floor
+       i32.trunc_sat_f64_s
+       local.set $5
+       global.get $~lib/memory/__stack_pointer
+       i32.const 8
+       i32.sub
+       global.set $~lib/memory/__stack_pointer
+       global.get $~lib/memory/__stack_pointer
+       i32.const 16192
+       i32.lt_s
+       br_if $folding-inner0
+       global.get $~lib/memory/__stack_pointer
+       i64.const 0
+       i64.store
+       global.get $~lib/memory/__stack_pointer
+       i32.const 10032
+       i32.store
+       block $__inlined_func$~lib/string/String#charAt$721
+        local.get $5
+        i32.const 10028
+        i32.load
+        i32.const 1
+        i32.shr_u
+        i32.ge_u
+        if
+         global.get $~lib/memory/__stack_pointer
+         i32.const 8
+         i32.add
+         global.set $~lib/memory/__stack_pointer
+         i32.const 11568
+         local.set $1
+         br $__inlined_func$~lib/string/String#charAt$721
+        end
+        global.get $~lib/memory/__stack_pointer
+        i32.const 2
+        i32.const 2
+        call $~lib/rt/itcms/__new
+        local.tee $1
+        i32.store offset=4
+        local.get $1
+        local.get $5
+        i32.const 1
+        i32.shl
+        i32.const 10032
+        i32.add
+        i32.load16_u
+        i32.store16
+        global.get $~lib/memory/__stack_pointer
+        i32.const 8
+        i32.add
+        global.set $~lib/memory/__stack_pointer
+       end
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.store offset=8
+       local.get $2
+       local.get $1
+       call $~lib/string/String.__concat
+       local.tee $2
+       i32.store
+       local.get $4
+       i32.const 1
+       i32.add
+       local.set $4
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     i32.const 12
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store offset=8
+     local.get $0
+     local.get $3
+     local.get $2
+     call $~lib/array/Array<std/array/Ref>#__set
+     local.get $3
+     i32.const 1
+     i32.add
+     local.set $3
+     br $for-loop|0
+    end
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   return
+  end
+  i32.const 48992
+  i32.const 49040
+  i32.const 1
+  i32.const 1
+  call $~lib/builtins/abort
+  unreachable
+ )
  (func $start:std/array~anonymous|54 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 4
@@ -17852,6 +18049,7 @@
   (local $13 i32)
   (local $14 i32)
   (local $15 i32)
+  (local $16 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 444
   i32.sub
@@ -17902,9 +18100,9 @@
    global.set $std/array/arr
    i32.const 0
    call $std/array/Ref#constructor
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -17921,11 +18119,11 @@
    i32.const 12
    i32.const 6
    call $~lib/rt/itcms/__new
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 16
@@ -17941,87 +18139,65 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store offset=8
-   local.get $0
+   local.get $1
    i32.eqz
    if
     global.get $~lib/memory/__stack_pointer
     i32.const 12
     i32.const 3
     call $~lib/rt/itcms/__new
-    local.tee $0
+    local.tee $1
     i32.store
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store
-   local.get $0
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 1
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $10
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $1
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $10
    i32.store offset=12
-   local.get $0
+   local.get $1
    local.get $10
    i32.store
-   local.get $0
+   local.get $1
    local.get $10
    i32.const 0
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
+   local.get $1
+   i32.store offset=8
+   local.get $1
    local.get $10
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
+   local.get $1
+   i32.store offset=8
+   local.get $1
    i32.const 1
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.eqz
    if
     i32.const 0
@@ -18037,18 +18213,18 @@
    i32.const 7
    i32.const 1696
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 1
    i32.const 3
    call $~lib/array/Array<u8>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 0
@@ -18059,7 +18235,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u8>
    i32.eqz
@@ -18072,16 +18248,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/array/Array<u8>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 0
@@ -18092,7 +18268,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u8>
    i32.eqz
@@ -18105,15 +18281,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 0
    i32.const -3
    call $~lib/array/Array<u8>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 0
@@ -18124,7 +18300,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u8>
    i32.eqz
@@ -18137,16 +18313,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const -2
    call $~lib/array/Array<u8>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 0
@@ -18157,7 +18333,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u8>
    i32.eqz
@@ -18170,15 +18346,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    i32.const 0
    call $~lib/array/Array<u8>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 0
@@ -18189,7 +18365,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u8>
    i32.eqz
@@ -18202,16 +18378,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const -1
    i32.const 0
    call $~lib/array/Array<u8>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 0
@@ -18222,7 +18398,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u8>
    i32.eqz
@@ -18240,18 +18416,18 @@
    i32.const 8
    i32.const 1920
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 1
    i32.const 3
    call $~lib/array/Array<u32>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18262,7 +18438,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u32>
    i32.eqz
@@ -18275,16 +18451,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/array/Array<u32>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18295,7 +18471,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u32>
    i32.eqz
@@ -18308,15 +18484,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 0
    i32.const -3
    call $~lib/array/Array<u32>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18327,7 +18503,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u32>
    i32.eqz
@@ -18340,16 +18516,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const -2
    call $~lib/array/Array<u32>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18360,7 +18536,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u32>
    i32.eqz
@@ -18373,15 +18549,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    i32.const 0
    call $~lib/array/Array<u32>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18392,7 +18568,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u32>
    i32.eqz
@@ -18405,16 +18581,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const -1
    i32.const 0
    call $~lib/array/Array<u32>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18425,7 +18601,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<u32>
    i32.eqz
@@ -18443,18 +18619,18 @@
    i32.const 9
    i32.const 2256
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    f32.const 1
    i32.const 1
    i32.const 3
    call $~lib/array/Array<f32>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18465,7 +18641,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<f32>
    i32.eqz
@@ -18478,16 +18654,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    f32.const 0
    i32.const 0
    call $~lib/array/Array<f32>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18498,7 +18674,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<f32>
    i32.eqz
@@ -18511,15 +18687,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    f32.const 1
    i32.const 0
    i32.const -3
    call $~lib/array/Array<f32>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18530,7 +18706,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<f32>
    i32.eqz
@@ -18543,16 +18719,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    f32.const 2
    i32.const -2
    call $~lib/array/Array<f32>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18563,7 +18739,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<f32>
    i32.eqz
@@ -18576,15 +18752,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    f32.const 0
    i32.const 1
    i32.const 0
    call $~lib/array/Array<f32>#fill
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18595,7 +18771,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<f32>
    i32.eqz
@@ -18608,16 +18784,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    f32.const -1
    i32.const 0
    call $~lib/array/Array<f32>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18628,7 +18804,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<f32>
    i32.eqz
@@ -18641,16 +18817,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    f32.const -0
    i32.const 0
    call $~lib/array/Array<f32>#fill@varargs
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -18661,7 +18837,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    call $std/array/isArraysEqual<f32>
    i32.eqz
@@ -18675,9 +18851,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    if
     i32.const 0
@@ -18689,9 +18865,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -18705,16 +18881,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 42
    call $~lib/array/Array<i32>#push
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 42
@@ -18729,9 +18905,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 1
    i32.ne
@@ -18745,9 +18921,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -18761,9 +18937,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<i32>#pop
    i32.const 42
    i32.ne
@@ -18777,9 +18953,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    if
     i32.const 0
@@ -18791,9 +18967,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -18807,16 +18983,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 43
    call $~lib/array/Array<i32>#push
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 1
    i32.ne
@@ -18830,9 +19006,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -18846,9 +19022,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 43
@@ -18863,16 +19039,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 44
    call $~lib/array/Array<i32>#push
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 2
    i32.ne
@@ -18886,9 +19062,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -18902,9 +19078,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 43
@@ -18919,9 +19095,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<i32>#__get
    i32.const 44
@@ -18936,16 +19112,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 45
    call $~lib/array/Array<i32>#push
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 3
    i32.ne
@@ -18959,9 +19135,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -18975,9 +19151,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 43
@@ -18992,9 +19168,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<i32>#__get
    i32.const 44
@@ -19009,9 +19185,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<i32>#__get
    i32.const 45
@@ -19092,12 +19268,12 @@
    i32.const 4
    i32.const 2688
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=28
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#at
    i32.const 1
@@ -19111,9 +19287,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/array/Array<i32>#at
    i32.const 4
@@ -19127,9 +19303,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const -1
    call $~lib/array/Array<i32>#at
    i32.const 4
@@ -19143,9 +19319,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const -4
    call $~lib/array/Array<i32>#at
    i32.const 1
@@ -19161,18 +19337,18 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    call $~lib/array/Array<i32>#constructor
-   local.tee $0
+   local.tee $1
    i32.store offset=32
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
    local.tee $9
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $9
-   local.get $0
+   local.get $1
    call $~lib/array/Array<i32>#concat
    local.tee $9
    i32.store offset=36
@@ -19304,15 +19480,15 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 46
    call $~lib/array/Array<i32>#push
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 47
    call $~lib/array/Array<i32>#push
    global.get $~lib/memory/__stack_pointer
@@ -19320,11 +19496,11 @@
    local.tee $9
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $9
-   local.get $0
+   local.get $1
    call $~lib/array/Array<i32>#concat
    local.tee $9
    i32.store offset=36
@@ -19345,9 +19521,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 2
    i32.ne
@@ -19481,12 +19657,12 @@
    i32.const 4
    i32.const 2768
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=40
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    if
     i32.const 0
@@ -19497,14 +19673,14 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
    local.tee $9
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    local.get $9
    call $~lib/array/Array<i32>#concat
    local.tee $9
@@ -19525,9 +19701,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    if
     i32.const 0
@@ -19543,20 +19719,20 @@
    i32.const 4
    i32.const 2800
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 3
    call $~lib/array/Array<i32>#copyWithin@varargs
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19567,7 +19743,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19586,20 +19762,20 @@
    i32.const 4
    i32.const 2896
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 3
    call $~lib/array/Array<i32>#copyWithin@varargs
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19610,7 +19786,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19629,20 +19805,20 @@
    i32.const 4
    i32.const 2992
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 2
    call $~lib/array/Array<i32>#copyWithin@varargs
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19653,7 +19829,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19672,20 +19848,20 @@
    i32.const 4
    i32.const 3088
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 2
    call $~lib/array/Array<i32>#copyWithin@varargs
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19696,7 +19872,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19715,19 +19891,19 @@
    i32.const 4
    i32.const 3184
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 3
    i32.const 4
    call $~lib/array/Array<i32>#copyWithin
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19738,7 +19914,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19757,19 +19933,19 @@
    i32.const 4
    i32.const 3280
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 3
    i32.const 4
    call $~lib/array/Array<i32>#copyWithin
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19780,7 +19956,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19799,19 +19975,19 @@
    i32.const 4
    i32.const 3376
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 2
    i32.const 4
    call $~lib/array/Array<i32>#copyWithin
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19822,7 +19998,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19841,20 +20017,20 @@
    i32.const 4
    i32.const 3472
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const -2
    call $~lib/array/Array<i32>#copyWithin@varargs
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19865,7 +20041,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19884,19 +20060,19 @@
    i32.const 4
    i32.const 3568
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const -2
    i32.const -1
    call $~lib/array/Array<i32>#copyWithin
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19907,7 +20083,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19926,19 +20102,19 @@
    i32.const 4
    i32.const 3664
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
-   local.get $0
+   local.get $1
    i32.const -4
    i32.const -3
    i32.const -2
    call $~lib/array/Array<i32>#copyWithin
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19949,7 +20125,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -19968,19 +20144,19 @@
    i32.const 4
    i32.const 3760
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
-   local.get $0
+   local.get $1
    i32.const -4
    i32.const -3
    i32.const -1
    call $~lib/array/Array<i32>#copyWithin
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -19991,7 +20167,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -20010,20 +20186,20 @@
    i32.const 4
    i32.const 3856
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=44
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=48
    i32.const 2
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const -4
    i32.const -3
    call $~lib/array/Array<i32>#copyWithin@varargs
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
@@ -20034,7 +20210,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store offset=8
-   local.get $0
+   local.get $1
    local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
@@ -20049,16 +20225,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 42
    call $~lib/array/Array<i32>#unshift
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 4
    i32.ne
@@ -20072,9 +20248,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -20088,9 +20264,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 42
@@ -20105,9 +20281,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<i32>#__get
    i32.const 43
@@ -20122,9 +20298,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<i32>#__get
    i32.const 44
@@ -20139,9 +20315,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/array/Array<i32>#__get
    i32.const 45
@@ -20156,16 +20332,16 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 41
    call $~lib/array/Array<i32>#unshift
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 5
    i32.ne
@@ -20179,9 +20355,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -20195,9 +20371,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 41
@@ -20212,9 +20388,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<i32>#__get
    i32.const 42
@@ -20229,9 +20405,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<i32>#__get
    i32.const 43
@@ -20246,9 +20422,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/array/Array<i32>#__get
    i32.const 44
@@ -20263,9 +20439,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 4
    call $~lib/array/Array<i32>#__get
    i32.const 45
@@ -20280,7 +20456,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -20294,9 +20470,9 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=12
    local.tee $9
    i32.const 0
@@ -20310,9 +20486,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=4
    local.tee $10
    i32.load
@@ -20334,9 +20510,9 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    local.get $9
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
@@ -20357,9 +20533,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 4
    i32.ne
@@ -20373,9 +20549,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -20389,9 +20565,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 42
@@ -20406,9 +20582,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<i32>#__get
    i32.const 43
@@ -20423,9 +20599,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<i32>#__get
    i32.const 44
@@ -20440,9 +20616,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/array/Array<i32>#__get
    i32.const 45
@@ -20457,9 +20633,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<i32>#pop
    global.set $std/array/i
    global.get $std/array/i
@@ -20475,9 +20651,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 3
    i32.ne
@@ -20491,9 +20667,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    call $std/array/internalCapacity<i32>
    i32.const 8
    i32.ne
@@ -20507,9 +20683,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#__get
    i32.const 42
@@ -20524,9 +20700,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/array/Array<i32>#__get
    i32.const 43
@@ -20541,9 +20717,9 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<i32>#__get
    i32.const 44
@@ -20562,15 +20738,15 @@
    i32.const 4
    i32.const 3952
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=52
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/array/Array<i32>#slice@varargs
    local.tee $9
@@ -20601,10 +20777,10 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 4
    call $~lib/array/Array<i32>#slice
@@ -20636,10 +20812,10 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 5
    call $~lib/array/Array<i32>#slice
@@ -20671,12 +20847,12 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 0
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/array/Array<i32>#slice@varargs
    local.tee $9
@@ -20685,10 +20861,10 @@
    local.get $9
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=8
    local.get $9
-   local.get $0
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -20701,12 +20877,12 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 1
    global.set $~argumentsLength
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.const -2
    call $~lib/array/Array<i32>#slice@varargs
    local.tee $9
@@ -20737,10 +20913,10 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const -1
    call $~lib/array/Array<i32>#slice
@@ -20772,10 +20948,10 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.const -3
    i32.const -1
    call $~lib/array/Array<i32>#slice
@@ -20807,9 +20983,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=8
-   local.get $0
+   local.get $1
    i32.const -1
    i32.const -3
    call $~lib/array/Array<i32>#slice
@@ -20828,18 +21004,18 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=8
    i32.const 1
    global.set $~argumentsLength
-   local.get $0
+   local.get $1
    i32.const 10
    call $~lib/array/Array<i32>#slice@varargs
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    if
     i32.const 0
@@ -20851,7 +21027,7 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $0
+   local.tee $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -20865,35 +21041,35 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=4
    local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=12
-   local.tee $0
+   local.tee $1
    i32.const 1
    i32.gt_u
    if
-    local.get $0
+    local.get $1
     i32.const 1
     i32.shr_u
     local.set $10
-    local.get $0
+    local.get $1
     i32.const 1
     i32.sub
-    local.set $0
+    local.set $1
     loop $while-continue|0
-     local.get $2
+     local.get $0
      local.get $10
      i32.lt_u
      if
       local.get $9
-      local.get $2
+      local.get $0
       i32.const 2
       i32.shl
       i32.add
@@ -20902,8 +21078,8 @@
       local.set $12
       local.get $11
       local.get $9
+      local.get $1
       local.get $0
-      local.get $2
       i32.sub
       i32.const 2
       i32.shl
@@ -20914,10 +21090,10 @@
       local.get $11
       local.get $12
       i32.store
-      local.get $2
+      local.get $0
       i32.const 1
       i32.add
-      local.set $2
+      local.set $0
       br $while-continue|0
      end
     end
@@ -21029,37 +21205,39 @@
    i32.const 7
    i32.const 4208
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u8>#reverse
    local.tee $0
    i32.store offset=60
+   i32.const 0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    call $~lib/array/Array<u8>#get:length
-   local.set $2
+   local.set $9
    loop $for-loop|0
-    local.get $2
-    local.get $3
-    i32.gt_s
+    local.get $1
+    local.get $9
+    i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
-     local.get $3
+     local.get $1
      call $~lib/array/Array<u8>#__get
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
      call $~lib/array/Array<u8>#get:length
-     local.get $3
+     local.get $1
      i32.sub
      i32.const 1
      i32.sub
@@ -21072,10 +21250,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
      br $for-loop|0
     end
    end
@@ -21085,39 +21263,39 @@
    i32.const 7
    i32.const 4240
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u8>#reverse
    local.tee $0
    i32.store offset=64
    i32.const 0
-   local.set $3
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    call $~lib/array/Array<u8>#get:length
-   local.set $2
+   local.set $9
    loop $for-loop|1
-    local.get $2
-    local.get $3
-    i32.gt_s
+    local.get $1
+    local.get $9
+    i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
-     local.get $3
+     local.get $1
      call $~lib/array/Array<u8>#__get
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
      call $~lib/array/Array<u8>#get:length
-     local.get $3
+     local.get $1
      i32.sub
      i32.const 1
      i32.sub
@@ -21130,10 +21308,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
      br $for-loop|1
     end
    end
@@ -21143,39 +21321,39 @@
    i32.const 7
    i32.const 4272
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u8>#reverse
    local.tee $0
    i32.store offset=68
    i32.const 0
-   local.set $3
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    call $~lib/array/Array<u8>#get:length
-   local.set $2
+   local.set $9
    loop $for-loop|2
-    local.get $2
-    local.get $3
-    i32.gt_s
+    local.get $1
+    local.get $9
+    i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
-     local.get $3
+     local.get $1
      call $~lib/array/Array<u8>#__get
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
      call $~lib/array/Array<u8>#get:length
-     local.get $3
+     local.get $1
      i32.sub
      i32.const 1
      i32.sub
@@ -21188,10 +21366,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
      br $for-loop|2
     end
    end
@@ -21201,39 +21379,39 @@
    i32.const 11
    i32.const 4320
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u16>#reverse
    local.tee $0
    i32.store offset=72
    i32.const 0
-   local.set $3
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    call $~lib/array/Array<u8>#get:length
-   local.set $2
+   local.set $9
    loop $for-loop|3
-    local.get $2
-    local.get $3
-    i32.gt_s
+    local.get $1
+    local.get $9
+    i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
-     local.get $3
+     local.get $1
      call $~lib/array/Array<u16>#__get
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
      call $~lib/array/Array<u8>#get:length
-     local.get $3
+     local.get $1
      i32.sub
      i32.const 1
      i32.sub
@@ -21246,10 +21424,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
      br $for-loop|3
     end
    end
@@ -21259,39 +21437,39 @@
    i32.const 11
    i32.const 4368
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u16>#reverse
    local.tee $0
    i32.store offset=76
    i32.const 0
-   local.set $3
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    call $~lib/array/Array<u8>#get:length
-   local.set $2
+   local.set $9
    loop $for-loop|4
-    local.get $2
-    local.get $3
-    i32.gt_s
+    local.get $1
+    local.get $9
+    i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
-     local.get $3
+     local.get $1
      call $~lib/array/Array<u16>#__get
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
      call $~lib/array/Array<u8>#get:length
-     local.get $3
+     local.get $1
      i32.sub
      i32.const 1
      i32.sub
@@ -21304,10 +21482,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
      br $for-loop|4
     end
    end
@@ -21317,39 +21495,39 @@
    i32.const 11
    i32.const 4416
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u16>#reverse
    local.tee $0
    i32.store offset=80
    i32.const 0
-   local.set $3
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    call $~lib/array/Array<u8>#get:length
-   local.set $2
+   local.set $9
    loop $for-loop|5
-    local.get $2
-    local.get $3
-    i32.gt_s
+    local.get $1
+    local.get $9
+    i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
-     local.get $3
+     local.get $1
      call $~lib/array/Array<u16>#__get
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store
      local.get $0
      call $~lib/array/Array<u8>#get:length
-     local.get $3
+     local.get $1
      i32.sub
      i32.const 1
      i32.sub
@@ -21362,10 +21540,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $3
+     local.get $1
      i32.const 1
      i32.add
-     local.set $3
+     local.set $1
      br $for-loop|5
     end
    end
@@ -21572,12 +21750,12 @@
    i32.const 9
    i32.const 4464
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
    i32.const 0
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -21590,14 +21768,14 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
-   block $__inlined_func$~lib/array/Array<f32>#indexOf$718
-    local.get $2
+   block $__inlined_func$~lib/array/Array<f32>#indexOf$700
+    local.get $0
     i32.load offset=12
-    local.tee $3
+    local.tee $9
     i32.eqz
-    local.get $3
+    local.get $9
     i32.const 0
     i32.le_s
     i32.or
@@ -21607,22 +21785,22 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const -1
-     local.set $0
-     br $__inlined_func$~lib/array/Array<f32>#indexOf$718
+     local.set $1
+     br $__inlined_func$~lib/array/Array<f32>#indexOf$700
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $2
+    local.get $0
     i32.store
-    local.get $2
+    local.get $0
     i32.load offset=4
-    local.set $2
+    local.set $0
     loop $while-continue|05
-     local.get $0
-     local.get $3
+     local.get $1
+     local.get $9
      i32.lt_s
      if
-      local.get $2
       local.get $0
+      local.get $1
       i32.const 2
       i32.shl
       i32.add
@@ -21634,12 +21812,12 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f32>#indexOf$718
+       br $__inlined_func$~lib/array/Array<f32>#indexOf$700
       end
-      local.get $0
+      local.get $1
       i32.const 1
       i32.add
-      local.set $0
+      local.set $1
       br $while-continue|05
      end
     end
@@ -21648,9 +21826,9 @@
     i32.add
     global.set $~lib/memory/__stack_pointer
     i32.const -1
-    local.set $0
+    local.set $1
    end
-   local.get $0
+   local.get $1
    i32.const -1
    i32.ne
    if
@@ -21666,12 +21844,12 @@
    i32.const 12
    i32.const 4496
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
    i32.const 0
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -21684,14 +21862,14 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
-   block $__inlined_func$~lib/array/Array<f64>#indexOf$719
-    local.get $2
+   block $__inlined_func$~lib/array/Array<f64>#indexOf$701
+    local.get $0
     i32.load offset=12
-    local.tee $3
+    local.tee $9
     i32.eqz
-    local.get $3
+    local.get $9
     i32.const 0
     i32.le_s
     i32.or
@@ -21701,22 +21879,22 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const -1
-     local.set $0
-     br $__inlined_func$~lib/array/Array<f64>#indexOf$719
+     local.set $1
+     br $__inlined_func$~lib/array/Array<f64>#indexOf$701
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $2
+    local.get $0
     i32.store
-    local.get $2
+    local.get $0
     i32.load offset=4
-    local.set $2
+    local.set $0
     loop $while-continue|07
-     local.get $0
-     local.get $3
+     local.get $1
+     local.get $9
      i32.lt_s
      if
-      local.get $2
       local.get $0
+      local.get $1
       i32.const 3
       i32.shl
       i32.add
@@ -21728,12 +21906,12 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $__inlined_func$~lib/array/Array<f64>#indexOf$719
+       br $__inlined_func$~lib/array/Array<f64>#indexOf$701
       end
-      local.get $0
+      local.get $1
       i32.const 1
       i32.add
-      local.set $0
+      local.set $1
       br $while-continue|07
      end
     end
@@ -21742,9 +21920,9 @@
     i32.add
     global.set $~lib/memory/__stack_pointer
     i32.const -1
-    local.set $0
+    local.set $1
    end
-   local.get $0
+   local.get $1
    i32.const -1
    i32.ne
    if
@@ -22044,12 +22222,12 @@
    i32.const 9
    i32.const 4576
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
    i32.const 0
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -22062,14 +22240,14 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
-   block $__inlined_func$~lib/array/Array<f32>#includes$720 (result i32)
-    local.get $2
+   block $__inlined_func$~lib/array/Array<f32>#includes$702 (result i32)
+    local.get $0
     i32.load offset=12
-    local.tee $3
+    local.tee $9
     i32.eqz
-    local.get $3
+    local.get $9
     i32.const 0
     i32.le_s
     i32.or
@@ -22079,21 +22257,21 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f32>#includes$720
+     br $__inlined_func$~lib/array/Array<f32>#includes$702
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $2
+    local.get $0
     i32.store
-    local.get $2
+    local.get $0
     i32.load offset=4
-    local.set $2
+    local.set $0
     loop $while-continue|09
-     local.get $0
-     local.get $3
+     local.get $1
+     local.get $9
      i32.lt_s
      if
-      local.get $2
       local.get $0
+      local.get $1
       i32.const 2
       i32.shl
       i32.add
@@ -22107,12 +22285,12 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f32>#includes$720
+       br $__inlined_func$~lib/array/Array<f32>#includes$702
       end
-      local.get $0
+      local.get $1
       i32.const 1
       i32.add
-      local.set $0
+      local.set $1
       br $while-continue|09
      end
     end
@@ -22136,12 +22314,12 @@
    i32.const 12
    i32.const 4608
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $0
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
    i32.const 0
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -22154,14 +22332,14 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $0
    i32.store
-   block $__inlined_func$~lib/array/Array<f64>#includes$721 (result i32)
-    local.get $2
+   block $__inlined_func$~lib/array/Array<f64>#includes$703 (result i32)
+    local.get $0
     i32.load offset=12
-    local.tee $3
+    local.tee $9
     i32.eqz
-    local.get $3
+    local.get $9
     i32.const 0
     i32.le_s
     i32.or
@@ -22171,21 +22349,21 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$~lib/array/Array<f64>#includes$721
+     br $__inlined_func$~lib/array/Array<f64>#includes$703
     end
     global.get $~lib/memory/__stack_pointer
-    local.get $2
+    local.get $0
     i32.store
-    local.get $2
+    local.get $0
     i32.load offset=4
-    local.set $2
+    local.set $0
     loop $while-continue|011
-     local.get $0
-     local.get $3
+     local.get $1
+     local.get $9
      i32.lt_s
      if
-      local.get $2
       local.get $0
+      local.get $1
       i32.const 3
       i32.shl
       i32.add
@@ -22199,12 +22377,12 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 1
-       br $__inlined_func$~lib/array/Array<f64>#includes$721
+       br $__inlined_func$~lib/array/Array<f64>#includes$703
       end
-      local.get $0
+      local.get $1
       i32.const 1
       i32.add
-      local.set $0
+      local.set $1
       br $while-continue|011
      end
     end
@@ -22314,21 +22492,21 @@
    local.get $0
    i32.const 0
    call $~lib/array/Array<i32>#splice@varargs
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 5
    i32.const 2
    i32.const 4
    i32.const 4688
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22348,12 +22526,12 @@
    i32.const 4
    i32.const 4736
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22380,21 +22558,21 @@
    i32.const 0
    i32.const 0
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 0
    i32.const 2
    i32.const 4
    i32.const 4816
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22414,12 +22592,12 @@
    i32.const 4
    i32.const 4848
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22447,21 +22625,21 @@
    local.get $0
    i32.const 2
    call $~lib/array/Array<i32>#splice@varargs
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 3
    i32.const 2
    i32.const 4
    i32.const 4944
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22481,12 +22659,12 @@
    i32.const 4
    i32.const 4976
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22513,21 +22691,21 @@
    i32.const 2
    i32.const 2
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 2
    i32.const 2
    i32.const 4
    i32.const 5056
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22547,12 +22725,12 @@
    i32.const 4
    i32.const 5088
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22579,21 +22757,21 @@
    i32.const 0
    i32.const 1
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 1
    i32.const 2
    i32.const 4
    i32.const 5168
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22613,12 +22791,12 @@
    i32.const 4
    i32.const 5200
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22646,21 +22824,21 @@
    local.get $0
    i32.const -1
    call $~lib/array/Array<i32>#splice@varargs
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 1
    i32.const 2
    i32.const 4
    i32.const 5296
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22680,12 +22858,12 @@
    i32.const 4
    i32.const 5328
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22713,21 +22891,21 @@
    local.get $0
    i32.const -2
    call $~lib/array/Array<i32>#splice@varargs
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 2
    i32.const 2
    i32.const 4
    i32.const 5424
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22747,12 +22925,12 @@
    i32.const 4
    i32.const 5456
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22779,21 +22957,21 @@
    i32.const -2
    i32.const 1
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 1
    i32.const 2
    i32.const 4
    i32.const 5536
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22813,12 +22991,12 @@
    i32.const 4
    i32.const 5568
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22845,21 +23023,21 @@
    i32.const -7
    i32.const 1
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 1
    i32.const 2
    i32.const 4
    i32.const 5664
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22879,12 +23057,12 @@
    i32.const 4
    i32.const 5696
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22911,21 +23089,21 @@
    i32.const -2
    i32.const -1
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 0
    i32.const 2
    i32.const 4
    i32.const 5792
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22945,12 +23123,12 @@
    i32.const 4
    i32.const 5824
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -22977,21 +23155,21 @@
    i32.const 1
    i32.const -2
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 0
    i32.const 2
    i32.const 4
    i32.const 5920
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23011,12 +23189,12 @@
    i32.const 4
    i32.const 5952
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23043,21 +23221,21 @@
    i32.const 4
    i32.const 0
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 0
    i32.const 2
    i32.const 4
    i32.const 6048
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23077,12 +23255,12 @@
    i32.const 4
    i32.const 6080
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23109,21 +23287,21 @@
    i32.const 7
    i32.const 0
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 0
    i32.const 2
    i32.const 4
    i32.const 6176
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23143,12 +23321,12 @@
    i32.const 4
    i32.const 6208
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23175,21 +23353,21 @@
    i32.const 7
    i32.const 5
    call $~lib/array/Array<i32>#splice
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    i32.const 0
    i32.const 2
    i32.const 4
    i32.const 6304
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $2
-   local.get $3
+   local.get $1
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23209,12 +23387,12 @@
    i32.const 4
    i32.const 6336
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -23241,12 +23419,12 @@
    local.get $0
    i32.const 1
    call $~lib/array/Array<std/array/Ref>#splice
-   local.tee $2
+   local.tee $1
    i32.store offset=96
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    if
     i32.const 0
@@ -23276,40 +23454,40 @@
    i32.const 10
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $2
+   local.tee $1
    i32.store offset=100
-   local.get $2
+   local.get $1
    i32.const 0
    i32.const 1
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 1
    i32.const 2
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 2
    i32.const 3
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 3
    i32.const 4
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 4
    i32.const 5
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.store offset=92
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.const 2
    call $~lib/array/Array<std/array/Ref>#splice
    local.tee $0
@@ -23335,11 +23513,11 @@
    local.get $0
    i32.const 0
    call $~lib/array/Array<std/array/Ref>#__get
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store
-   local.get $3
+   local.get $9
    i32.load
    i32.const 3
    i32.ne
@@ -23374,9 +23552,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 3
    i32.ne
@@ -23389,9 +23567,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $1
    i32.const 0
    call $~lib/array/Array<std/array/Ref>#__get
    local.set $0
@@ -23411,9 +23589,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $1
    i32.const 1
    call $~lib/array/Array<std/array/Ref>#__get
    local.set $0
@@ -23433,9 +23611,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $1
    i32.const 2
    call $~lib/array/Array<std/array/Ref>#__get
    local.set $0
@@ -23461,27 +23639,27 @@
    i32.const 13
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $2
+   local.tee $1
    i32.store offset=104
-   local.get $2
+   local.get $1
    i32.const 0
    i32.const 1
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 1
    i32.const 0
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 2
    i32.const 2
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.store offset=108
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -23495,98 +23673,98 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.load offset=12
-   local.tee $3
+   local.tee $9
    i32.const 0
-   local.get $3
+   local.get $9
    i32.const 0
    i32.le_s
    select
-   local.set $9
+   local.set $10
    global.get $~lib/memory/__stack_pointer
    i32.const 1
-   local.get $3
    local.get $9
-   i32.sub
-   local.tee $10
    local.get $10
+   i32.sub
+   local.tee $11
+   local.get $11
    i32.const 1
    i32.gt_s
    select
-   local.tee $10
+   local.tee $11
    i32.const 0
-   local.get $10
+   local.get $11
    i32.const 0
    i32.gt_s
    select
-   local.tee $10
+   local.tee $11
    i32.const 2
    i32.const 13
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $11
+   local.tee $12
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $11
+   local.get $12
    i32.store
-   local.get $11
+   local.get $12
    i32.load offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.load offset=4
-   local.tee $12
-   local.get $9
-   i32.const 2
-   i32.shl
-   i32.add
    local.tee $13
    local.get $10
    i32.const 2
    i32.shl
-   memory.copy
-   local.get $9
-   local.get $10
    i32.add
-   local.tee $9
-   local.get $3
+   local.tee $14
+   local.get $11
+   i32.const 2
+   i32.shl
+   memory.copy
+   local.get $10
+   local.get $11
+   i32.add
+   local.tee $10
+   local.get $9
    i32.ne
    if
+    local.get $14
     local.get $13
-    local.get $12
-    local.get $9
+    local.get $10
     i32.const 2
     i32.shl
     i32.add
-    local.get $3
     local.get $9
+    local.get $10
     i32.sub
     i32.const 2
     i32.shl
     memory.copy
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
-   local.get $3
-   local.get $10
+   local.get $1
+   local.get $9
+   local.get $11
    i32.sub
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $11
+   local.get $12
    i32.store offset=112
    global.get $~lib/memory/__stack_pointer
-   local.get $11
+   local.get $12
    i32.store
-   local.get $11
+   local.get $12
    call $~lib/array/Array<u8>#get:length
    i32.const 1
    i32.ne
@@ -23599,10 +23777,10 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $11
+   local.get $12
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $11
+   local.get $12
    i32.const 0
    call $~lib/array/Array<std/array/Ref|null>#__get
    local.tee $0
@@ -23633,9 +23811,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $~lib/array/Array<u8>#get:length
    i32.const 2
    i32.ne
@@ -23648,9 +23826,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 0
    call $~lib/array/Array<std/array/Ref|null>#__get
    if
@@ -23662,10 +23840,10 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.const 1
    call $~lib/array/Array<std/array/Ref|null>#__get
    local.tee $0
@@ -24552,23 +24730,23 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|6
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      global.get $std/array/arr
-     local.tee $2
+     local.tee $0
      i32.store
-     local.get $2
+     local.get $0
      call $~lib/array/Array<i32>#pop
      drop
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|6
     end
    end
@@ -24603,7 +24781,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $3
+   local.tee $9
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 9296
@@ -24621,37 +24799,37 @@
    i32.const 20
    memory.fill
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.load offset=12
-   local.tee $9
+   local.tee $10
    i32.const 2
    i32.const 16
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $10
+   local.tee $11
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
-   local.get $10
+   local.get $11
    i32.load offset=4
-   local.set $11
+   local.set $12
    i32.const 0
-   local.set $2
+   local.set $0
    loop $for-loop|012
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $9
     i32.store
-    local.get $2
+    local.get $0
+    local.get $10
     local.get $9
-    local.get $3
     i32.load offset=12
-    local.tee $12
-    local.get $9
-    local.get $12
+    local.tee $13
+    local.get $10
+    local.get $13
     i32.lt_s
     select
     i32.lt_s
@@ -24660,44 +24838,44 @@
      i32.const 9296
      i32.store offset=8
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $9
      i32.store offset=12
-     local.get $2
+     local.get $0
      i32.const 2
      i32.shl
-     local.tee $12
-     local.get $3
+     local.tee $13
+     local.get $9
      i32.load offset=4
      i32.add
      i32.load
-     local.set $13
+     local.set $14
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $9
      i32.store
      i32.const 3
      global.set $~argumentsLength
      global.get $~lib/memory/__stack_pointer
-     local.get $13
-     local.get $2
-     local.get $3
+     local.get $14
+     local.get $0
+     local.get $9
      i32.const 9296
      i32.load
      call_indirect (type $1)
-     local.tee $13
+     local.tee $14
      i32.store offset=16
-     local.get $11
      local.get $12
+     local.get $13
      i32.add
-     local.get $13
+     local.get $14
      i32.store
-     local.get $10
-     local.get $13
+     local.get $11
+     local.get $14
      i32.const 1
      call $~lib/rt/itcms/__link
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $for-loop|012
     end
    end
@@ -24705,12 +24883,12 @@
    i32.const 20
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store offset=128
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/arr
-   local.tee $3
+   local.tee $9
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 9328
@@ -24730,37 +24908,37 @@
    i64.const 0
    i64.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.load offset=12
-   local.tee $9
+   local.tee $10
    i32.const 2
    i32.const 9
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $10
+   local.tee $11
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
-   local.get $10
+   local.get $11
    i32.load offset=4
-   local.set $11
+   local.set $12
    i32.const 0
-   local.set $2
+   local.set $0
    loop $for-loop|013
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $9
     i32.store
-    local.get $2
+    local.get $0
+    local.get $10
     local.get $9
-    local.get $3
     i32.load offset=12
-    local.tee $12
-    local.get $9
-    local.get $12
+    local.tee $13
+    local.get $10
+    local.get $13
     i32.lt_s
     select
     i32.lt_s
@@ -24769,36 +24947,36 @@
      i32.const 9328
      i32.store offset=8
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $9
      i32.store offset=12
-     local.get $2
+     local.get $0
      i32.const 2
      i32.shl
-     local.tee $12
-     local.get $3
+     local.tee $13
+     local.get $9
      i32.load offset=4
      i32.add
      i32.load
-     local.set $13
+     local.set $14
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $9
      i32.store
      i32.const 3
      global.set $~argumentsLength
-     local.get $11
      local.get $12
-     i32.add
      local.get $13
-     local.get $2
-     local.get $3
+     i32.add
+     local.get $14
+     local.get $0
+     local.get $9
      i32.const 9328
      i32.load
      call_indirect (type $17)
      f32.store
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
+     local.set $0
      br $for-loop|013
     end
    end
@@ -24806,12 +24984,12 @@
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store offset=132
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
-   local.get $10
+   local.get $11
    call $~lib/array/Array<u8>#get:length
    i32.const 4
    i32.ne
@@ -24824,9 +25002,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
-   local.get $10
+   local.get $11
    i32.const 0
    call $~lib/array/Array<f32>#__get
    global.get $~lib/memory/__stack_pointer
@@ -25693,243 +25871,243 @@
    i32.store offset=140
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=144
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 80
    i32.store offset=4
    local.get $0
    i32.const 0
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=148
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 90
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 90
    i32.store offset=4
    local.get $0
    i32.const 1
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=152
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 95
    i32.store offset=4
    local.get $0
    i32.const 2
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=156
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store offset=4
    local.get $0
    i32.const 3
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=160
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 80
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 110
    i32.store offset=4
    local.get $0
    i32.const 4
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=164
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 110
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 115
    i32.store offset=4
    local.get $0
    i32.const 5
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=168
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 120
    i32.store offset=4
    local.get $0
    i32.const 6
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=172
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 125
    i32.store offset=4
    local.get $0
    i32.const 7
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=176
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 130
    i32.store offset=4
    local.get $0
    i32.const 8
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=180
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 135
    i32.store offset=4
    local.get $0
    i32.const 9
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=184
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 75
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 140
    i32.store offset=4
    local.get $0
    i32.const 10
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=188
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 140
    i32.store offset=4
    local.get $0
    i32.const 11
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    global.set $std/array/inputStabArr
@@ -25943,243 +26121,243 @@
    i32.store offset=192
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=196
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 95
    i32.store offset=4
    local.get $0
    i32.const 0
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=200
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 125
    i32.store offset=4
    local.get $0
    i32.const 1
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=204
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 130
    i32.store offset=4
    local.get $0
    i32.const 2
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=208
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 70
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 140
    i32.store offset=4
    local.get $0
    i32.const 3
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=212
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 75
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 140
    i32.store offset=4
    local.get $0
    i32.const 4
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=216
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 80
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 110
    i32.store offset=4
    local.get $0
    i32.const 5
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=220
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 90
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 90
    i32.store offset=4
    local.get $0
    i32.const 6
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=224
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 80
    i32.store offset=4
    local.get $0
    i32.const 7
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=228
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store offset=4
    local.get $0
    i32.const 8
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=232
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 120
    i32.store offset=4
    local.get $0
    i32.const 9
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=236
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 100
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 135
    i32.store offset=4
    local.get $0
    i32.const 10
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    global.get $~lib/memory/__stack_pointer
    call $std/array/Dim#constructor
-   local.tee $2
+   local.tee $1
    i32.store offset=240
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 110
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    i32.const 115
    i32.store offset=4
    local.get $0
    i32.const 11
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref>#__set
    local.get $0
    global.set $std/array/outputStabArr
@@ -26206,12 +26384,12 @@
    i32.const 9
    i32.const 10288
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    call $std/array/isArraysEqual<f32>
    i32.eqz
    if
@@ -26245,12 +26423,12 @@
    i32.const 9
    i32.const 10384
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    call $std/array/isArraysEqual<f32>
    i32.eqz
    if
@@ -26267,10 +26445,10 @@
    i32.const 12
    i32.const 10448
    call $~lib/rt/__newArray
-   local.tee $0
+   local.tee $1
    i32.store offset=252
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 0
    global.set $~argumentsLength
@@ -26292,7 +26470,7 @@
    i32.const 10544
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 10544
@@ -26309,14 +26487,14 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.load offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.load offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 10544
@@ -26331,20 +26509,20 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    i32.const 8
    i32.const 3
    i32.const 12
    i32.const 10576
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   block $__inlined_func$std/array/isArraysEqual<f64>$7 (result i32)
+   block $__inlined_func$std/array/isArraysEqual<f64>$6 (result i32)
     i32.const 0
-    local.set $2
+    local.set $0
     global.get $~lib/memory/__stack_pointer
     i32.const 4
     i32.sub
@@ -26357,45 +26535,45 @@
     i32.const 0
     i32.store
     global.get $~lib/memory/__stack_pointer
-    local.get $0
+    local.get $1
     i32.store
-    local.get $0
+    local.get $1
     call $~lib/array/Array<u8>#get:length
-    local.set $9
+    local.set $10
     global.get $~lib/memory/__stack_pointer
-    local.get $3
+    local.get $9
     i32.store
     block $folding-inner1
-     block $folding-inner01
-      local.get $3
-      call $~lib/array/Array<u8>#get:length
+     block $folding-inner00
       local.get $9
+      call $~lib/array/Array<u8>#get:length
+      local.get $10
       i32.ne
-      br_if $folding-inner01
-      local.get $0
-      local.get $3
+      br_if $folding-inner00
+      local.get $1
+      local.get $9
       i32.eq
       br_if $folding-inner1
-      loop $for-loop|02
-       local.get $2
-       local.get $9
+      loop $for-loop|01
+       local.get $0
+       local.get $10
        i32.lt_s
        if
         global.get $~lib/memory/__stack_pointer
-        local.get $0
+        local.get $1
         i32.store
+        local.get $1
         local.get $0
-        local.get $2
         call $~lib/array/Array<f64>#__get
         local.tee $7
         local.get $7
         f64.ne
         if (result i32)
          global.get $~lib/memory/__stack_pointer
-         local.get $3
+         local.get $9
          i32.store
-         local.get $3
-         local.get $2
+         local.get $9
+         local.get $0
          call $~lib/array/Array<f64>#__get
          local.tee $7
          local.get $7
@@ -26406,49 +26584,49 @@
         i32.eqz
         if
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $1
          i32.store
+         local.get $1
          local.get $0
-         local.get $2
          call $~lib/array/Array<f64>#__get
          i64.reinterpret_f64
          i64.const 63
          i64.shr_u
          i32.wrap_i64
          global.get $~lib/memory/__stack_pointer
-         local.get $3
+         local.get $9
          i32.store
-         local.get $3
-         local.get $2
+         local.get $9
+         local.get $0
          call $~lib/array/Array<f64>#__get
          i64.reinterpret_f64
          i64.const 63
          i64.shr_u
          i32.wrap_i64
          i32.ne
-         br_if $folding-inner01
+         br_if $folding-inner00
          global.get $~lib/memory/__stack_pointer
-         local.get $0
+         local.get $1
          i32.store
+         local.get $1
          local.get $0
-         local.get $2
          call $~lib/array/Array<f64>#__get
          local.set $7
          global.get $~lib/memory/__stack_pointer
-         local.get $3
+         local.get $9
          i32.store
-         local.get $3
-         local.get $2
+         local.get $9
+         local.get $0
          call $~lib/array/Array<f64>#__get
          local.get $7
          f64.ne
-         br_if $folding-inner01
+         br_if $folding-inner00
         end
-        local.get $2
+        local.get $0
         i32.const 1
         i32.add
-        local.set $2
-        br $for-loop|02
+        local.set $0
+        br $for-loop|01
        end
       end
       br $folding-inner1
@@ -26458,7 +26636,7 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$std/array/isArraysEqual<f64>$7
+     br $__inlined_func$std/array/isArraysEqual<f64>$6
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 4
@@ -26527,12 +26705,12 @@
    i32.const 4
    i32.const 10752
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26621,12 +26799,12 @@
    i32.const 8
    i32.const 10880
    call $~lib/rt/__newArray
-   local.set $2
+   local.set $1
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    local.get $0
-   local.get $2
+   local.get $1
    call $std/array/isArraysEqual<u32>
    i32.eqz
    if
@@ -26643,7 +26821,7 @@
    i32.const 4
    i32.const 10928
    call $~lib/rt/__newArray
-   local.tee $3
+   local.tee $9
    i32.store offset=264
    global.get $~lib/memory/__stack_pointer
    i32.const 1
@@ -26651,7 +26829,7 @@
    i32.const 4
    i32.const 10960
    call $~lib/rt/__newArray
-   local.tee $9
+   local.tee $10
    i32.store offset=268
    global.get $~lib/memory/__stack_pointer
    i32.const 2
@@ -26659,7 +26837,7 @@
    i32.const 4
    i32.const 10992
    call $~lib/rt/__newArray
-   local.tee $10
+   local.tee $11
    i32.store offset=272
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -26667,7 +26845,7 @@
    i32.const 4
    i32.const 11024
    call $~lib/rt/__newArray
-   local.tee $11
+   local.tee $12
    i32.store offset=276
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -26675,22 +26853,22 @@
    i32.const 4
    i32.const 11072
    call $~lib/rt/__newArray
-   local.tee $12
+   local.tee $13
    i32.store offset=280
    global.get $~lib/memory/__stack_pointer
    i32.const 64
    call $std/array/createReverseOrderedArray
-   local.tee $13
+   local.tee $14
    i32.store offset=284
    global.get $~lib/memory/__stack_pointer
    i32.const 128
    call $std/array/createReverseOrderedArray
-   local.tee $14
+   local.tee $15
    i32.store offset=288
    global.get $~lib/memory/__stack_pointer
    i32.const 1024
    call $std/array/createReverseOrderedArray
-   local.tee $15
+   local.tee $16
    i32.store offset=292
    global.get $~lib/memory/__stack_pointer
    i32.const 10000
@@ -26700,32 +26878,32 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 512
    call $std/array/createRandomOrderedArray
-   local.tee $2
+   local.tee $1
    i32.store offset=300
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store
-   local.get $3
-   call $std/array/assertSortedDefault<i32>
-   global.get $~lib/memory/__stack_pointer
    local.get $9
    i32.store
    local.get $9
    call $std/array/assertSortedDefault<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $9
+   local.get $10
+   i32.store
+   local.get $10
+   call $std/array/assertSortedDefault<i32>
+   global.get $~lib/memory/__stack_pointer
+   local.get $10
    i32.store
    i32.const 1
    i32.const 2
    i32.const 4
    i32.const 11152
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=8
    local.get $9
-   local.get $3
+   i32.store offset=8
+   local.get $10
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26738,24 +26916,24 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
-   local.get $10
+   local.get $11
    call $std/array/assertSortedDefault<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
    i32.const 2
    i32.const 2
    i32.const 4
    i32.const 11184
    call $~lib/rt/__newArray
-   local.set $3
+   local.set $9
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $9
    i32.store offset=8
-   local.get $10
-   local.get $3
+   local.get $11
+   local.get $9
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26768,18 +26946,18 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $11
+   local.get $12
    i32.store
-   local.get $11
+   local.get $12
    call $std/array/assertSortedDefault<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $11
+   local.get $12
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $12
+   local.get $13
    i32.store offset=8
-   local.get $11
    local.get $12
+   local.get $13
    i32.const 0
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26792,18 +26970,18 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $13
+   local.get $14
    i32.store
-   local.get $13
+   local.get $14
    call $std/array/assertSortedDefault<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $13
+   local.get $14
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $12
-   i32.store offset=8
    local.get $13
-   local.get $12
+   i32.store offset=8
+   local.get $14
+   local.get $13
    i32.const 4
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26816,18 +26994,18 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $14
+   local.get $15
    i32.store
-   local.get $14
+   local.get $15
    call $std/array/assertSortedDefault<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $14
+   local.get $15
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $12
+   local.get $13
    i32.store offset=8
-   local.get $14
-   local.get $12
+   local.get $15
+   local.get $13
    i32.const 4
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26840,18 +27018,18 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $15
+   local.get $16
    i32.store
-   local.get $15
+   local.get $16
    call $std/array/assertSortedDefault<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $15
+   local.get $16
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $12
+   local.get $13
    i32.store offset=8
-   local.get $15
-   local.get $12
+   local.get $16
+   local.get $13
    i32.const 4
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26872,10 +27050,10 @@
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $12
+   local.get $13
    i32.store offset=8
    local.get $0
-   local.get $12
+   local.get $13
    i32.const 4
    call $std/array/isArraysEqual<i32>
    i32.eqz
@@ -26888,9 +27066,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   local.get $2
+   local.get $1
    call $std/array/assertSortedDefault<i32>
    global.get $~lib/memory/__stack_pointer
    i32.const 24
@@ -26907,7 +27085,7 @@
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/inputStabArr
-   local.tee $0
+   local.tee $1
    i32.store offset=8
    i32.const 1
    global.set $~argumentsLength
@@ -26923,7 +27101,7 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -26937,79 +27115,79 @@
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=12
-   local.tee $3
+   local.tee $9
    i32.const 0
-   local.get $3
+   local.get $9
    i32.const 0
    i32.le_s
    select
-   local.set $9
+   local.set $10
    global.get $~lib/memory/__stack_pointer
-   local.get $3
    local.get $9
+   local.get $10
    i32.sub
-   local.tee $3
+   local.tee $9
    i32.const 0
-   local.get $3
+   local.get $9
    i32.const 0
    i32.gt_s
    select
-   local.tee $3
+   local.tee $9
    i32.const 2
    i32.const 23
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $10
+   local.tee $11
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
-   local.get $10
+   local.get $11
    i32.load offset=4
-   local.set $11
+   local.set $12
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=4
-   local.get $9
+   local.get $10
    i32.const 2
    i32.shl
    i32.add
-   local.set $9
+   local.set $10
    i32.const 0
-   local.set $0
-   local.get $3
+   local.set $1
+   local.get $9
    i32.const 2
    i32.shl
-   local.set $3
-   loop $while-continue|06
-    local.get $0
-    local.get $3
+   local.set $9
+   loop $while-continue|04
+    local.get $1
+    local.get $9
     i32.lt_u
     if
-     local.get $0
-     local.get $11
+     local.get $1
+     local.get $12
      i32.add
-     local.get $0
-     local.get $9
+     local.get $1
+     local.get $10
      i32.add
      i32.load
-     local.tee $12
+     local.tee $13
      i32.store
-     local.get $10
-     local.get $12
+     local.get $11
+     local.get $13
      i32.const 1
      call $~lib/rt/itcms/__link
-     local.get $0
+     local.get $1
      i32.const 4
      i32.add
-     local.set $0
-     br $while-continue|06
+     local.set $1
+     br $while-continue|04
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -27021,90 +27199,90 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $11
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 11216
    i32.store offset=4
-   local.get $10
+   local.get $11
    i32.const 11216
    call $~lib/array/Array<std/array/Dim>#sort
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    i32.const 1
-   local.set $2
+   local.set $0
    global.get $~lib/memory/__stack_pointer
    global.get $std/array/inputStabArr
-   local.tee $3
+   local.tee $9
    i32.store
-   local.get $3
+   local.get $9
    call $~lib/array/Array<u8>#get:length
-   local.set $3
+   local.set $9
    loop $for-loop|014
-    local.get $3
-    local.get $4
-    i32.gt_s
+    local.get $5
+    local.get $9
+    i32.lt_s
     if
      block $for-break0
       global.get $~lib/memory/__stack_pointer
-      local.get $0
+      local.get $1
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $0
-      local.get $4
+      local.get $1
+      local.get $5
       call $~lib/array/Array<std/array/Ref>#__get
-      local.tee $9
+      local.tee $10
       i32.store offset=16
       global.get $~lib/memory/__stack_pointer
       global.get $std/array/outputStabArr
-      local.tee $10
+      local.tee $11
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $10
-      local.get $4
+      local.get $11
+      local.get $5
       call $~lib/array/Array<std/array/Ref>#__get
-      local.tee $10
+      local.tee $11
       i32.store offset=20
       global.get $~lib/memory/__stack_pointer
-      local.get $9
+      local.get $10
       i32.store
-      local.get $9
+      local.get $10
       i32.load
       global.get $~lib/memory/__stack_pointer
-      local.get $10
+      local.get $11
       i32.store
-      local.get $10
+      local.get $11
       i32.load
       i32.ne
       if (result i32)
        i32.const 1
       else
        global.get $~lib/memory/__stack_pointer
-       local.get $9
+       local.get $10
        i32.store
-       local.get $9
+       local.get $10
        i32.load offset=4
        global.get $~lib/memory/__stack_pointer
-       local.get $10
+       local.get $11
        i32.store
-       local.get $10
+       local.get $11
        i32.load offset=4
        i32.ne
       end
       if
        i32.const 0
-       local.set $2
+       local.set $0
        br $for-break0
       end
-      local.get $4
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
+      local.set $5
       br $for-loop|014
      end
     end
    end
-   local.get $2
+   local.get $0
    i32.eqz
    if
     i32.const 0
@@ -27126,7 +27304,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 257
    call $std/array/createRandomOrderedArray
-   local.tee $2
+   local.tee $1
    i32.store offset=308
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -27147,21 +27325,21 @@
    i32.const 11280
    call $std/array/assertSorted<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 11312
    i32.store offset=8
-   local.get $2
+   local.get $1
    i32.const 11312
    call $std/array/assertSorted<i32>
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 11344
    i32.store offset=8
-   local.get $2
+   local.get $1
    i32.const 11344
    call $std/array/assertSorted<i32>
    global.get $~lib/memory/__stack_pointer
@@ -27198,133 +27376,105 @@
    i32.const 16
    i32.const 29
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $5
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store
-   local.get $3
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 32
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $4
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.tee $9
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $9
    i32.store offset=12
-   local.get $3
-   local.get $4
+   local.get $5
+   local.get $9
    i32.store
-   local.get $3
-   local.get $4
+   local.get $5
+   local.get $9
    i32.const 0
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   local.get $4
+   local.get $5
+   i32.store offset=8
+   local.get $5
+   local.get $9
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
+   local.get $5
+   i32.store offset=8
+   local.get $5
    i32.const 32
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
+   local.get $5
+   i32.store offset=8
+   local.get $5
    i32.const 2
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $5
    i32.store
-   i32.const 0
-   local.set $0
-   loop $for-loop|015
-    local.get $0
+   loop $for-loop|06
+    local.get $3
     i32.const 2
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
      i32.const 1
      call $~lib/array/Array<i32>#constructor
-     local.tee $4
+     local.tee $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $1
      i32.store offset=8
-     local.get $4
+     local.get $1
      i32.const 0
      i32.const 1
-     local.get $0
+     local.get $3
      i32.sub
      call $~lib/array/Array<i32>#__set
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $5
      i32.store offset=8
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $1
      i32.store offset=12
+     local.get $5
      local.get $3
-     local.get $0
-     local.get $4
+     local.get $1
      call $~lib/array/Array<std/array/Ref>#__set
-     local.get $0
+     local.get $3
      i32.const 1
      i32.add
-     local.set $0
-     br $for-loop|015
+     local.set $3
+     br $for-loop|06
     end
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $5
    i32.store offset=312
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $5
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 11376
    i32.store offset=8
-   local.get $3
+   local.get $5
    i32.const 11376
    call $std/array/assertSorted<~lib/array/Array<i32>>
    global.get $~lib/memory/__stack_pointer
+   i32.const 0
+   local.set $0
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.sub
@@ -27358,88 +27508,58 @@
    i32.const 16
    i32.const 32
    call $~lib/rt/itcms/__new
-   local.tee $3
+   local.tee $5
    i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store
-   local.get $3
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   i32.const 0
-   i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 2048
    i32.const 1
    call $~lib/rt/itcms/__new
-   local.tee $4
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.tee $9
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $9
    i32.store offset=12
-   local.get $3
-   local.get $4
+   local.get $5
+   local.get $9
    i32.store
-   local.get $3
-   local.get $4
+   local.get $5
+   local.get $9
    i32.const 0
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
-   local.get $4
+   local.get $5
+   i32.store offset=8
+   local.get $5
+   local.get $9
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
+   local.get $5
+   i32.store offset=8
+   local.get $5
    i32.const 2048
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $3
-   i32.store offset=4
-   local.get $3
+   local.get $5
+   i32.store offset=8
+   local.get $5
    i32.const 512
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $5
    i32.store
-   i32.const 0
-   local.set $2
-   loop $for-loop|06
-    local.get $2
+   loop $for-loop|08
+    local.get $0
     i32.const 512
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $5
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 8
@@ -27456,14 +27576,14 @@
      i32.const 4
      i32.const 31
      call $~lib/rt/itcms/__new
-     local.tee $4
+     local.tee $3
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $3
      i32.store offset=4
-     local.get $4
+     local.get $3
      i32.const 511
-     local.get $2
+     local.get $0
      i32.sub
      i32.store
      global.get $~lib/memory/__stack_pointer
@@ -27471,32 +27591,32 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $4
-     i32.store offset=8
      local.get $3
-     local.get $2
-     local.get $4
+     i32.store offset=8
+     local.get $5
+     local.get $0
+     local.get $3
      call $~lib/array/Array<std/array/Ref>#__set
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
-     br $for-loop|06
+     local.set $0
+     br $for-loop|08
     end
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $5
    i32.store offset=316
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $5
    i32.store
    global.get $~lib/memory/__stack_pointer
    i32.const 11408
    i32.store offset=8
-   local.get $3
+   local.get $5
    i32.const 11408
    call $std/array/assertSorted<~lib/array/Array<i32>>
    global.get $~lib/memory/__stack_pointer
@@ -27513,7 +27633,7 @@
    i32.const 34
    i32.const 11648
    call $~lib/rt/__newArray
-   local.tee $2
+   local.tee $1
    i32.store offset=324
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -27588,16 +27708,16 @@
    i64.const 0
    i64.store offset=8
    i32.const 1
-   local.set $4
+   local.set $5
    global.get $~lib/memory/__stack_pointer
    local.get $3
    i32.store
    local.get $3
    call $~lib/array/Array<u8>#get:length
    local.set $9
-   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$666 (result i32)
-    loop $for-loop|07
-     local.get $4
+   block $__inlined_func$std/array/isSorted<~lib/string/String|null>$647 (result i32)
+    loop $for-loop|069
+     local.get $5
      local.get $9
      i32.lt_s
      if
@@ -27608,7 +27728,7 @@
       local.get $3
       i32.store offset=12
       local.get $3
-      local.get $4
+      local.get $5
       i32.const 1
       i32.sub
       call $~lib/array/Array<std/array/Ref|null>#__get
@@ -27620,7 +27740,7 @@
       local.get $3
       i32.store offset=12
       local.get $3
-      local.get $4
+      local.get $5
       call $~lib/array/Array<std/array/Ref|null>#__get
       local.set $11
       global.get $~lib/memory/__stack_pointer
@@ -27641,13 +27761,13 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$666
+       br $__inlined_func$std/array/isSorted<~lib/string/String|null>$647
       end
-      local.get $4
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
-      br $for-loop|07
+      local.set $5
+      br $for-loop|069
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -27677,7 +27797,7 @@
    local.get $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    i32.const 12
@@ -27700,10 +27820,10 @@
    call $~lib/array/Array<u8>#get:length
    local.set $3
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store
-   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$752 (result i32)
-    local.get $2
+   block $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$732 (result i32)
+    local.get $1
     call $~lib/array/Array<u8>#get:length
     local.get $3
     i32.ne
@@ -27713,10 +27833,10 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 0
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$752
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$732
     end
     local.get $0
-    local.get $2
+    local.get $1
     i32.eq
     if
      global.get $~lib/memory/__stack_pointer
@@ -27724,30 +27844,30 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 1
-     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$752
+     br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$732
     end
     i32.const 0
-    local.set $4
-    loop $for-loop|08
+    local.set $5
+    loop $for-loop|07
      local.get $3
-     local.get $4
+     local.get $5
      i32.gt_s
      if
       global.get $~lib/memory/__stack_pointer
       local.get $0
       i32.store offset=8
       local.get $0
-      local.get $4
+      local.get $5
       call $~lib/array/Array<std/array/Ref|null>#__get
       local.set $9
       global.get $~lib/memory/__stack_pointer
       local.get $9
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $2
+      local.get $1
       i32.store offset=8
-      local.get $2
-      local.get $4
+      local.get $1
+      local.get $5
       call $~lib/array/Array<std/array/Ref|null>#__get
       local.set $10
       global.get $~lib/memory/__stack_pointer
@@ -27784,13 +27904,13 @@
        i32.add
        global.set $~lib/memory/__stack_pointer
        i32.const 0
-       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$752
+       br $__inlined_func$std/array/isArraysEqual<~lib/string/String|null>$732
       end
-      local.get $4
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
-      br $for-loop|08
+      local.set $5
+      br $for-loop|07
      end
     end
     global.get $~lib/memory/__stack_pointer
@@ -27809,257 +27929,11 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner2
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16192
-   i32.lt_s
-   br_if $folding-inner2
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 16
-   call $~lib/rt/itcms/__new
-   local.tee $10
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   local.get $10
-   i32.const 0
-   i32.store
-   local.get $10
-   i32.const 0
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   local.get $10
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   local.get $10
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   local.get $10
-   i32.const 0
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1600
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $2
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $2
-   i32.store offset=12
-   local.get $10
-   local.get $2
-   i32.store
-   local.get $10
-   local.get $2
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   local.get $10
-   local.get $2
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   local.get $10
-   i32.const 1600
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store offset=4
-   local.get $10
-   i32.const 400
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $10
-   i32.store
-   i32.const 0
-   local.set $2
-   loop $for-loop|019
-    local.get $2
-    i32.const 400
-    i32.lt_s
-    if
-     global.get $~lib/memory/__stack_pointer
-     local.get $10
-     i32.store offset=4
-     call $~lib/math/NativeMath.random
-     f64.const 32
-     f64.mul
-     i32.trunc_sat_f64_s
-     local.set $11
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 16192
-     i32.lt_s
-     br_if $folding-inner2
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 0
-     i32.store offset=8
-     i32.const 11568
-     local.set $0
-     global.get $~lib/memory/__stack_pointer
-     i32.const 11568
-     i32.store
-     i32.const 0
-     local.set $4
-     loop $for-loop|00
-      local.get $4
-      local.get $11
-      i32.lt_s
-      if
-       global.get $~lib/memory/__stack_pointer
-       local.get $0
-       i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       call $~lib/math/NativeMath.random
-       i32.const 10028
-       i32.load
-       i32.const 1
-       i32.shr_u
-       f64.convert_i32_s
-       f64.mul
-       f64.floor
-       i32.trunc_sat_f64_s
-       local.set $13
-       global.get $~lib/memory/__stack_pointer
-       i32.const 8
-       i32.sub
-       global.set $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       i32.const 16192
-       i32.lt_s
-       br_if $folding-inner2
-       global.get $~lib/memory/__stack_pointer
-       i64.const 0
-       i64.store
-       global.get $~lib/memory/__stack_pointer
-       i32.const 10032
-       i32.store
-       block $__inlined_func$~lib/string/String#charAt$741
-        local.get $13
-        i32.const 10028
-        i32.load
-        i32.const 1
-        i32.shr_u
-        i32.ge_u
-        if
-         global.get $~lib/memory/__stack_pointer
-         i32.const 8
-         i32.add
-         global.set $~lib/memory/__stack_pointer
-         i32.const 11568
-         local.set $3
-         br $__inlined_func$~lib/string/String#charAt$741
-        end
-        global.get $~lib/memory/__stack_pointer
-        i32.const 2
-        i32.const 2
-        call $~lib/rt/itcms/__new
-        local.tee $3
-        i32.store offset=4
-        local.get $3
-        local.get $13
-        i32.const 1
-        i32.shl
-        i32.const 10032
-        i32.add
-        i32.load16_u
-        i32.store16
-        global.get $~lib/memory/__stack_pointer
-        i32.const 8
-        i32.add
-        global.set $~lib/memory/__stack_pointer
-       end
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.store offset=8
-       local.get $0
-       local.get $3
-       call $~lib/string/String.__concat
-       local.tee $0
-       i32.store
-       local.get $4
-       i32.const 1
-       i32.add
-       local.set $4
-       br $for-loop|00
-      end
-     end
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=8
-     local.get $10
-     local.get $2
-     local.get $0
-     call $~lib/array/Array<std/array/Ref>#__set
-     local.get $2
-     i32.const 1
-     i32.add
-     local.set $2
-     br $for-loop|019
-    end
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 12
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $10
+   call $std/array/createRandomStringArray
+   local.tee $0
    i32.store offset=328
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $0
    i32.store
    i32.const 1
    global.set $~argumentsLength
@@ -28081,12 +27955,12 @@
    i32.const 11728
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $10
+   local.get $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 11728
    i32.store offset=8
-   local.get $10
+   local.get $0
    i32.const 11728
    call $std/array/assertSorted<~lib/array/Array<i32>>
    global.get $~lib/memory/__stack_pointer
@@ -28124,14 +27998,14 @@
    i32.store
    local.get $0
    i32.load offset=12
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    i32.const 11856
    i32.store
    i32.const 0
-   local.set $2
+   local.set $0
    i32.const 0
-   local.set $4
+   local.set $5
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -28143,8 +28017,8 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinBooleanArray$12
-    local.get $0
+   block $__inlined_func$~lib/util/string/joinBooleanArray$10
+    local.get $1
     i32.const 1
     i32.sub
     local.tee $9
@@ -28156,10 +28030,10 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     local.set $0
-     br $__inlined_func$~lib/util/string/joinBooleanArray$12
+     local.set $1
+     br $__inlined_func$~lib/util/string/joinBooleanArray$10
     end
-    block $folding-inner07
+    block $folding-inner010
      local.get $9
      i32.eqz
      if
@@ -28168,8 +28042,8 @@
       local.get $3
       i32.load8_u
       select
-      local.set $0
-      br $folding-inner07
+      local.set $1
+      br $folding-inner010
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 11856
@@ -28191,15 +28065,15 @@
      i32.shl
      i32.const 2
      call $~lib/rt/itcms/__new
-     local.tee $0
+     local.tee $1
      i32.store offset=4
-     loop $for-loop|18
-      local.get $4
+     loop $for-loop|111
+      local.get $5
       local.get $9
       i32.lt_s
       if
        local.get $3
-       local.get $4
+       local.get $5
        i32.add
        i32.load8_u
        local.tee $12
@@ -28207,8 +28081,8 @@
        i32.const 4
        i32.add
        local.set $13
+       local.get $1
        local.get $0
-       local.get $2
        i32.const 1
        i32.shl
        i32.add
@@ -28220,14 +28094,14 @@
        i32.const 1
        i32.shl
        memory.copy
-       local.get $2
+       local.get $0
        local.get $13
        i32.add
-       local.set $2
+       local.set $0
        local.get $10
        if
+        local.get $1
         local.get $0
-        local.get $2
         i32.const 1
         i32.shl
         i32.add
@@ -28236,16 +28110,16 @@
         i32.const 1
         i32.shl
         memory.copy
-        local.get $2
+        local.get $0
         local.get $10
         i32.add
-        local.set $2
+        local.set $0
        end
-       local.get $4
+       local.get $5
        i32.const 1
        i32.add
-       local.set $4
-       br $for-loop|18
+       local.set $5
+       br $for-loop|111
       end
      end
      local.get $3
@@ -28256,9 +28130,9 @@
      i32.eqz
      i32.const 4
      i32.add
-     local.set $4
+     local.set $5
+     local.get $1
      local.get $0
-     local.get $2
      i32.const 1
      i32.shl
      i32.add
@@ -28266,31 +28140,31 @@
      i32.const 11824
      local.get $3
      select
-     local.get $4
+     local.get $5
      i32.const 1
      i32.shl
      memory.copy
-     local.get $2
-     local.get $4
+     local.get $0
+     local.get $5
      i32.add
-     local.tee $2
+     local.tee $0
      local.get $11
      i32.lt_s
      if
       global.get $~lib/memory/__stack_pointer
-      local.get $0
+      local.get $1
       i32.store
+      local.get $1
       local.get $0
-      local.get $2
       call $~lib/string/String#substring
-      local.set $0
-      br $folding-inner07
+      local.set $1
+      br $folding-inner010
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinBooleanArray$12
+     br $__inlined_func$~lib/util/string/joinBooleanArray$10
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -28302,9 +28176,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 11888
    call $~lib/string/String.__eq
    i32.eqz
@@ -28489,28 +28363,28 @@
    i32.const 13
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $2
+   local.tee $1
    i32.store offset=332
-   local.get $2
+   local.get $1
    i32.const 0
    i32.const 0
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 1
    i32.const 0
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 2
    i32.const 0
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.store offset=336
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref|null>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -28535,24 +28409,24 @@
    i32.const 10
    i32.const 0
    call $~lib/rt/__newArray
-   local.tee $2
+   local.tee $1
    i32.store offset=340
-   local.get $2
+   local.get $1
    i32.const 0
    i32.const 0
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.const 1
    i32.const 0
    call $std/array/Ref#constructor
    call $~lib/array/Array<std/array/Ref>#__set
-   local.get $2
+   local.get $1
    i32.store offset=344
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $1
    call $~lib/array/Array<std/array/Ref|null>#join
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -28584,7 +28458,7 @@
    i32.const 4
    i32.const 13920
    call $~lib/rt/__newArray
-   local.tee $2
+   local.tee $1
    i32.store offset=352
    global.get $~lib/memory/__stack_pointer
    i32.const 2
@@ -28600,7 +28474,7 @@
    i32.const 4
    i32.const 13984
    call $~lib/rt/__newArray
-   local.tee $4
+   local.tee $5
    i32.store offset=360
    global.get $~lib/memory/__stack_pointer
    local.get $0
@@ -28624,9 +28498,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $2
+   local.get $1
    i32.store offset=8
-   local.get $2
+   local.get $1
    call $~lib/array/Array<i32>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -28666,9 +28540,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=8
-   local.get $4
+   local.get $5
    call $~lib/array/Array<i32>#toString
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -28779,7 +28653,7 @@
    i32.store
    local.get $0
    i32.load offset=4
-   local.set $2
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -28800,11 +28674,11 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$745
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$725
     local.get $0
     i32.const 1
     i32.sub
-    local.tee $3
+    local.tee $0
     i32.const 0
     i32.lt_s
     if
@@ -28813,21 +28687,21 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$745
+     local.set $1
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$725
     end
-    local.get $3
+    local.get $0
     i32.eqz
     if
-     local.get $2
+     local.get $3
      i32.load16_u
      call $~lib/util/number/utoa32
-     local.set $0
+     local.set $1
      global.get $~lib/memory/__stack_pointer
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$745
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$725
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -28837,10 +28711,10 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.tee $4
+    local.tee $5
     i32.const 10
     i32.add
-    local.get $3
+    local.get $0
     i32.mul
     i32.const 10
     i32.add
@@ -28849,82 +28723,82 @@
     i32.shl
     i32.const 2
     call $~lib/rt/itcms/__new
-    local.tee $0
+    local.tee $1
     i32.store offset=4
-    loop $for-loop|03
-     local.get $3
-     local.get $5
+    loop $for-loop|02
+     local.get $0
+     local.get $4
      i32.gt_s
      if
-      local.get $0
       local.get $1
+      local.get $2
       i32.const 1
       i32.shl
       i32.add
-      local.get $2
-      local.get $5
+      local.get $3
+      local.get $4
       i32.const 1
       i32.shl
       i32.add
       i32.load16_u
       call $~lib/util/number/itoa_buffered<u16>
-      local.get $1
+      local.get $2
       i32.add
-      local.set $1
-      local.get $4
+      local.set $2
+      local.get $5
       if
-       local.get $0
        local.get $1
+       local.get $2
        i32.const 1
        i32.shl
        i32.add
        i32.const 11856
-       local.get $4
+       local.get $5
        i32.const 1
        i32.shl
        memory.copy
-       local.get $1
-       local.get $4
+       local.get $2
+       local.get $5
        i32.add
-       local.set $1
+       local.set $2
       end
-      local.get $5
+      local.get $4
       i32.const 1
       i32.add
-      local.set $5
-      br $for-loop|03
+      local.set $4
+      br $for-loop|02
      end
     end
     local.get $9
-    local.get $0
     local.get $1
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
-    local.get $2
     local.get $3
+    local.get $0
     i32.const 1
     i32.shl
     i32.add
     i32.load16_u
     call $~lib/util/number/itoa_buffered<u16>
-    local.get $1
+    local.get $2
     i32.add
-    local.tee $1
+    local.tee $0
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $0
      local.get $1
+     i32.store
+     local.get $1
+     local.get $0
      call $~lib/string/String#substring
-     local.set $0
+     local.set $1
      global.get $~lib/memory/__stack_pointer
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$745
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$725
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -28940,9 +28814,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 14288
    call $~lib/string/String.__eq
    i32.eqz
@@ -28964,9 +28838,9 @@
    local.get $0
    i32.store offset=8
    i32.const 0
-   local.set $1
+   local.set $2
    i32.const 0
-   local.set $5
+   local.set $4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
    i32.sub
@@ -28997,7 +28871,7 @@
    i32.store
    local.get $0
    i32.load offset=4
-   local.set $2
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
@@ -29018,11 +28892,11 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$746
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$726
     local.get $0
     i32.const 1
     i32.sub
-    local.tee $3
+    local.tee $0
     i32.const 0
     i32.lt_s
     if
@@ -29031,21 +28905,21 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$746
+     local.set $1
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$726
     end
-    local.get $3
+    local.get $0
     i32.eqz
     if
-     local.get $2
+     local.get $3
      i32.load16_s
      call $~lib/util/number/itoa32
-     local.set $0
+     local.set $1
      global.get $~lib/memory/__stack_pointer
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$746
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$726
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 11856
@@ -29055,10 +28929,10 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.tee $4
+    local.tee $5
     i32.const 11
     i32.add
-    local.get $3
+    local.get $0
     i32.mul
     i32.const 11
     i32.add
@@ -29067,82 +28941,82 @@
     i32.shl
     i32.const 2
     call $~lib/rt/itcms/__new
-    local.tee $0
+    local.tee $1
     i32.store offset=4
-    loop $for-loop|05
-     local.get $3
-     local.get $5
+    loop $for-loop|04
+     local.get $0
+     local.get $4
      i32.gt_s
      if
-      local.get $0
       local.get $1
+      local.get $2
       i32.const 1
       i32.shl
       i32.add
-      local.get $2
-      local.get $5
+      local.get $3
+      local.get $4
       i32.const 1
       i32.shl
       i32.add
       i32.load16_s
       call $~lib/util/number/itoa_buffered<i16>
-      local.get $1
+      local.get $2
       i32.add
-      local.set $1
-      local.get $4
+      local.set $2
+      local.get $5
       if
-       local.get $0
        local.get $1
+       local.get $2
        i32.const 1
        i32.shl
        i32.add
        i32.const 11856
-       local.get $4
+       local.get $5
        i32.const 1
        i32.shl
        memory.copy
-       local.get $1
-       local.get $4
+       local.get $2
+       local.get $5
        i32.add
-       local.set $1
+       local.set $2
       end
-      local.get $5
+      local.get $4
       i32.const 1
       i32.add
-      local.set $5
-      br $for-loop|05
+      local.set $4
+      br $for-loop|04
      end
     end
     local.get $9
-    local.get $0
     local.get $1
+    local.get $2
     i32.const 1
     i32.shl
     i32.add
-    local.get $2
     local.get $3
+    local.get $0
     i32.const 1
     i32.shl
     i32.add
     i32.load16_s
     call $~lib/util/number/itoa_buffered<i16>
-    local.get $1
+    local.get $2
     i32.add
-    local.tee $1
+    local.tee $0
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     local.get $0
      local.get $1
+     i32.store
+     local.get $1
+     local.get $0
      call $~lib/string/String#substring
-     local.set $0
+     local.set $1
      global.get $~lib/memory/__stack_pointer
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$746
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$726
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -29158,9 +29032,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 14368
    call $~lib/string/String.__eq
    i32.eqz
@@ -29310,20 +29184,20 @@
    i32.store
    local.get $0
    i32.load offset=4
-   local.set $1
+   local.set $2
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    i32.load offset=12
-   local.set $0
+   local.set $1
    global.get $~lib/memory/__stack_pointer
    i32.const 11856
    i32.store
    i32.const 0
-   local.set $2
+   local.set $0
    i32.const 0
-   local.set $4
+   local.set $5
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.sub
@@ -29335,8 +29209,8 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i64>$13
-    local.get $0
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i64>$11
+    local.get $1
     i32.const 1
     i32.sub
     local.tee $3
@@ -29348,15 +29222,15 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$13
+     local.set $1
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$11
     end
-    block $folding-inner09
+    block $folding-inner012
      local.get $3
      i32.eqz
      if
       block $__inlined_func$~lib/util/number/itoa64$4 (result i32)
-       local.get $1
+       local.get $2
        i64.load
        i64.extend32_s
        local.set $6
@@ -29391,7 +29265,7 @@
        i32.wrap_i64
        i32.const 1
        i32.shl
-       local.tee $0
+       local.tee $1
        select
        local.tee $6
        i64.const 4294967295
@@ -29400,66 +29274,66 @@
         global.get $~lib/memory/__stack_pointer
         local.get $6
         i32.wrap_i64
-        local.tee $1
+        local.tee $2
         i32.const 100000
         i32.lt_u
         if (result i32)
-         local.get $1
+         local.get $2
          i32.const 100
          i32.lt_u
          if (result i32)
-          local.get $1
+          local.get $2
           i32.const 10
           i32.ge_u
           i32.const 1
           i32.add
          else
-          local.get $1
+          local.get $2
           i32.const 10000
           i32.ge_u
           i32.const 3
           i32.add
-          local.get $1
+          local.get $2
           i32.const 1000
           i32.ge_u
           i32.add
          end
         else
-         local.get $1
+         local.get $2
          i32.const 10000000
          i32.lt_u
          if (result i32)
-          local.get $1
+          local.get $2
           i32.const 1000000
           i32.ge_u
           i32.const 6
           i32.add
          else
-          local.get $1
+          local.get $2
           i32.const 1000000000
           i32.ge_u
           i32.const 8
           i32.add
-          local.get $1
+          local.get $2
           i32.const 100000000
           i32.ge_u
           i32.add
          end
         end
-        local.tee $2
+        local.tee $3
         i32.const 1
         i32.shl
-        local.get $0
+        local.get $1
         i32.add
         i32.const 2
         call $~lib/rt/itcms/__new
-        local.tee $3
+        local.tee $0
         i32.store
         local.get $0
-        local.get $3
-        i32.add
         local.get $1
+        i32.add
         local.get $2
+        local.get $3
         call $~lib/util/number/utoa32_dec_lut
        else
         global.get $~lib/memory/__stack_pointer
@@ -29513,25 +29387,25 @@
           i32.add
          end
         end
-        local.tee $1
+        local.tee $2
         i32.const 1
         i32.shl
-        local.get $0
+        local.get $1
         i32.add
         i32.const 2
         call $~lib/rt/itcms/__new
-        local.tee $3
+        local.tee $0
         i32.store
         local.get $0
-        local.get $3
+        local.get $1
         i32.add
         local.get $6
-        local.get $1
+        local.get $2
         call $~lib/util/number/utoa64_dec_lut
        end
-       local.get $0
+       local.get $1
        if
-        local.get $3
+        local.get $0
         i32.const 45
         i32.store16
        end
@@ -29539,10 +29413,10 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       local.get $3
+       local.get $0
       end
-      local.set $0
-      br $folding-inner09
+      local.set $1
+      br $folding-inner012
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 11856
@@ -29552,7 +29426,7 @@
      i32.load
      i32.const 1
      i32.shr_u
-     local.tee $5
+     local.tee $4
      i32.const 21
      i32.add
      local.get $3
@@ -29564,84 +29438,84 @@
      i32.shl
      i32.const 2
      call $~lib/rt/itcms/__new
-     local.tee $0
+     local.tee $1
      i32.store offset=4
-     loop $for-loop|010
+     loop $for-loop|015
       local.get $3
-      local.get $4
+      local.get $5
       i32.gt_s
       if
+       local.get $1
        local.get $0
-       local.get $2
        i32.const 1
        i32.shl
        i32.add
-       local.get $1
-       local.get $4
+       local.get $2
+       local.get $5
        i32.const 3
        i32.shl
        i32.add
        i64.load
        call $~lib/util/number/itoa_buffered<i64>
-       local.get $2
+       local.get $0
        i32.add
-       local.set $2
-       local.get $5
+       local.set $0
+       local.get $4
        if
+        local.get $1
         local.get $0
-        local.get $2
         i32.const 1
         i32.shl
         i32.add
         i32.const 11856
-        local.get $5
+        local.get $4
         i32.const 1
         i32.shl
         memory.copy
-        local.get $2
-        local.get $5
+        local.get $0
+        local.get $4
         i32.add
-        local.set $2
+        local.set $0
        end
-       local.get $4
+       local.get $5
        i32.const 1
        i32.add
-       local.set $4
-       br $for-loop|010
+       local.set $5
+       br $for-loop|015
       end
      end
      local.get $9
+     local.get $1
      local.get $0
-     local.get $2
      i32.const 1
      i32.shl
      i32.add
-     local.get $1
+     local.get $2
      local.get $3
      i32.const 3
      i32.shl
      i32.add
      i64.load
      call $~lib/util/number/itoa_buffered<i64>
-     local.get $2
+     local.get $0
      i32.add
-     local.tee $1
+     local.tee $0
      i32.gt_s
      if
       global.get $~lib/memory/__stack_pointer
-      local.get $0
-      i32.store
-      local.get $0
       local.get $1
+      i32.store
+      local.get $1
+      local.get $0
       call $~lib/string/String#substring
-      local.set $0
-      br $folding-inner09
+      local.set $1
+      br $folding-inner012
      end
      global.get $~lib/memory/__stack_pointer
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$13
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i64>$11
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -29657,9 +29531,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.const 14704
    call $~lib/string/String.__eq
    i32.eqz
@@ -29798,7 +29672,7 @@
    i32.const 11856
    i32.store
    i32.const 0
-   local.set $4
+   local.set $5
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.sub
@@ -29811,11 +29685,11 @@
    i32.const 0
    i32.const 20
    memory.fill
-   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$14
+   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$12
     local.get $1
     i32.const 1
     i32.sub
-    local.tee $1
+    local.tee $2
     i32.const 0
     i32.lt_s
     if
@@ -29824,10 +29698,10 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     local.set $3
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$14
+     local.set $1
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$12
     end
-    local.get $1
+    local.get $2
     i32.eqz
     if
      global.get $~lib/memory/__stack_pointer
@@ -29845,15 +29719,15 @@
      else
       i32.const 11568
      end
-     local.set $3
+     local.set $1
      global.get $~lib/memory/__stack_pointer
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$14
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<i32>>$12
     end
     i32.const 11568
-    local.set $3
+    local.set $1
     global.get $~lib/memory/__stack_pointer
     i32.const 11568
     i32.store offset=8
@@ -29864,67 +29738,67 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.set $2
-    loop $for-loop|011
-     local.get $1
-     local.get $4
+    local.set $3
+    loop $for-loop|016
+     local.get $2
+     local.get $5
      i32.gt_s
      if
       global.get $~lib/memory/__stack_pointer
       local.get $0
-      local.get $4
+      local.get $5
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.tee $5
+      local.tee $4
       i32.store
-      local.get $5
-      if
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       local.get $5
-       i32.store offset=16
-       local.get $5
-       call $~lib/array/Array<i32>#toString
-       local.set $5
-       global.get $~lib/memory/__stack_pointer
-       local.get $5
-       i32.store offset=12
-       local.get $3
-       local.get $5
-       call $~lib/string/String.__concat
-       local.tee $3
-       i32.store offset=8
-      end
-      local.get $2
-      if
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 11856
-       i32.store offset=12
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.const 11856
-       call $~lib/string/String.__concat
-       local.tee $3
-       i32.store offset=8
-      end
       local.get $4
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.store offset=4
+       global.get $~lib/memory/__stack_pointer
+       global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=16
+       local.get $4
+       call $~lib/array/Array<i32>#toString
+       local.set $4
+       global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=12
+       local.get $1
+       local.get $4
+       call $~lib/string/String.__concat
+       local.tee $1
+       i32.store offset=8
+      end
+      local.get $3
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.store offset=4
+       global.get $~lib/memory/__stack_pointer
+       i32.const 11856
+       i32.store offset=12
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.const 11856
+       call $~lib/string/String.__concat
+       local.tee $1
+       i32.store offset=8
+      end
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
-      br $for-loop|011
+      local.set $5
+      br $for-loop|016
      end
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -29934,7 +29808,7 @@
     local.get $0
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
@@ -29946,10 +29820,10 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=12
-     local.get $3
+     local.get $1
      local.get $0
      call $~lib/string/String.__concat
-     local.tee $3
+     local.tee $1
      i32.store offset=8
     end
     global.get $~lib/memory/__stack_pointer
@@ -29966,9 +29840,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $1
    i32.store
-   local.get $3
+   local.get $1
    i32.const 15168
    call $~lib/string/String.__eq
    i32.eqz
@@ -30051,7 +29925,7 @@
    i32.const 11856
    i32.store
    i32.const 0
-   local.set $4
+   local.set $5
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.sub
@@ -30064,11 +29938,11 @@
    i32.const 0
    i32.const 20
    memory.fill
-   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$15
+   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$13
     local.get $1
     i32.const 1
     i32.sub
-    local.tee $1
+    local.tee $2
     i32.const 0
     i32.lt_s
     if
@@ -30077,10 +29951,10 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     local.set $3
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$15
+     local.set $1
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$13
     end
-    local.get $1
+    local.get $2
     i32.eqz
     if
      global.get $~lib/memory/__stack_pointer
@@ -30098,15 +29972,15 @@
      else
       i32.const 11568
      end
-     local.set $3
+     local.set $1
      global.get $~lib/memory/__stack_pointer
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$15
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<u8>>$13
     end
     i32.const 11568
-    local.set $3
+    local.set $1
     global.get $~lib/memory/__stack_pointer
     i32.const 11568
     i32.store offset=8
@@ -30117,67 +29991,67 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.set $2
-    loop $for-loop|016
-     local.get $1
-     local.get $4
+    local.set $3
+    loop $for-loop|017
+     local.get $2
+     local.get $5
      i32.gt_s
      if
       global.get $~lib/memory/__stack_pointer
       local.get $0
-      local.get $4
+      local.get $5
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.tee $5
+      local.tee $4
       i32.store
-      local.get $5
-      if
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       local.get $5
-       i32.store offset=16
-       local.get $5
-       call $~lib/array/Array<u8>#toString
-       local.set $5
-       global.get $~lib/memory/__stack_pointer
-       local.get $5
-       i32.store offset=12
-       local.get $3
-       local.get $5
-       call $~lib/string/String.__concat
-       local.tee $3
-       i32.store offset=8
-      end
-      local.get $2
-      if
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 11856
-       i32.store offset=12
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.const 11856
-       call $~lib/string/String.__concat
-       local.tee $3
-       i32.store offset=8
-      end
       local.get $4
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.store offset=4
+       global.get $~lib/memory/__stack_pointer
+       global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=16
+       local.get $4
+       call $~lib/array/Array<u8>#toString
+       local.set $4
+       global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=12
+       local.get $1
+       local.get $4
+       call $~lib/string/String.__concat
+       local.tee $1
+       i32.store offset=8
+      end
+      local.get $3
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.store offset=4
+       global.get $~lib/memory/__stack_pointer
+       i32.const 11856
+       i32.store offset=12
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.const 11856
+       call $~lib/string/String.__concat
+       local.tee $1
+       i32.store offset=8
+      end
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
-      br $for-loop|016
+      local.set $5
+      br $for-loop|017
      end
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -30187,7 +30061,7 @@
     local.get $0
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
@@ -30199,10 +30073,10 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=12
-     local.get $3
+     local.get $1
      local.get $0
      call $~lib/string/String.__concat
-     local.tee $3
+     local.tee $1
      i32.store offset=8
     end
     global.get $~lib/memory/__stack_pointer
@@ -30219,9 +30093,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $1
    i32.store
-   local.get $3
+   local.get $1
    i32.const 15168
    call $~lib/string/String.__eq
    i32.eqz
@@ -30308,7 +30182,7 @@
    i32.const 11856
    i32.store
    i32.const 0
-   local.set $4
+   local.set $5
    global.get $~lib/memory/__stack_pointer
    i32.const 20
    i32.sub
@@ -30321,11 +30195,11 @@
    i32.const 0
    i32.const 20
    memory.fill
-   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$16
+   block $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$14
     local.get $1
     i32.const 1
     i32.sub
-    local.tee $1
+    local.tee $2
     i32.const 0
     i32.lt_s
     if
@@ -30334,10 +30208,10 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      i32.const 11568
-     local.set $3
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$16
+     local.set $1
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$14
     end
-    local.get $1
+    local.get $2
     i32.eqz
     if
      global.get $~lib/memory/__stack_pointer
@@ -30355,15 +30229,15 @@
      else
       i32.const 11568
      end
-     local.set $3
+     local.set $1
      global.get $~lib/memory/__stack_pointer
      i32.const 20
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$16
+     br $__inlined_func$~lib/util/string/joinReferenceArray<~lib/array/Array<~lib/array/Array<u32>>>$14
     end
     i32.const 11568
-    local.set $3
+    local.set $1
     global.get $~lib/memory/__stack_pointer
     i32.const 11568
     i32.store offset=8
@@ -30374,67 +30248,67 @@
     i32.load
     i32.const 1
     i32.shr_u
-    local.set $2
-    loop $for-loop|017
-     local.get $1
-     local.get $4
+    local.set $3
+    loop $for-loop|018
+     local.get $2
+     local.get $5
      i32.gt_s
      if
       global.get $~lib/memory/__stack_pointer
       local.get $0
-      local.get $4
+      local.get $5
       i32.const 2
       i32.shl
       i32.add
       i32.load
-      local.tee $5
+      local.tee $4
       i32.store
-      local.get $5
-      if
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       global.get $~lib/memory/__stack_pointer
-       local.get $5
-       i32.store offset=16
-       local.get $5
-       call $~lib/array/Array<~lib/array/Array<u32>>#toString
-       local.set $5
-       global.get $~lib/memory/__stack_pointer
-       local.get $5
-       i32.store offset=12
-       local.get $3
-       local.get $5
-       call $~lib/string/String.__concat
-       local.tee $3
-       i32.store offset=8
-      end
-      local.get $2
-      if
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.store offset=4
-       global.get $~lib/memory/__stack_pointer
-       i32.const 11856
-       i32.store offset=12
-       global.get $~lib/memory/__stack_pointer
-       local.get $3
-       i32.const 11856
-       call $~lib/string/String.__concat
-       local.tee $3
-       i32.store offset=8
-      end
       local.get $4
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.store offset=4
+       global.get $~lib/memory/__stack_pointer
+       global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=16
+       local.get $4
+       call $~lib/array/Array<~lib/array/Array<u32>>#toString
+       local.set $4
+       global.get $~lib/memory/__stack_pointer
+       local.get $4
+       i32.store offset=12
+       local.get $1
+       local.get $4
+       call $~lib/string/String.__concat
+       local.tee $1
+       i32.store offset=8
+      end
+      local.get $3
+      if
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.store offset=4
+       global.get $~lib/memory/__stack_pointer
+       i32.const 11856
+       i32.store offset=12
+       global.get $~lib/memory/__stack_pointer
+       local.get $1
+       i32.const 11856
+       call $~lib/string/String.__concat
+       local.tee $1
+       i32.store offset=8
+      end
+      local.get $5
       i32.const 1
       i32.add
-      local.set $4
-      br $for-loop|017
+      local.set $5
+      br $for-loop|018
      end
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
-    local.get $1
+    local.get $2
     i32.const 2
     i32.shl
     i32.add
@@ -30444,7 +30318,7 @@
     local.get $0
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $3
+     local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
@@ -30456,10 +30330,10 @@
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=12
-     local.get $3
+     local.get $1
      local.get $0
      call $~lib/string/String.__concat
-     local.tee $3
+     local.tee $1
      i32.store offset=8
     end
     global.get $~lib/memory/__stack_pointer
@@ -30476,9 +30350,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $3
+   local.get $1
    i32.store
-   local.get $3
+   local.get $1
    i32.const 13568
    call $~lib/string/String.__eq
    i32.eqz
@@ -30539,12 +30413,12 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    call $~lib/array/Array<~lib/array/Array<i32>>#flat
-   local.tee $1
+   local.tee $0
    i32.store offset=404
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store
-   local.get $1
+   local.get $0
    call $~lib/array/Array<u8>#get:length
    i32.const 10
    i32.ne
@@ -30557,19 +30431,19 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|7
-    local.get $0
+    local.get $1
     i32.const 10
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $0
      i32.store
+     local.get $0
      local.get $1
-     local.get $0
      call $~lib/array/Array<i32>#__get
-     local.get $0
+     local.get $1
      i32.ne
      if
       i32.const 0
@@ -30579,10 +30453,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|7
     end
    end
@@ -30652,47 +30526,47 @@
    i32.store
    local.get $1
    i32.load offset=4
-   local.set $5
+   local.set $3
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
    local.get $1
    i32.load offset=12
-   local.set $1
-   i32.const 0
    local.set $4
    i32.const 0
-   local.set $0
-   loop $for-loop|023
-    local.get $0
+   local.set $5
+   i32.const 0
+   local.set $1
+   loop $for-loop|021
     local.get $1
+    local.get $4
     i32.lt_s
     if
-     local.get $5
-     local.get $0
+     local.get $3
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.tee $2
+     local.tee $0
      if (result i32)
-      local.get $2
+      local.get $0
       i32.load offset=12
      else
       i32.const 0
      end
-     local.get $4
+     local.get $5
      i32.add
-     local.set $4
-     local.get $0
+     local.set $5
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
-     br $for-loop|023
+     local.set $1
+     br $for-loop|021
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.const 2
    i32.shl
    local.tee $0
@@ -30707,7 +30581,7 @@
    local.tee $10
    i32.store offset=8
    local.get $10
-   local.get $4
+   local.get $5
    i32.store offset=12
    local.get $10
    local.get $0
@@ -30723,23 +30597,23 @@
    i32.const 0
    call $~lib/rt/itcms/__link
    i32.const 0
-   local.set $0
+   local.set $1
    i32.const 0
-   local.set $2
-   loop $for-loop|124
-    local.get $1
-    local.get $2
-    i32.gt_s
+   local.set $0
+   loop $for-loop|122
+    local.get $0
+    local.get $4
+    i32.lt_s
     if
-     local.get $5
-     local.get $2
+     local.get $3
+     local.get $0
      i32.const 2
      i32.shl
      i32.add
      i32.load
      local.tee $11
      if
-      local.get $0
+      local.get $1
       local.get $9
       i32.add
       local.get $11
@@ -30750,39 +30624,39 @@
       i32.shl
       local.tee $11
       memory.copy
-      local.get $0
+      local.get $1
       local.get $11
       i32.add
-      local.set $0
+      local.set $1
      end
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
-     br $for-loop|124
+     local.set $0
+     br $for-loop|122
     end
    end
    i32.const 0
-   local.set $0
-   loop $for-loop|225
-    local.get $0
-    local.get $4
+   local.set $1
+   loop $for-loop|223
+    local.get $1
+    local.get $5
     i32.lt_s
     if
      local.get $9
      local.get $9
-     local.get $0
+     local.get $1
      i32.const 2
      i32.shl
      i32.add
      i32.load
      i32.const 1
      call $~lib/rt/itcms/__link
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
-     br $for-loop|225
+     local.set $1
+     br $for-loop|223
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -30815,37 +30689,37 @@
     unreachable
    end
    i32.const 0
-   local.set $2
+   local.set $1
    loop $for-loop|8
     global.get $~lib/memory/__stack_pointer
     local.get $0
     i32.store
     local.get $0
     call $~lib/array/Array<u8>#get:length
-    local.get $2
+    local.get $1
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $10
      i32.store offset=48
      local.get $10
-     local.get $2
-     call $~lib/array/Array<std/array/Ref|null>#__get
-     local.set $1
-     global.get $~lib/memory/__stack_pointer
      local.get $1
+     call $~lib/array/Array<std/array/Ref|null>#__get
+     local.set $2
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
      i32.store
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=48
      local.get $0
-     local.get $2
+     local.get $1
      call $~lib/array/Array<std/array/Ref|null>#__get
      local.set $3
      global.get $~lib/memory/__stack_pointer
      local.get $3
      i32.store offset=8
-     local.get $1
+     local.get $2
      local.get $3
      call $~lib/string/String.__eq
      i32.eqz
@@ -30857,10 +30731,10 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $2
+     local.get $1
      i32.const 1
      i32.add
-     local.set $2
+     local.set $1
      br $for-loop|8
     end
    end
@@ -30976,12 +30850,12 @@
    i32.load offset=4
    local.set $5
    i32.const 0
-   local.set $2
-   loop $for-loop|026
+   local.set $0
+   loop $for-loop|024
     global.get $~lib/memory/__stack_pointer
     local.get $1
     i32.store
-    local.get $2
+    local.get $0
     local.get $3
     local.get $1
     i32.load offset=12
@@ -30999,7 +30873,7 @@
      local.get $1
      i32.store offset=16
      global.get $~lib/memory/__stack_pointer
-     local.get $2
+     local.get $0
      i32.const 2
      i32.shl
      local.tee $9
@@ -31016,7 +30890,7 @@
      global.set $~argumentsLength
      global.get $~lib/memory/__stack_pointer
      local.get $10
-     local.get $2
+     local.get $0
      local.get $1
      i32.const 15984
      i32.load
@@ -31032,11 +30906,11 @@
      local.get $10
      i32.const 1
      call $~lib/rt/itcms/__link
-     local.get $2
+     local.get $0
      i32.const 1
      i32.add
-     local.set $2
-     br $for-loop|026
+     local.set $0
+     br $for-loop|024
     end
    end
    global.get $~lib/memory/__stack_pointer
@@ -31141,12 +31015,12 @@
    i32.const 0
    i32.gt_s
    if
-    loop $while-continue|028
+    loop $while-continue|026
      global.get $~lib/rt/itcms/state
      if
       call $~lib/rt/itcms/step
       drop
-      br $while-continue|028
+      br $while-continue|026
      end
     end
    end

--- a/tests/compiler/std/arraybuffer.debug.wat
+++ b/tests/compiler/std/arraybuffer.debug.wat
@@ -3027,30 +3027,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -3072,7 +3048,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -3081,7 +3057,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -3094,7 +3070,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -3102,7 +3078,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
@@ -3218,30 +3194,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $~lib/dataview/DataView#set:buffer
-  local.get $this
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $~lib/dataview/DataView#set:dataStart
-  local.get $this
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $~lib/dataview/DataView#set:byteLength
   local.get $byteLength
   i32.const 1073741820
   i32.gt_u

--- a/tests/compiler/std/arraybuffer.release.wat
+++ b/tests/compiler/std/arraybuffer.release.wat
@@ -478,60 +478,6 @@
    global.set $~lib/rt/itcms/visitCount
   end
  )
- (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
-  local.get $1
-  i32.eqz
-  if
-   return
-  end
-  local.get $0
-  i32.eqz
-  if
-   i32.const 0
-   i32.const 1232
-   i32.const 295
-   i32.const 14
-   call $~lib/builtins/abort
-   unreachable
-  end
-  global.get $~lib/rt/itcms/white
-  local.get $1
-  i32.const 20
-  i32.sub
-  local.tee $1
-  i32.load offset=4
-  i32.const 3
-  i32.and
-  i32.eq
-  if
-   local.get $0
-   i32.const 20
-   i32.sub
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   local.tee $0
-   global.get $~lib/rt/itcms/white
-   i32.eqz
-   i32.eq
-   if
-    local.get $1
-    call $~lib/rt/itcms/Object#makeGray
-   else
-    global.get $~lib/rt/itcms/state
-    i32.const 1
-    i32.eq
-    local.get $0
-    i32.const 3
-    i32.eq
-    i32.and
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    end
-   end
-  end
- )
  (func $~lib/rt/itcms/step (result i32)
   (local $0 i32)
   (local $1 i32)
@@ -1184,6 +1130,60 @@
   i32.or
   i32.store offset=4
  )
+ (func $~lib/rt/itcms/__link (param $0 i32) (param $1 i32)
+  local.get $1
+  i32.eqz
+  if
+   return
+  end
+  local.get $0
+  i32.eqz
+  if
+   i32.const 0
+   i32.const 1232
+   i32.const 295
+   i32.const 14
+   call $~lib/builtins/abort
+   unreachable
+  end
+  global.get $~lib/rt/itcms/white
+  local.get $1
+  i32.const 20
+  i32.sub
+  local.tee $1
+  i32.load offset=4
+  i32.const 3
+  i32.and
+  i32.eq
+  if
+   local.get $0
+   i32.const 20
+   i32.sub
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   local.tee $0
+   global.get $~lib/rt/itcms/white
+   i32.eqz
+   i32.eq
+   if
+    local.get $1
+    call $~lib/rt/itcms/Object#makeGray
+   else
+    global.get $~lib/rt/itcms/state
+    i32.const 1
+    i32.eq
+    local.get $0
+    i32.const 3
+    i32.eq
+    i32.and
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    end
+   end
+  end
+ )
  (func $~lib/rt/itcms/Object#makeGray (param $0 i32)
   (local $1 i32)
   (local $2 i32)
@@ -1207,7 +1207,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$185
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$179
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1231,7 +1231,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$185
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$179
    end
    local.get $0
    i32.load offset=8
@@ -1773,27 +1773,6 @@
    local.tee $0
    i32.store
   end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  call $~lib/rt/itcms/__link
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   i32.const 1073741820
   local.get $1
   i32.shr_u
@@ -1814,10 +1793,10 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $1
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   local.get $1
   i32.store offset=12
@@ -1829,13 +1808,13 @@
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   local.get $0
   local.get $1
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   local.get $0
   local.get $2
   i32.store offset=8
@@ -2343,27 +2322,6 @@
      call $~lib/rt/itcms/__new
      local.tee $2
      i32.store
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store
-     local.get $2
-     i32.const 0
-     call $~lib/rt/itcms/__link
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=4
-     local.get $2
-     i32.const 0
-     i32.store offset=8
      global.get $~lib/memory/__stack_pointer
      local.get $0
      i32.store offset=4

--- a/tests/compiler/std/dataview.debug.wat
+++ b/tests/compiler/std/dataview.debug.wat
@@ -2674,30 +2674,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -2719,7 +2695,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -2728,7 +2704,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -2741,7 +2717,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -2749,7 +2725,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength
@@ -2868,30 +2844,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $~lib/dataview/DataView#set:buffer
-  local.get $this
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $~lib/dataview/DataView#set:dataStart
-  local.get $this
-  local.set $5
-  global.get $~lib/memory/__stack_pointer
-  local.get $5
-  i32.store offset=4
-  local.get $5
-  i32.const 0
-  call $~lib/dataview/DataView#set:byteLength
   local.get $byteLength
   i32.const 1073741820
   i32.gt_u

--- a/tests/compiler/std/dataview.release.wat
+++ b/tests/compiler/std/dataview.release.wat
@@ -1377,61 +1377,6 @@
   i32.add
   global.set $~lib/memory/__stack_pointer
  )
- (func $~lib/arraybuffer/ArrayBufferView#set:buffer (param $0 i32) (param $1 i32)
-  local.get $0
-  local.get $1
-  i32.store
-  local.get $1
-  if
-   local.get $0
-   i32.eqz
-   if
-    i32.const 0
-    i32.const 1232
-    i32.const 295
-    i32.const 14
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/rt/itcms/white
-   local.get $1
-   i32.const 20
-   i32.sub
-   local.tee $1
-   i32.load offset=4
-   i32.const 3
-   i32.and
-   i32.eq
-   if
-    local.get $0
-    i32.const 20
-    i32.sub
-    i32.load offset=4
-    i32.const 3
-    i32.and
-    local.tee $0
-    global.get $~lib/rt/itcms/white
-    i32.eqz
-    i32.eq
-    if
-     local.get $1
-     call $~lib/rt/itcms/Object#makeGray
-    else
-     global.get $~lib/rt/itcms/state
-     i32.const 1
-     i32.eq
-     local.get $0
-     i32.const 3
-     i32.eq
-     i32.and
-     if
-      local.get $1
-      call $~lib/rt/itcms/Object#makeGray
-     end
-    end
-   end
-  end
- )
  (func $~lib/rt/tlsf/removeBlock (param $0 i32) (param $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -1847,7 +1792,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$221
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$217
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1871,7 +1816,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$221
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$217
    end
    local.get $0
    i32.load offset=8
@@ -2919,24 +2864,6 @@
   local.tee $3
   i32.store
   global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $3
-  i32.store offset=4
-  local.get $3
-  i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
   local.get $0
   i32.store offset=4
   local.get $0
@@ -2988,6 +2915,61 @@
   global.set $~lib/memory/__stack_pointer
   local.get $3
  )
+ (func $~lib/arraybuffer/ArrayBufferView#set:buffer (param $0 i32) (param $1 i32)
+  local.get $0
+  local.get $1
+  i32.store
+  local.get $1
+  if
+   local.get $0
+   i32.eqz
+   if
+    i32.const 0
+    i32.const 1232
+    i32.const 295
+    i32.const 14
+    call $~lib/builtins/abort
+    unreachable
+   end
+   global.get $~lib/rt/itcms/white
+   local.get $1
+   i32.const 20
+   i32.sub
+   local.tee $1
+   i32.load offset=4
+   i32.const 3
+   i32.and
+   i32.eq
+   if
+    local.get $0
+    i32.const 20
+    i32.sub
+    i32.load offset=4
+    i32.const 3
+    i32.and
+    local.tee $0
+    global.get $~lib/rt/itcms/white
+    i32.eqz
+    i32.eq
+    if
+     local.get $1
+     call $~lib/rt/itcms/Object#makeGray
+    else
+     global.get $~lib/rt/itcms/state
+     i32.const 1
+     i32.eq
+     local.get $0
+     i32.const 3
+     i32.eq
+     i32.and
+     if
+      local.get $1
+      call $~lib/rt/itcms/Object#makeGray
+     end
+    end
+   end
+  end
+ )
  (func $~lib/arraybuffer/ArrayBufferView#get:byteOffset (param $0 i32) (result i32)
   (local $1 i32)
   global.get $~lib/memory/__stack_pointer
@@ -3036,11 +3018,11 @@
   i32.const 16
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1772
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -3080,200 +3062,175 @@
    i32.const 1456
    global.set $~lib/rt/itcms/fromSpace
    global.get $~lib/memory/__stack_pointer
-   block $__inlined_func$~lib/typedarray/Uint8Array#constructor (result i32)
-    global.get $~lib/memory/__stack_pointer
-    i32.const 8
-    i32.sub
-    global.set $~lib/memory/__stack_pointer
-    block $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i32.const 1772
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 12
-     i32.const 4
-     call $~lib/rt/itcms/__new
-     local.tee $0
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     i32.const 16
-     i32.sub
-     global.set $~lib/memory/__stack_pointer
-     global.get $~lib/memory/__stack_pointer
-     i32.const 1772
-     i32.lt_s
-     br_if $folding-inner00
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store
-     global.get $~lib/memory/__stack_pointer
-     i64.const 0
-     i64.store offset=8
-     local.get $0
-     i32.eqz
-     if
-      global.get $~lib/memory/__stack_pointer
-      i32.const 12
-      i32.const 3
-      call $~lib/rt/itcms/__new
-      local.tee $0
-      i32.store
-     end
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     local.get $0
-     i32.const 0
-     call $~lib/arraybuffer/ArrayBufferView#set:buffer
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     local.get $0
-     i32.const 0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     local.get $0
-     i32.const 0
-     i32.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.const 1
-     call $~lib/rt/itcms/__new
-     local.tee $2
-     i32.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $2
-     i32.store offset=12
-     local.get $0
-     local.get $2
-     call $~lib/arraybuffer/ArrayBufferView#set:buffer
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     local.get $0
-     local.get $2
-     i32.store offset=4
-     global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     local.get $0
-     i32.const 8
-     i32.store offset=8
-     global.get $~lib/memory/__stack_pointer
-     i32.const 16
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store
-     global.get $~lib/memory/__stack_pointer
-     i32.const 8
-     i32.add
-     global.set $~lib/memory/__stack_pointer
-     local.get $0
-     br $__inlined_func$~lib/typedarray/Uint8Array#constructor
-    end
-    br $folding-inner1
-   end
-   local.tee $1
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1772
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 12
+   i32.const 4
+   call $~lib/rt/itcms/__new
+   local.tee $0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
    i32.store offset=4
-   local.get $1
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.sub
+   global.set $~lib/memory/__stack_pointer
+   global.get $~lib/memory/__stack_pointer
+   i32.const 1772
+   i32.lt_s
+   br_if $folding-inner0
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store
+   global.get $~lib/memory/__stack_pointer
+   i64.const 0
+   i64.store offset=8
+   local.get $0
+   i32.eqz
+   if
+    global.get $~lib/memory/__stack_pointer
+    i32.const 12
+    i32.const 3
+    call $~lib/rt/itcms/__new
+    local.tee $0
+    i32.store
+   end
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.const 1
+   call $~lib/rt/itcms/__new
+   local.tee $3
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   local.get $3
+   i32.store offset=12
+   local.get $0
+   local.get $3
+   call $~lib/arraybuffer/ArrayBufferView#set:buffer
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   local.get $3
+   i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=8
+   local.get $0
+   i32.const 8
+   i32.store offset=8
+   global.get $~lib/memory/__stack_pointer
+   i32.const 16
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   i32.const 8
+   i32.add
+   global.set $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store
+   global.get $~lib/memory/__stack_pointer
+   local.get $0
+   i32.store offset=4
+   local.get $0
    i32.const 0
    i32.const 246
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 1
    i32.const 224
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 2
    i32.const 88
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 3
    i32.const 159
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 4
    i32.const 130
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 5
    i32.const 101
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 6
    i32.const 67
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 7
    i32.const 95
    call $~lib/typedarray/Uint8Array#__set
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.load
-   local.tee $2
+   local.tee $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
    local.set $3
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=8
-   local.get $2
-   local.get $3
    local.get $1
+   local.get $3
+   local.get $0
    i32.load offset=8
    call $~lib/dataview/DataView#constructor
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getFloat32
@@ -3288,9 +3245,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 1
    call $~lib/dataview/DataView#getFloat32
@@ -3305,9 +3262,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 1
    call $~lib/dataview/DataView#getFloat32
@@ -3322,9 +3279,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 1
    call $~lib/dataview/DataView#getFloat32
@@ -3339,9 +3296,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 1
    call $~lib/dataview/DataView#getFloat32
@@ -3356,9 +3313,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getFloat32
@@ -3373,9 +3330,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 0
    call $~lib/dataview/DataView#getFloat32
@@ -3390,9 +3347,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 0
    call $~lib/dataview/DataView#getFloat32
@@ -3407,9 +3364,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 0
    call $~lib/dataview/DataView#getFloat32
@@ -3424,9 +3381,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 0
    call $~lib/dataview/DataView#getFloat32
@@ -3441,9 +3398,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getFloat64
    f64.const 7936550095674706383278551e126
@@ -3457,9 +3414,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getFloat64
    f64.const -411777475818852546741639e241
@@ -3473,9 +3430,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getInt8
    i32.const -10
@@ -3489,9 +3446,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getInt8
    i32.const -32
@@ -3505,9 +3462,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/dataview/DataView#getInt8
    i32.const 88
@@ -3521,9 +3478,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/dataview/DataView#getInt8
    i32.const -97
@@ -3537,9 +3494,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    call $~lib/dataview/DataView#getInt8
    i32.const -126
@@ -3553,9 +3510,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 5
    call $~lib/dataview/DataView#getInt8
    i32.const 101
@@ -3569,9 +3526,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 6
    call $~lib/dataview/DataView#getInt8
    i32.const 67
@@ -3585,9 +3542,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 7
    call $~lib/dataview/DataView#getInt8
    i32.const 95
@@ -3601,9 +3558,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -3620,9 +3577,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -3639,9 +3596,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -3658,9 +3615,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -3677,9 +3634,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -3696,9 +3653,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 5
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -3715,9 +3672,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 6
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -3734,9 +3691,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -3753,9 +3710,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -3772,9 +3729,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -3791,9 +3748,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -3810,9 +3767,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -3829,9 +3786,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 5
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -3848,9 +3805,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 6
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -3867,9 +3824,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getInt32
@@ -3884,9 +3841,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 1
    call $~lib/dataview/DataView#getInt32
@@ -3901,9 +3858,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 1
    call $~lib/dataview/DataView#getInt32
@@ -3918,9 +3875,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 1
    call $~lib/dataview/DataView#getInt32
@@ -3935,9 +3892,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 1
    call $~lib/dataview/DataView#getInt32
@@ -3952,9 +3909,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getInt32
@@ -3969,9 +3926,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 0
    call $~lib/dataview/DataView#getInt32
@@ -3986,9 +3943,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 0
    call $~lib/dataview/DataView#getInt32
@@ -4003,9 +3960,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 0
    call $~lib/dataview/DataView#getInt32
@@ -4020,9 +3977,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 0
    call $~lib/dataview/DataView#getInt32
@@ -4037,9 +3994,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getInt64
    i64.const 6864441868736323830
@@ -4053,9 +4010,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getInt64
    i64.const -657428103485373601
@@ -4069,9 +4026,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getUint8
    i32.const 246
@@ -4085,9 +4042,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getUint8
    i32.const 224
@@ -4101,9 +4058,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    call $~lib/dataview/DataView#getUint8
    i32.const 88
@@ -4117,9 +4074,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    call $~lib/dataview/DataView#getUint8
    i32.const 159
@@ -4133,9 +4090,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    call $~lib/dataview/DataView#getUint8
    i32.const 130
@@ -4149,9 +4106,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 5
    call $~lib/dataview/DataView#getUint8
    i32.const 101
@@ -4165,9 +4122,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 6
    call $~lib/dataview/DataView#getUint8
    i32.const 67
@@ -4181,9 +4138,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 7
    call $~lib/dataview/DataView#getUint8
    i32.const 95
@@ -4197,9 +4154,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -4216,9 +4173,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -4235,9 +4192,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -4254,9 +4211,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -4273,9 +4230,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -4292,9 +4249,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 5
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -4311,9 +4268,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 6
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -4330,9 +4287,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -4349,9 +4306,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -4368,9 +4325,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -4387,9 +4344,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -4406,9 +4363,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -4425,9 +4382,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 5
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -4444,9 +4401,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 6
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -4463,9 +4420,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getUint32
@@ -4480,9 +4437,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 1
    call $~lib/dataview/DataView#getUint32
@@ -4497,9 +4454,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 1
    call $~lib/dataview/DataView#getUint32
@@ -4514,9 +4471,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 1
    call $~lib/dataview/DataView#getUint32
@@ -4531,9 +4488,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 1
    call $~lib/dataview/DataView#getUint32
@@ -4548,9 +4505,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getUint32
@@ -4565,9 +4522,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    i32.const 0
    call $~lib/dataview/DataView#getUint32
@@ -4582,9 +4539,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 2
    i32.const 0
    call $~lib/dataview/DataView#getUint32
@@ -4599,9 +4556,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 3
    i32.const 0
    call $~lib/dataview/DataView#getUint32
@@ -4616,9 +4573,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 4
    i32.const 0
    call $~lib/dataview/DataView#getUint32
@@ -4633,9 +4590,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getUint64
    i64.const 6864441868736323830
@@ -4649,9 +4606,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getUint64
    i64.const -657428103485373601
@@ -4665,16 +4622,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    f32.const 1.5976661625240943e-18
    i32.const 1
    call $~lib/dataview/DataView#setFloat32
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getFloat32
@@ -4689,16 +4646,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    f32.const 1976281973381696323584
    i32.const 0
    call $~lib/dataview/DataView#setFloat32
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getFloat32
@@ -4713,16 +4670,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    f64.const -1094252199637739024055454e124
    i32.const 1
    call $~lib/dataview/DataView#setFloat64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getFloat64
    f64.const -1094252199637739024055454e124
@@ -4736,16 +4693,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    f64.const 6.022586634778589e-103
    i32.const 0
    call $~lib/dataview/DataView#setFloat64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getFloat64
    f64.const 6.022586634778589e-103
@@ -4759,7 +4716,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -4768,14 +4725,14 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1772
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=8
    i32.eqz
    if
@@ -4787,9 +4744,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=4
    i32.const 108
    i32.store8
@@ -4798,9 +4755,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getInt8
    i32.const 108
@@ -4814,16 +4771,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const -13360
    i32.const 1
    call $~lib/dataview/DataView#setInt16
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getInt16
@@ -4840,16 +4797,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 14689
    i32.const 0
    call $~lib/dataview/DataView#setInt16
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getInt16
@@ -4866,16 +4823,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1204680201
    i32.const 1
    call $~lib/dataview/DataView#setInt32
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getInt32
@@ -4890,16 +4847,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 660673230
    i32.const 0
    call $~lib/dataview/DataView#setInt32
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getInt32
@@ -4914,16 +4871,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i64.const -3290739641816099749
    i32.const 1
    call $~lib/dataview/DataView#setInt64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getInt64
    i64.const -3290739641816099749
@@ -4937,16 +4894,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i64.const 8178932412950708047
    i32.const 0
    call $~lib/dataview/DataView#setInt64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getInt64
    i64.const 8178932412950708047
@@ -4960,7 +4917,7 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 4
@@ -4969,14 +4926,14 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1772
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=8
    i32.eqz
    if
@@ -4988,9 +4945,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store
-   local.get $0
+   local.get $1
    i32.load offset=4
    i32.const 238
    i32.store8
@@ -4999,9 +4956,9 @@
    i32.add
    global.set $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getUint8
    i32.const 238
@@ -5015,16 +4972,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 58856
    i32.const 1
    call $~lib/dataview/DataView#setUint16
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getUint16
@@ -5041,16 +4998,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 60400
    i32.const 0
    call $~lib/dataview/DataView#setUint16
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getUint16
@@ -5067,16 +5024,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const -846805744
    i32.const 1
    call $~lib/dataview/DataView#setUint32
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 1
    call $~lib/dataview/DataView#getUint32
@@ -5091,16 +5048,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const -1510791631
    i32.const 0
    call $~lib/dataview/DataView#setUint32
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    i32.const 0
    call $~lib/dataview/DataView#getUint32
@@ -5115,16 +5072,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i64.const 2334704782995986958
    i32.const 1
    call $~lib/dataview/DataView#setUint64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 1
    call $~lib/dataview/DataView#getUint64
    i64.const 2334704782995986958
@@ -5138,16 +5095,16 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i64.const -7123186897289856329
    i32.const 0
    call $~lib/dataview/DataView#setUint64
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $1
    i32.store offset=4
-   local.get $0
+   local.get $1
    i32.const 0
    call $~lib/dataview/DataView#getUint64
    i64.const -7123186897289856329
@@ -5162,12 +5119,12 @@
    end
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.load
-   local.tee $1
+   local.tee $0
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
    i32.const 8
@@ -5176,14 +5133,14 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1772
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store
-   local.get $1
+   local.get $0
    i32.const 20
    i32.sub
    i32.load offset=16
@@ -5192,23 +5149,23 @@
    i32.const 0
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.const 0
    local.get $2
    call $~lib/dataview/DataView#constructor
-   local.set $1
+   local.set $0
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    call $~lib/arraybuffer/ArrayBufferView#get:byteOffset
    if
     i32.const 0
@@ -5219,9 +5176,9 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $0
    i32.store offset=4
-   local.get $1
+   local.get $0
    i32.load offset=8
    i32.const 8
    i32.ne

--- a/tests/compiler/std/date.debug.wat
+++ b/tests/compiler/std/date.debug.wat
@@ -3826,30 +3826,6 @@
   local.get $2
   local.get $epochMillis
   call $~lib/date/Date#set:epochMillis
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $~lib/date/Date#set:year
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $~lib/date/Date#set:month
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $~lib/date/Date#set:day
   local.get $epochMillis
   call $~lib/date/invalidDate
   if

--- a/tests/compiler/std/date.release.wat
+++ b/tests/compiler/std/date.release.wat
@@ -289,24 +289,6 @@
   local.get $1
   local.get $0
   i64.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=8
   local.get $0
   i64.const -8640000000000000
   i64.lt_s
@@ -607,7 +589,7 @@
       global.get $~lib/memory/__stack_pointer
       local.get $2
       i32.store
-      block $__inlined_func$~lib/string/String#charCodeAt$401
+      block $__inlined_func$~lib/string/String#charCodeAt$398
        local.get $3
        local.get $2
        i32.const 20
@@ -623,7 +605,7 @@
         global.set $~lib/memory/__stack_pointer
         i32.const -1
         local.set $0
-        br $__inlined_func$~lib/string/String#charCodeAt$401
+        br $__inlined_func$~lib/string/String#charCodeAt$398
        end
        local.get $2
        local.get $3
@@ -895,7 +877,7 @@
       global.get $~lib/memory/__stack_pointer
       local.get $2
       i32.store
-      block $__inlined_func$~lib/string/String#substr$402 (result i32)
+      block $__inlined_func$~lib/string/String#substr$399 (result i32)
        i32.const 3
        local.get $2
        i32.const 20
@@ -937,7 +919,7 @@
         i32.add
         global.set $~lib/memory/__stack_pointer
         i32.const 3456
-        br $__inlined_func$~lib/string/String#substr$402
+        br $__inlined_func$~lib/string/String#substr$399
        end
        global.get $~lib/memory/__stack_pointer
        local.get $8
@@ -987,7 +969,7 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1872
       i32.store
-      block $__inlined_func$~lib/string/String#padEnd$403
+      block $__inlined_func$~lib/string/String#padEnd$400
        i32.const 1868
        i32.load
        i32.const -2
@@ -1003,7 +985,7 @@
         i32.const 8
         i32.add
         global.set $~lib/memory/__stack_pointer
-        br $__inlined_func$~lib/string/String#padEnd$403
+        br $__inlined_func$~lib/string/String#padEnd$400
        end
        global.get $~lib/memory/__stack_pointer
        i32.const 6
@@ -1562,7 +1544,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1872
    i32.store
-   block $__inlined_func$~lib/string/String#padStart$399
+   block $__inlined_func$~lib/string/String#padStart$396
     i32.const 1868
     i32.load
     i32.const -2
@@ -1581,7 +1563,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/string/String#padStart$399
+     br $__inlined_func$~lib/string/String#padStart$396
     end
     global.get $~lib/memory/__stack_pointer
     local.get $5
@@ -1761,7 +1743,7 @@
     global.get $~lib/memory/__stack_pointer
     local.get $4
     i32.store
-    block $__inlined_func$~lib/string/String#concat$400
+    block $__inlined_func$~lib/string/String#concat$397
      local.get $4
      i32.const 20
      i32.sub
@@ -1780,7 +1762,7 @@
       global.set $~lib/memory/__stack_pointer
       i32.const 3456
       local.set $1
-      br $__inlined_func$~lib/string/String#concat$400
+      br $__inlined_func$~lib/string/String#concat$397
      end
      global.get $~lib/memory/__stack_pointer
      local.get $1
@@ -2139,7 +2121,7 @@
    i32.load16_u
    local.set $0
    loop $while-continue|0
-    block $__inlined_func$~lib/util/string/isSpace$164 (result i32)
+    block $__inlined_func$~lib/util/string/isSpace$161 (result i32)
      local.get $0
      i32.const 128
      i32.or
@@ -2154,7 +2136,7 @@
      local.get $0
      i32.const 5760
      i32.lt_u
-     br_if $__inlined_func$~lib/util/string/isSpace$164
+     br_if $__inlined_func$~lib/util/string/isSpace$161
      drop
      i32.const 1
      local.get $0
@@ -2162,7 +2144,7 @@
      i32.add
      i32.const 10
      i32.le_u
-     br_if $__inlined_func$~lib/util/string/isSpace$164
+     br_if $__inlined_func$~lib/util/string/isSpace$161
      drop
      block $break|0
       block $case0|0
@@ -2197,7 +2179,7 @@
        br $break|0
       end
       i32.const 1
-      br $__inlined_func$~lib/util/string/isSpace$164
+      br $__inlined_func$~lib/util/string/isSpace$161
      end
      i32.const 0
     end
@@ -3975,7 +3957,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$391
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$388
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -3999,7 +3981,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$391
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$388
    end
    local.get $0
    i32.load offset=8
@@ -5630,7 +5612,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
-   block $__inlined_func$~lib/rt/itcms/__renew$378
+   block $__inlined_func$~lib/rt/itcms/__renew$375
     i32.const 1073741820
     local.get $2
     i32.const 1
@@ -5673,7 +5655,7 @@
      i32.store offset=16
      local.get $2
      local.set $1
-     br $__inlined_func$~lib/rt/itcms/__renew$378
+     br $__inlined_func$~lib/rt/itcms/__renew$375
     end
     local.get $3
     local.get $4

--- a/tests/compiler/std/map.debug.wat
+++ b/tests/compiler/std/map.debug.wat
@@ -2372,16 +2372,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<i8,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<i8,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $~lib/util/hash/HASH<i8> (param $key i32) (result i32)
   (local $key|1 i32)
   (local $len i32)
@@ -2501,6 +2491,16 @@
   local.get $this
   local.get $taggedNext
   i32.store offset=8
+ )
+ (func $"~lib/map/Map<i8,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<i8,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
  )
  (func $~lib/array/Array<i8>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
@@ -2652,16 +2652,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<i8,i8>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<i8,i8>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<i32,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -2689,16 +2679,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<i32,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<i32,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $"~lib/map/Map<i8,i8>#get:buckets" (param $this i32) (result i32)
   local.get $this
@@ -2750,6 +2730,16 @@
   local.get $this
   local.get $taggedNext
   i32.store offset=4
+ )
+ (func $"~lib/map/Map<i8,i8>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<i8,i8>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<i32> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -2870,6 +2860,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<i32,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<i32,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<u8,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -2897,16 +2897,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<u8,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u8,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<u8> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -3029,6 +3019,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<u8,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u8,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u8>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3089,16 +3089,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<u8,u8>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u8,u8>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<u8,u8>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -3150,6 +3140,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $"~lib/map/Map<u8,u8>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u8,u8>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<i16,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -3177,16 +3177,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<i16,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<i16,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<i16> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -3308,6 +3298,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<i16,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<i16,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<i16>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3368,16 +3368,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<i16,i16>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<i16,i16>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<i16,i16>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -3429,6 +3419,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $"~lib/map/Map<i16,i16>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<i16,i16>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<u16,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -3456,16 +3456,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<u16,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u16,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<u16> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -3588,6 +3578,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<u16,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u16,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u16>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3648,16 +3648,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<u16,u16>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u16,u16>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<u16,u16>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -3709,6 +3699,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $"~lib/map/Map<u16,u16>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u16,u16>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<u32,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -3736,16 +3736,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<u32,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u32,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<u32> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -3866,6 +3856,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<u32,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u32,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u32>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3926,16 +3926,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<u32,u32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u32,u32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<u32,u32>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -3987,6 +3977,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<u32,u32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u32,u32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<i64,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -4014,16 +4014,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<i64,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<i64,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<i64> (param $key i64) (result i32)
   (local $key|1 i64)
@@ -4161,6 +4151,16 @@
   local.get $taggedNext
   i32.store offset=12
  )
+ (func $"~lib/map/Map<i64,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<i64,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<i64>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -4221,16 +4221,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<i64,i64>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<i64,i64>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<i64,i64>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -4282,6 +4272,16 @@
   local.get $taggedNext
   i32.store offset=16
  )
+ (func $"~lib/map/Map<i64,i64>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<i64,i64>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<u64,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -4309,16 +4309,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<u64,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u64,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<u64> (param $key i64) (result i32)
   (local $key|1 i64)
@@ -4456,6 +4446,16 @@
   local.get $taggedNext
   i32.store offset=12
  )
+ (func $"~lib/map/Map<u64,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u64,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u64>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -4516,16 +4516,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<u64,u64>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<u64,u64>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<u64,u64>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -4577,6 +4567,16 @@
   local.get $taggedNext
   i32.store offset=16
  )
+ (func $"~lib/map/Map<u64,u64>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<u64,u64>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<f32,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -4604,16 +4604,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<f32,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<f32,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<f32> (param $key f32) (result i32)
   (local $key|1 i32)
@@ -4735,6 +4725,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<f32,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<f32,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<f32>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -4795,16 +4795,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<f32,f32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<f32,f32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<f32,f32>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -4856,6 +4846,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<f32,f32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<f32,f32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<f64,i32>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -4883,16 +4883,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<f64,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<f64,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<f64> (param $key f64) (result i32)
   (local $key|1 i64)
@@ -5031,6 +5021,16 @@
   local.get $taggedNext
   i32.store offset=12
  )
+ (func $"~lib/map/Map<f64,i32>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<f64,i32>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<f64>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -5091,16 +5091,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<f64,f64>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<f64,f64>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $"~lib/map/Map<f64,f64>#get:buckets" (param $this i32) (result i32)
   local.get $this
   i32.load
@@ -5151,6 +5141,16 @@
   local.get $this
   local.get $taggedNext
   i32.store offset=16
+ )
+ (func $"~lib/map/Map<f64,f64>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<f64,f64>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
  )
  (func $~lib/rt/itcms/__collect
   i32.const 0
@@ -5823,22 +5823,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i8,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i8,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -6452,38 +6436,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 0
@@ -6513,7 +6465,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -6522,7 +6474,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -6535,7 +6487,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i8>#set:dataStart
@@ -6543,7 +6495,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i8>#set:byteLength
@@ -6551,7 +6503,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i8>#set:length_
@@ -6909,38 +6861,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -6970,7 +6890,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -6979,7 +6899,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -6992,7 +6912,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
@@ -7000,7 +6920,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
@@ -7008,7 +6928,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i32>#set:length_
@@ -7301,22 +7221,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i8,i8>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i8,i8>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -7400,22 +7304,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<i32,i32>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i32,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i32,i32>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -9510,22 +9398,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u8,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u8,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -10141,38 +10013,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 0
@@ -10202,7 +10042,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -10211,7 +10051,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -10224,7 +10064,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u8>#set:dataStart
@@ -10232,7 +10072,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u8>#set:byteLength
@@ -10240,7 +10080,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u8>#set:length_
@@ -10633,22 +10473,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<u8,u8>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u8,u8>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u8,u8>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -12186,22 +12010,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i16,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i16,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -12815,38 +12623,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 1
@@ -12876,7 +12652,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -12885,7 +12661,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -12898,7 +12674,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i16>#set:dataStart
@@ -12906,7 +12682,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i16>#set:byteLength
@@ -12914,7 +12690,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i16>#set:length_
@@ -13307,22 +13083,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<i16,i16>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i16,i16>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i16,i16>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -14858,22 +14618,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u16,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u16,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -15489,38 +15233,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 1
@@ -15550,7 +15262,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -15559,7 +15271,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -15572,7 +15284,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u16>#set:dataStart
@@ -15580,7 +15292,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u16>#set:byteLength
@@ -15588,7 +15300,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u16>#set:length_
@@ -15981,22 +15693,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<u16,u16>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u16,u16>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u16,u16>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -18697,22 +18393,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u32,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u32,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -19324,38 +19004,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -19385,7 +19033,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -19394,7 +19042,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -19407,7 +19055,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u32>#set:dataStart
@@ -19415,7 +19063,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u32>#set:byteLength
@@ -19423,7 +19071,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u32>#set:length_
@@ -19816,22 +19464,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<u32,u32>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u32,u32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u32,u32>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -21365,22 +20997,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i64,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i64,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -21992,38 +21608,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 3
@@ -22053,7 +21637,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -22062,7 +21646,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -22075,7 +21659,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i64>#set:dataStart
@@ -22083,7 +21667,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i64>#set:byteLength
@@ -22091,7 +21675,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i64>#set:length_
@@ -22484,22 +22068,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<i64,i64>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i64,i64>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<i64,i64>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -24042,22 +23610,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u64,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u64,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -24669,38 +24221,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 3
@@ -24730,7 +24250,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -24739,7 +24259,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -24752,7 +24272,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u64>#set:dataStart
@@ -24760,7 +24280,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u64>#set:byteLength
@@ -24768,7 +24288,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u64>#set:length_
@@ -25161,22 +24681,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<u64,u64>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u64,u64>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<u64,u64>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -26719,22 +26223,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f32,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f32,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -27346,38 +26834,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -27407,7 +26863,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -27416,7 +26872,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -27429,7 +26885,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<f32>#set:dataStart
@@ -27437,7 +26893,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<f32>#set:byteLength
@@ -27445,7 +26901,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<f32>#set:length_
@@ -27838,22 +27294,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<f32,f32>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f32,f32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f32,f32>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -29396,22 +28836,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f64,i32>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f64,i32>#set:entriesCount"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -30023,38 +29447,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 3
@@ -30084,7 +29476,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -30093,7 +29485,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -30106,7 +29498,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<f64>#set:dataStart
@@ -30114,7 +29506,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<f64>#set:byteLength
@@ -30122,7 +29514,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<f64>#set:length_
@@ -30515,22 +29907,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<f64,f64>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f64,f64>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<f64,f64>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/map.release.wat
+++ b/tests/compiler/std/map.release.wat
@@ -766,18 +766,6 @@
   i32.const 4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -1557,7 +1545,7 @@
     select
     local.set $1
    end
-   block $__inlined_func$~lib/rt/itcms/__renew$1377
+   block $__inlined_func$~lib/rt/itcms/__renew$1299
     local.get $4
     i32.const 20
     i32.sub
@@ -1575,7 +1563,7 @@
      i32.store offset=16
      local.get $4
      local.set $2
-     br $__inlined_func$~lib/rt/itcms/__renew$1377
+     br $__inlined_func$~lib/rt/itcms/__renew$1299
     end
     local.get $1
     local.get $3
@@ -3958,7 +3946,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$1422
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$1346
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -3982,7 +3970,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$1422
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$1346
    end
    local.get $0
    i32.load offset=8
@@ -6161,33 +6149,6 @@
   call $~lib/rt/itcms/__new
   local.tee $1
   i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store
-  local.get $1
-  i32.const 0
-  call $~lib/rt/itcms/__link
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=8
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  i32.store offset=12
   local.get $0
   i32.const 268435455
   i32.gt_u
@@ -6212,10 +6173,10 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $2
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store offset=12
@@ -6227,19 +6188,19 @@
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   local.get $1
   local.get $2
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   local.get $1
   local.get $3
   i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   local.get $1
-  i32.store offset=4
+  i32.store offset=8
   local.get $1
   local.get $0
   i32.store offset=12
@@ -10447,7 +10408,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<u8,u8>#find$1383"
+   block $"__inlined_func$~lib/map/Map<u8,u8>#find$1306"
     loop $while-continue|0
      local.get $3
      if
@@ -10471,7 +10432,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<u8,u8>#find$1383"
+       br $"__inlined_func$~lib/map/Map<u8,u8>#find$1306"
       end
       local.get $4
       i32.const -2
@@ -10898,7 +10859,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<u64,u64>#find$1408"
+   block $"__inlined_func$~lib/map/Map<u64,u64>#find$1331"
     loop $while-continue|0
      local.get $3
      if
@@ -10920,7 +10881,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<u64,u64>#find$1408"
+       br $"__inlined_func$~lib/map/Map<u64,u64>#find$1331"
       end
       local.get $4
       i32.const -2
@@ -11724,7 +11685,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<u16,u16>#find$1393"
+   block $"__inlined_func$~lib/map/Map<u16,u16>#find$1316"
     loop $while-continue|0
      local.get $3
      if
@@ -11748,7 +11709,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<u16,u16>#find$1393"
+       br $"__inlined_func$~lib/map/Map<u16,u16>#find$1316"
       end
       local.get $4
       i32.const -2
@@ -12165,7 +12126,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<i8,i8>#find$1378"
+   block $"__inlined_func$~lib/map/Map<i8,i8>#find$1301"
     loop $while-continue|0
      local.get $3
      if
@@ -12189,7 +12150,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<i8,i8>#find$1378"
+       br $"__inlined_func$~lib/map/Map<i8,i8>#find$1301"
       end
       local.get $4
       i32.const -2
@@ -12616,7 +12577,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<i64,i64>#find$1403"
+   block $"__inlined_func$~lib/map/Map<i64,i64>#find$1326"
     loop $while-continue|0
      local.get $3
      if
@@ -12638,7 +12599,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<i64,i64>#find$1403"
+       br $"__inlined_func$~lib/map/Map<i64,i64>#find$1326"
       end
       local.get $4
       i32.const -2
@@ -13067,7 +13028,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<i16,i16>#find$1388"
+   block $"__inlined_func$~lib/map/Map<i16,i16>#find$1311"
     loop $while-continue|0
      local.get $3
      if
@@ -13091,7 +13052,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<i16,i16>#find$1388"
+       br $"__inlined_func$~lib/map/Map<i16,i16>#find$1311"
       end
       local.get $4
       i32.const -2
@@ -13424,8 +13385,8 @@
  (func $"~lib/map/Map<f64,i32>#keys" (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f64)
+  (local $3 f64)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -13433,11 +13394,11 @@
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1896
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -13446,14 +13407,14 @@
    i32.store
    local.get $0
    i32.load offset=8
-   local.set $3
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
+   local.set $6
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.sub
@@ -13461,7 +13422,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1896
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -13472,36 +13433,9 @@
    i32.const 16
    i32.const 31
    call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
+   local.tee $2
    i32.store
    local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
    i32.const 134217727
    i32.gt_u
    if
@@ -13514,8 +13448,8 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $6
+   local.get $6
    i32.const 8
    i32.le_u
    select
@@ -13525,50 +13459,52 @@
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store offset=12
-   local.get $6
+   local.get $2
    local.get $7
    i32.store
-   local.get $6
+   local.get $2
    local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $7
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store offset=4
+   i32.const 0
+   local.set $0
    loop $for-loop|0
-    local.get $2
     local.get $5
+    local.get $6
     i32.lt_s
     if
-     local.get $3
-     local.get $2
+     local.get $4
+     local.get $5
      i32.const 4
      i32.shl
      i32.add
@@ -13579,16 +13515,16 @@
      i32.eqz
      if
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $1
-      local.tee $0
+      local.get $0
+      local.tee $1
       i32.const 1
       i32.add
-      local.set $1
+      local.set $0
       local.get $7
       f64.load
-      local.set $4
+      local.set $3
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.sub
@@ -13596,19 +13532,19 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1896
       i32.lt_s
-      br_if $folding-inner1
+      br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $0
-      local.get $6
+      local.get $1
+      local.get $2
       i32.load offset=12
       i32.ge_u
       if
-       local.get $0
+       local.get $1
        i32.const 0
        i32.lt_s
        if
@@ -13619,8 +13555,8 @@
         call $~lib/builtins/abort
         unreachable
        end
-       local.get $6
-       local.get $0
+       local.get $2
+       local.get $1
        i32.const 1
        i32.add
        local.tee $7
@@ -13628,46 +13564,46 @@
        i32.const 1
        call $~lib/array/ensureCapacity
        global.get $~lib/memory/__stack_pointer
-       local.get $6
+       local.get $2
        i32.store
-       local.get $6
+       local.get $2
        local.get $7
        i32.store offset=12
       end
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $6
+      local.get $2
       i32.load offset=4
-      local.get $0
+      local.get $1
       i32.const 3
       i32.shl
       i32.add
-      local.get $4
+      local.get $3
       f64.store
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.add
       global.set $~lib/memory/__stack_pointer
      end
-     local.get $2
+     local.get $5
      i32.const 1
      i32.add
-     local.set $2
+     local.set $5
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store
-   local.get $6
-   local.get $1
+   local.get $2
+   local.get $0
    call $~lib/array/Array<i64>#set:length
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    return
   end
   i32.const 34688
@@ -13777,7 +13713,7 @@
    i32.add
    i32.load
    local.set $3
-   block $"__inlined_func$~lib/map/Map<f64,f64>#find$1418"
+   block $"__inlined_func$~lib/map/Map<f64,f64>#find$1342"
     loop $while-continue|0
      local.get $3
      if
@@ -13799,7 +13735,7 @@
        i32.const 4
        i32.add
        global.set $~lib/memory/__stack_pointer
-       br $"__inlined_func$~lib/map/Map<f64,f64>#find$1418"
+       br $"__inlined_func$~lib/map/Map<f64,f64>#find$1342"
       end
       local.get $4
       i32.const -2
@@ -14146,8 +14082,8 @@
  (func $"~lib/map/Map<f32,i32>#keys" (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f32)
+  (local $3 f32)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -14155,11 +14091,11 @@
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1896
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -14168,14 +14104,14 @@
    i32.store
    local.get $0
    i32.load offset=8
-   local.set $3
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
+   local.set $6
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.sub
@@ -14183,7 +14119,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1896
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -14194,36 +14130,9 @@
    i32.const 16
    i32.const 28
    call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
+   local.tee $2
    i32.store
    local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
    i32.const 268435455
    i32.gt_u
    if
@@ -14236,8 +14145,8 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $6
+   local.get $6
    i32.const 8
    i32.le_u
    select
@@ -14247,50 +14156,52 @@
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store offset=12
-   local.get $6
+   local.get $2
    local.get $7
    i32.store
-   local.get $6
+   local.get $2
    local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $7
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store offset=4
+   i32.const 0
+   local.set $0
    loop $for-loop|0
-    local.get $2
     local.get $5
+    local.get $6
     i32.lt_s
     if
-     local.get $3
-     local.get $2
+     local.get $4
+     local.get $5
      i32.const 12
      i32.mul
      i32.add
@@ -14301,16 +14212,16 @@
      i32.eqz
      if
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $1
-      local.tee $0
+      local.get $0
+      local.tee $1
       i32.const 1
       i32.add
-      local.set $1
+      local.set $0
       local.get $7
       f32.load
-      local.set $4
+      local.set $3
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.sub
@@ -14318,19 +14229,19 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1896
       i32.lt_s
-      br_if $folding-inner1
+      br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $0
-      local.get $6
+      local.get $1
+      local.get $2
       i32.load offset=12
       i32.ge_u
       if
-       local.get $0
+       local.get $1
        i32.const 0
        i32.lt_s
        if
@@ -14341,8 +14252,8 @@
         call $~lib/builtins/abort
         unreachable
        end
-       local.get $6
-       local.get $0
+       local.get $2
+       local.get $1
        i32.const 1
        i32.add
        local.tee $7
@@ -14350,46 +14261,46 @@
        i32.const 1
        call $~lib/array/ensureCapacity
        global.get $~lib/memory/__stack_pointer
-       local.get $6
+       local.get $2
        i32.store
-       local.get $6
+       local.get $2
        local.get $7
        i32.store offset=12
       end
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $6
+      local.get $2
       i32.load offset=4
-      local.get $0
+      local.get $1
       i32.const 2
       i32.shl
       i32.add
-      local.get $4
+      local.get $3
       f32.store
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.add
       global.set $~lib/memory/__stack_pointer
      end
-     local.get $2
+     local.get $5
      i32.const 1
      i32.add
-     local.set $2
+     local.set $5
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store
-   local.get $6
-   local.get $1
+   local.get $2
+   local.get $0
    call $~lib/array/Array<i32>#set:length
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    return
   end
   i32.const 34688
@@ -14786,6 +14697,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -14818,78 +14730,66 @@
    i32.const 24
    i32.const 9
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 48
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store
    loop $for-loop|0
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      if
       i32.const 0
@@ -14900,19 +14800,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<u8,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      i32.eqz
      if
@@ -14924,12 +14824,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -14941,17 +14841,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -14964,17 +14864,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|1
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      i32.eqz
      if
@@ -14986,12 +14886,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -15004,19 +14904,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      call $"~lib/map/Map<u8,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      i32.eqz
      if
@@ -15028,12 +14928,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -15045,17 +14945,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|1
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -15068,196 +14968,174 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 10
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store
-   local.get $7
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=12
-   local.get $6
-   i32.const 1073741820
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $6
-   local.get $6
-   i32.const 8
-   i32.le_u
-   select
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=12
-   local.get $7
-   local.get $8
-   i32.store
-   local.get $7
-   local.get $8
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $6
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $3
-    local.get $6
-    i32.lt_s
-    if
-     local.get $5
-     local.get $3
-     i32.const 12
-     i32.mul
-     i32.add
-     local.tee $8
+   block $"__inlined_func$~lib/map/Map<u8,i32>#keys$5" (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
      i32.load offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
+     i32.load offset=16
+     local.set $8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 10
+     call $~lib/rt/itcms/__new
+     local.tee $9
+     i32.store
+     local.get $8
+     i32.const 1073741820
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $7
-      i32.store
-      local.get $7
-      local.get $0
-      local.get $8
-      i32.load8_u
-      call $~lib/array/Array<i8>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1728
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $8
+     local.get $8
+     i32.const 8
+     i32.le_u
+     select
+     local.tee $1
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=12
+     local.get $9
+     local.get $5
+     i32.store
+     local.get $9
+     local.get $5
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $1
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $8
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=4
+     loop $for-loop|01
+      local.get $3
+      local.get $8
+      i32.lt_s
+      if
+       local.get $6
+       local.get $3
+       i32.const 12
+       i32.mul
+       i32.add
+       local.tee $1
+       i32.load offset=8
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $9
+        i32.store
+        local.get $9
+        local.get $0
+        local.get $1
+        i32.load8_u
+        call $~lib/array/Array<i8>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|01
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store
+     local.get $9
+     local.get $0
+     call $~lib/array/Array<i8>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     br $"__inlined_func$~lib/map/Map<u8,i32>#keys$5"
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store
-   local.get $7
-   local.get $0
-   call $~lib/array/Array<i8>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#values"
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -15278,67 +15156,55 @@
    i32.const 24
    i32.const 11
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $5
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 32
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    call $"~lib/map/Map<i32,i32>#constructor"
@@ -15346,15 +15212,15 @@
    i32.store offset=20
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $0
     i32.store offset=4
-    local.get $7
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -15368,10 +15234,10 @@
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $2
-     local.get $7
+     local.get $4
+     local.get $0
      i32.load offset=12
      i32.ge_u
      if
@@ -15383,30 +15249,30 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $2
-     local.get $7
+     local.get $4
+     local.get $0
      i32.load offset=4
      i32.add
      i32.load8_u
-     local.set $5
+     local.set $6
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $1
      i32.store offset=4
-     local.get $0
-     local.get $2
+     local.get $1
+     local.get $4
      call $~lib/array/Array<i32>#__get
-     local.set $6
+     local.set $7
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $5
+     local.get $2
+     local.get $6
      call $"~lib/map/Map<u8,i32>#has"
      i32.eqz
      if
@@ -15418,10 +15284,10 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $7
      i32.const 20
      i32.sub
      call $"~lib/map/Map<u8,i32>#has"
@@ -15435,33 +15301,33 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $5
      i32.store offset=4
-     local.get $4
      local.get $5
-     local.get $5
+     local.get $6
+     local.get $6
      call $"~lib/map/Map<u8,u8>#set"
      global.get $~lib/memory/__stack_pointer
      local.get $3
      i32.store offset=4
      local.get $3
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
-     local.tee $5
-     local.get $5
+     local.tee $6
+     local.get $6
      call $"~lib/map/Map<i32,i32>#set"
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -15489,17 +15355,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|3
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      i32.eqz
      if
@@ -15511,12 +15377,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -15529,16 +15395,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      if
       i32.const 0
@@ -15548,17 +15414,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|3
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -15571,17 +15437,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|4
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      if
       i32.const 0
@@ -15592,19 +15458,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<u8,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      i32.eqz
      if
@@ -15616,16 +15482,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u8,i32>#has"
      if
       i32.const 0
@@ -15635,17 +15501,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|4
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -15658,14 +15524,14 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#clear"
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    if
     i32.const 0
@@ -15699,6 +15565,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -15738,15 +15605,15 @@
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
    local.get $1
-   local.get $5
+   local.get $6
    i32.store
    local.get $1
-   local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -15759,15 +15626,15 @@
    i32.store offset=4
    i32.const 64
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
    local.get $1
-   local.get $5
+   local.get $6
    i32.store offset=8
    local.get $1
-   local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -15775,18 +15642,6 @@
    local.get $1
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
@@ -15986,188 +15841,168 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $7
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 25
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store
-   local.get $8
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=12
-   local.get $7
-   i32.const 134217727
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $7
-   local.get $7
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 3
-   i32.shl
-   local.tee $9
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $4
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=12
-   local.get $8
-   local.get $4
-   i32.store
-   local.get $8
-   local.get $4
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $4
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $9
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $7
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   loop $for-loop|00
-    local.get $3
-    local.get $7
-    i32.lt_s
-    if
-     local.get $6
-     local.get $3
-     i32.const 4
-     i32.shl
-     i32.add
-     local.tee $4
-     i32.load offset=12
-     i32.const 1
-     i32.and
-     i32.eqz
+   block $"__inlined_func$~lib/map/Map<u64,i32>#keys$27" (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $8
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 25
+     call $~lib/rt/itcms/__new
+     local.tee $10
+     i32.store
+     local.get $5
+     i32.const 134217727
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $8
-      i32.store
-      local.get $8
-      local.get $0
-      local.get $4
-      i64.load
-      call $~lib/array/Array<i64>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1728
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $5
+     local.get $5
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 3
+     i32.shl
+     local.tee $6
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $7
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=12
+     local.get $10
+     local.get $7
+     i32.store
+     local.get $10
+     local.get $7
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $7
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $6
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $5
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=4
+     loop $for-loop|01
+      local.get $3
+      local.get $5
+      i32.lt_s
+      if
+       local.get $8
+       local.get $3
+       i32.const 4
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=12
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $10
+        i32.store
+        local.get $10
+        local.get $0
+        local.get $6
+        i64.load
+        call $~lib/array/Array<i64>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|01
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store
+     local.get $10
+     local.get $0
+     call $~lib/array/Array<i64>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     br $"__inlined_func$~lib/map/Map<u64,i32>#keys$27"
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store
-   local.get $8
-   local.get $0
-   call $~lib/array/Array<i64>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -16175,7 +16010,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    call $"~lib/map/Map<i64,i32>#values"
-   local.tee $0
+   local.tee $3
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -16196,85 +16031,71 @@
    i32.const 24
    i32.const 26
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $6
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $7
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $7
    i32.store offset=8
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    i32.store
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
-   local.get $4
+   local.get $6
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
    i32.const 96
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $7
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $7
    i32.store offset=8
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    i32.store offset=8
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
-   local.get $4
+   local.get $6
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    call $"~lib/map/Map<i32,i32>#constructor"
    local.tee $5
    i32.store offset=20
-   i32.const 0
-   local.set $3
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $0
     i32.store offset=4
-    local.get $8
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $3
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -16288,10 +16109,10 @@
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store
-     local.get $3
-     local.get $8
+     local.get $4
+     local.get $0
      i32.load offset=12
      i32.ge_u
      if
@@ -16303,11 +16124,11 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store
-     local.get $8
+     local.get $0
      i32.load offset=4
-     local.get $3
+     local.get $4
      i32.const 3
      i32.shl
      i32.add
@@ -16318,12 +16139,12 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     local.get $0
      local.get $3
+     i32.store offset=4
+     local.get $3
+     local.get $4
      call $~lib/array/Array<i32>#__get
-     local.set $6
+     local.set $7
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
@@ -16343,7 +16164,7 @@
      local.get $1
      i32.store offset=4
      local.get $1
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
      i64.extend_i32_s
@@ -16358,9 +16179,9 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $6
      i32.store offset=4
-     local.get $4
+     local.get $6
      local.get $2
      local.get $2
      call $"~lib/map/Map<u64,u64>#set"
@@ -16368,23 +16189,23 @@
      local.get $5
      i32.store offset=4
      local.get $5
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
-     local.tee $6
-     local.get $6
+     local.tee $7
+     local.get $7
      call $"~lib/map/Map<i32,i32>#set"
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
-     local.set $3
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
-   local.get $4
+   local.get $6
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -16623,6 +16444,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -16655,78 +16477,66 @@
    i32.const 24
    i32.const 18
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 48
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store
    loop $for-loop|0
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      if
       i32.const 0
@@ -16737,19 +16547,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<u32,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      i32.eqz
      if
@@ -16761,12 +16571,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -16778,17 +16588,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -16801,17 +16611,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|1
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      i32.eqz
      if
@@ -16823,12 +16633,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -16841,19 +16651,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      call $"~lib/map/Map<u32,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      i32.eqz
      if
@@ -16865,12 +16675,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -16882,17 +16692,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|1
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -16905,198 +16715,176 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 19
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store
-   local.get $7
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=12
-   local.get $6
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $6
-   local.get $6
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 2
-   i32.shl
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=12
-   local.get $7
-   local.get $8
-   i32.store
-   local.get $7
-   local.get $8
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $6
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $3
-    local.get $6
-    i32.lt_s
-    if
-     local.get $5
-     local.get $3
-     i32.const 12
-     i32.mul
-     i32.add
-     local.tee $8
+   block $"__inlined_func$~lib/map/Map<u32,i32>#keys$11" (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
      i32.load offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
+     i32.load offset=16
+     local.set $8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 19
+     call $~lib/rt/itcms/__new
+     local.tee $9
+     i32.store
+     local.get $8
+     i32.const 268435455
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $7
-      i32.store
-      local.get $7
-      local.get $0
-      local.get $8
-      i32.load
-      call $~lib/array/Array<i32>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1728
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $8
+     local.get $8
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 2
+     i32.shl
+     local.tee $1
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=12
+     local.get $9
+     local.get $5
+     i32.store
+     local.get $9
+     local.get $5
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $1
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $8
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=4
+     loop $for-loop|01
+      local.get $3
+      local.get $8
+      i32.lt_s
+      if
+       local.get $6
+       local.get $3
+       i32.const 12
+       i32.mul
+       i32.add
+       local.tee $1
+       i32.load offset=8
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $9
+        i32.store
+        local.get $9
+        local.get $0
+        local.get $1
+        i32.load
+        call $~lib/array/Array<i32>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|01
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store
+     local.get $9
+     local.get $0
+     call $~lib/array/Array<i32>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     br $"__inlined_func$~lib/map/Map<u32,i32>#keys$11"
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store
-   local.get $7
-   local.get $0
-   call $~lib/array/Array<i32>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#values"
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -17117,67 +16905,55 @@
    i32.const 24
    i32.const 20
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $5
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 48
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    call $"~lib/map/Map<i32,i32>#constructor"
@@ -17185,15 +16961,15 @@
    i32.store offset=20
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $0
     i32.store offset=4
-    local.get $7
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -17207,10 +16983,10 @@
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $2
-     local.get $7
+     local.get $4
+     local.get $0
      i32.load offset=12
      i32.ge_u
      if
@@ -17222,32 +16998,32 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $7
+     local.get $0
      i32.load offset=4
-     local.get $2
+     local.get $4
      i32.const 2
      i32.shl
      i32.add
      i32.load
-     local.set $5
+     local.set $6
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $1
      i32.store offset=4
-     local.get $0
-     local.get $2
+     local.get $1
+     local.get $4
      call $~lib/array/Array<i32>#__get
-     local.set $6
+     local.set $7
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $5
+     local.get $2
+     local.get $6
      call $"~lib/map/Map<u32,i32>#has"
      i32.eqz
      if
@@ -17259,10 +17035,10 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $7
      i32.const 20
      i32.sub
      call $"~lib/map/Map<u32,i32>#has"
@@ -17276,33 +17052,33 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $5
      i32.store offset=4
-     local.get $4
      local.get $5
-     local.get $5
+     local.get $6
+     local.get $6
      call $"~lib/map/Map<u32,u32>#set"
      global.get $~lib/memory/__stack_pointer
      local.get $3
      i32.store offset=4
      local.get $3
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
-     local.tee $5
-     local.get $5
+     local.tee $6
+     local.get $6
      call $"~lib/map/Map<i32,i32>#set"
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -17330,17 +17106,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|3
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      i32.eqz
      if
@@ -17352,12 +17128,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -17370,16 +17146,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      if
       i32.const 0
@@ -17389,17 +17165,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|3
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -17412,17 +17188,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|4
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      if
       i32.const 0
@@ -17433,19 +17209,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<u32,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      i32.eqz
      if
@@ -17457,16 +17233,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u32,i32>#has"
      if
       i32.const 0
@@ -17476,17 +17252,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|4
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -17499,14 +17275,14 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#clear"
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    if
     i32.const 0
@@ -17539,6 +17315,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -17571,78 +17348,66 @@
    i32.const 24
    i32.const 15
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 48
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store
    loop $for-loop|0
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      if
       i32.const 0
@@ -17653,19 +17418,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<u16,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      i32.eqz
      if
@@ -17677,12 +17442,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -17694,17 +17459,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -17717,17 +17482,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|1
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      i32.eqz
      if
@@ -17739,12 +17504,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -17757,19 +17522,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      call $"~lib/map/Map<u16,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      i32.eqz
      if
@@ -17781,12 +17546,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -17798,17 +17563,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|1
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -17821,198 +17586,176 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 16
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store
-   local.get $7
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=12
-   local.get $6
-   i32.const 536870910
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $6
-   local.get $6
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 1
-   i32.shl
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=12
-   local.get $7
-   local.get $8
-   i32.store
-   local.get $7
-   local.get $8
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $6
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $3
-    local.get $6
-    i32.lt_s
-    if
-     local.get $5
-     local.get $3
-     i32.const 12
-     i32.mul
-     i32.add
-     local.tee $8
+   block $"__inlined_func$~lib/map/Map<u16,i32>#keys$9" (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
      i32.load offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
+     i32.load offset=16
+     local.set $8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 16
+     call $~lib/rt/itcms/__new
+     local.tee $9
+     i32.store
+     local.get $8
+     i32.const 536870910
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $7
-      i32.store
-      local.get $7
-      local.get $0
-      local.get $8
-      i32.load16_u
-      call $~lib/array/Array<i16>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1728
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $8
+     local.get $8
+     i32.const 8
+     i32.le_u
+     select
      i32.const 1
+     i32.shl
+     local.tee $1
+     i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=12
+     local.get $9
+     local.get $5
+     i32.store
+     local.get $9
+     local.get $5
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $1
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $8
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=4
+     loop $for-loop|01
+      local.get $3
+      local.get $8
+      i32.lt_s
+      if
+       local.get $6
+       local.get $3
+       i32.const 12
+       i32.mul
+       i32.add
+       local.tee $1
+       i32.load offset=8
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $9
+        i32.store
+        local.get $9
+        local.get $0
+        local.get $1
+        i32.load16_u
+        call $~lib/array/Array<i16>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|01
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store
+     local.get $9
+     local.get $0
+     call $~lib/array/Array<i16>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     br $"__inlined_func$~lib/map/Map<u16,i32>#keys$9"
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store
-   local.get $7
-   local.get $0
-   call $~lib/array/Array<i16>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#values"
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -18033,67 +17776,55 @@
    i32.const 24
    i32.const 17
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $5
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 32
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    call $"~lib/map/Map<i32,i32>#constructor"
@@ -18101,15 +17832,15 @@
    i32.store offset=20
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $0
     i32.store offset=4
-    local.get $7
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -18123,10 +17854,10 @@
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $2
-     local.get $7
+     local.get $4
+     local.get $0
      i32.load offset=12
      i32.ge_u
      if
@@ -18138,32 +17869,32 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $7
+     local.get $0
      i32.load offset=4
-     local.get $2
+     local.get $4
      i32.const 1
      i32.shl
      i32.add
      i32.load16_u
-     local.set $5
+     local.set $6
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $1
      i32.store offset=4
-     local.get $0
-     local.get $2
+     local.get $1
+     local.get $4
      call $~lib/array/Array<i32>#__get
-     local.set $6
+     local.set $7
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $5
+     local.get $2
+     local.get $6
      call $"~lib/map/Map<u16,i32>#has"
      i32.eqz
      if
@@ -18175,10 +17906,10 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $7
      i32.const 20
      i32.sub
      call $"~lib/map/Map<u16,i32>#has"
@@ -18192,33 +17923,33 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $5
      i32.store offset=4
-     local.get $4
      local.get $5
-     local.get $5
+     local.get $6
+     local.get $6
      call $"~lib/map/Map<u16,u16>#set"
      global.get $~lib/memory/__stack_pointer
      local.get $3
      i32.store offset=4
      local.get $3
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
-     local.tee $5
-     local.get $5
+     local.tee $6
+     local.get $6
      call $"~lib/map/Map<i32,i32>#set"
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -18246,17 +17977,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|3
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      i32.eqz
      if
@@ -18268,12 +17999,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -18286,16 +18017,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      if
       i32.const 0
@@ -18305,17 +18036,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|3
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -18328,17 +18059,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|4
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_u
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      if
       i32.const 0
@@ -18349,19 +18080,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<u16,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      i32.eqz
      if
@@ -18373,16 +18104,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<u16,i32>#has"
      if
       i32.const 0
@@ -18392,17 +18123,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|4
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -18415,14 +18146,14 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#clear"
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    if
     i32.const 0
@@ -18455,6 +18186,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -18487,78 +18219,66 @@
    i32.const 24
    i32.const 4
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 48
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store
    loop $for-loop|0
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      if
       i32.const 0
@@ -18569,19 +18289,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<i8,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      i32.eqz
      if
@@ -18593,12 +18313,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -18610,17 +18330,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -18633,17 +18353,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|1
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      i32.eqz
      if
@@ -18655,12 +18375,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -18673,19 +18393,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      call $"~lib/map/Map<i8,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      i32.eqz
      if
@@ -18697,12 +18417,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -18714,17 +18434,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|1
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -18737,196 +18457,174 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store
-   local.get $7
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=12
-   local.get $6
-   i32.const 1073741820
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $6
-   local.get $6
-   i32.const 8
-   i32.le_u
-   select
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=12
-   local.get $7
-   local.get $8
-   i32.store
-   local.get $7
-   local.get $8
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $6
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $3
-    local.get $6
-    i32.lt_s
-    if
-     local.get $5
-     local.get $3
-     i32.const 12
-     i32.mul
-     i32.add
-     local.tee $8
+   block $"__inlined_func$~lib/map/Map<i8,i32>#keys$3" (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
      i32.load offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
+     i32.load offset=16
+     local.set $8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 5
+     call $~lib/rt/itcms/__new
+     local.tee $9
+     i32.store
+     local.get $8
+     i32.const 1073741820
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $7
-      i32.store
-      local.get $7
-      local.get $0
-      local.get $8
-      i32.load8_s
-      call $~lib/array/Array<i8>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1728
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $8
+     local.get $8
+     i32.const 8
+     i32.le_u
+     select
+     local.tee $1
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=12
+     local.get $9
+     local.get $5
+     i32.store
+     local.get $9
+     local.get $5
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $1
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $8
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=4
+     loop $for-loop|01
+      local.get $3
+      local.get $8
+      i32.lt_s
+      if
+       local.get $6
+       local.get $3
+       i32.const 12
+       i32.mul
+       i32.add
+       local.tee $1
+       i32.load offset=8
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $9
+        i32.store
+        local.get $9
+        local.get $0
+        local.get $1
+        i32.load8_s
+        call $~lib/array/Array<i8>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|01
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store
+     local.get $9
+     local.get $0
+     call $~lib/array/Array<i8>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     br $"__inlined_func$~lib/map/Map<i8,i32>#keys$3"
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store
-   local.get $7
-   local.get $0
-   call $~lib/array/Array<i8>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#values"
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -18947,67 +18645,55 @@
    i32.const 24
    i32.const 7
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $5
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 32
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    call $"~lib/map/Map<i32,i32>#constructor"
@@ -19015,15 +18701,15 @@
    i32.store offset=20
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $0
     i32.store offset=4
-    local.get $7
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -19037,10 +18723,10 @@
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $2
-     local.get $7
+     local.get $4
+     local.get $0
      i32.load offset=12
      i32.ge_u
      if
@@ -19052,30 +18738,30 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $2
-     local.get $7
+     local.get $4
+     local.get $0
      i32.load offset=4
      i32.add
      i32.load8_s
-     local.set $5
+     local.set $6
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $1
      i32.store offset=4
-     local.get $0
-     local.get $2
+     local.get $1
+     local.get $4
      call $~lib/array/Array<i32>#__get
-     local.set $6
+     local.set $7
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $5
+     local.get $2
+     local.get $6
      call $"~lib/map/Map<i8,i32>#has"
      i32.eqz
      if
@@ -19087,10 +18773,10 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $7
      i32.const 20
      i32.sub
      call $"~lib/map/Map<i8,i32>#has"
@@ -19104,33 +18790,33 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $5
      i32.store offset=4
-     local.get $4
      local.get $5
-     local.get $5
+     local.get $6
+     local.get $6
      call $"~lib/map/Map<i8,i8>#set"
      global.get $~lib/memory/__stack_pointer
      local.get $3
      i32.store offset=4
      local.get $3
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
-     local.tee $5
-     local.get $5
+     local.tee $6
+     local.get $6
      call $"~lib/map/Map<i32,i32>#set"
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -19158,17 +18844,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|3
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      i32.eqz
      if
@@ -19180,12 +18866,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -19198,16 +18884,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      if
       i32.const 0
@@ -19217,17 +18903,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|3
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -19240,17 +18926,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|4
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      if
       i32.const 0
@@ -19261,19 +18947,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<i8,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      i32.eqz
      if
@@ -19285,16 +18971,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i8,i32>#has"
      if
       i32.const 0
@@ -19304,17 +18990,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|4
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -19327,14 +19013,14 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#clear"
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    if
     i32.const 0
@@ -19368,6 +19054,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -19407,15 +19094,15 @@
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
    local.get $1
-   local.get $5
+   local.get $6
    i32.store
    local.get $1
-   local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -19428,15 +19115,15 @@
    i32.store offset=4
    i32.const 64
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
    local.get $1
-   local.get $5
+   local.get $6
    i32.store offset=8
    local.get $1
-   local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -19444,18 +19131,6 @@
    local.get $1
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
@@ -19655,188 +19330,168 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $7
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 22
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store
-   local.get $8
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=12
-   local.get $7
-   i32.const 134217727
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $7
-   local.get $7
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 3
-   i32.shl
-   local.tee $9
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $4
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=12
-   local.get $8
-   local.get $4
-   i32.store
-   local.get $8
-   local.get $4
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $4
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $9
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $7
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   loop $for-loop|00
-    local.get $3
-    local.get $7
-    i32.lt_s
-    if
-     local.get $6
-     local.get $3
-     i32.const 4
-     i32.shl
-     i32.add
-     local.tee $4
-     i32.load offset=12
-     i32.const 1
-     i32.and
-     i32.eqz
+   block $"__inlined_func$~lib/map/Map<i64,i32>#keys$19" (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $8
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 22
+     call $~lib/rt/itcms/__new
+     local.tee $10
+     i32.store
+     local.get $5
+     i32.const 134217727
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $8
-      i32.store
-      local.get $8
-      local.get $0
-      local.get $4
-      i64.load
-      call $~lib/array/Array<i64>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1728
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $5
+     local.get $5
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 3
+     i32.shl
+     local.tee $6
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $7
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=12
+     local.get $10
+     local.get $7
+     i32.store
+     local.get $10
+     local.get $7
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $7
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $6
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $5
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=4
+     loop $for-loop|01
+      local.get $3
+      local.get $5
+      i32.lt_s
+      if
+       local.get $8
+       local.get $3
+       i32.const 4
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=12
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $10
+        i32.store
+        local.get $10
+        local.get $0
+        local.get $6
+        i64.load
+        call $~lib/array/Array<i64>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|01
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store
+     local.get $10
+     local.get $0
+     call $~lib/array/Array<i64>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     br $"__inlined_func$~lib/map/Map<i64,i32>#keys$19"
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store
-   local.get $8
-   local.get $0
-   call $~lib/array/Array<i64>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $1
@@ -19844,7 +19499,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    call $"~lib/map/Map<i64,i32>#values"
-   local.tee $0
+   local.tee $3
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -19865,85 +19520,71 @@
    i32.const 24
    i32.const 23
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $6
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $7
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $7
    i32.store offset=8
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    i32.store
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
-   local.get $4
+   local.get $6
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
    i32.const 96
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $7
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $7
    i32.store offset=8
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    i32.store offset=8
-   local.get $4
-   local.get $5
+   local.get $6
+   local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
-   local.get $4
+   local.get $6
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    call $"~lib/map/Map<i32,i32>#constructor"
    local.tee $5
    i32.store offset=20
-   i32.const 0
-   local.set $3
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $0
     i32.store offset=4
-    local.get $8
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $3
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -19957,10 +19598,10 @@
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store
-     local.get $3
-     local.get $8
+     local.get $4
+     local.get $0
      i32.load offset=12
      i32.ge_u
      if
@@ -19972,11 +19613,11 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store
-     local.get $8
+     local.get $0
      i32.load offset=4
-     local.get $3
+     local.get $4
      i32.const 3
      i32.shl
      i32.add
@@ -19987,12 +19628,12 @@
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $0
-     i32.store offset=4
-     local.get $0
      local.get $3
+     i32.store offset=4
+     local.get $3
+     local.get $4
      call $~lib/array/Array<i32>#__get
-     local.set $6
+     local.set $7
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
@@ -20012,7 +19653,7 @@
      local.get $1
      i32.store offset=4
      local.get $1
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
      i64.extend_i32_s
@@ -20027,9 +19668,9 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $6
      i32.store offset=4
-     local.get $4
+     local.get $6
      local.get $2
      local.get $2
      call $"~lib/map/Map<i64,i64>#set"
@@ -20037,23 +19678,23 @@
      local.get $5
      i32.store offset=4
      local.get $5
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
-     local.tee $6
-     local.get $6
+     local.tee $7
+     local.get $7
      call $"~lib/map/Map<i32,i32>#set"
-     local.get $3
+     local.get $4
      i32.const 1
      i32.add
-     local.set $3
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $6
    i32.store offset=4
-   local.get $4
+   local.get $6
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -20913,6 +20554,7 @@
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
+  (local $9 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 24
   i32.sub
@@ -20945,78 +20587,66 @@
    i32.const 24
    i32.const 12
    call $~lib/rt/itcms/__new
-   local.tee $1
+   local.tee $2
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    i32.const 48
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    i32.store offset=8
-   local.get $1
-   local.get $5
+   local.get $2
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store offset=4
-   local.get $1
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store
    loop $for-loop|0
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      if
       i32.const 0
@@ -21027,19 +20657,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<i16,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      i32.eqz
      if
@@ -21051,12 +20681,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -21068,17 +20698,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -21091,17 +20721,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|1
-    local.get $0
+    local.get $1
     i32.const 100
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      i32.eqz
      if
@@ -21113,12 +20743,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      i32.ne
@@ -21131,19 +20761,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      call $"~lib/map/Map<i16,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      i32.eqz
      if
@@ -21155,12 +20785,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -21172,17 +20802,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|1
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -21195,198 +20825,176 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1896
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 13
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store
-   local.get $7
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   i32.const 0
-   i32.store offset=12
-   local.get $6
-   i32.const 536870910
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1728
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $6
-   local.get $6
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 1
-   i32.shl
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=12
-   local.get $7
-   local.get $8
-   i32.store
-   local.get $7
-   local.get $8
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   local.get $7
-   local.get $6
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $3
-    local.get $6
-    i32.lt_s
-    if
-     local.get $5
-     local.get $3
-     i32.const 12
-     i32.mul
-     i32.add
-     local.tee $8
+   block $"__inlined_func$~lib/map/Map<i16,i32>#keys$7" (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
      i32.load offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $2
+     i32.store
+     local.get $2
+     i32.load offset=16
+     local.set $8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1896
+     i32.lt_s
+     br_if $folding-inner00
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 13
+     call $~lib/rt/itcms/__new
+     local.tee $9
+     i32.store
+     local.get $8
+     i32.const 536870910
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $7
-      i32.store
-      local.get $7
-      local.get $0
-      local.get $8
-      i32.load16_s
-      call $~lib/array/Array<i16>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1728
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $8
+     local.get $8
+     i32.const 8
+     i32.le_u
+     select
      i32.const 1
+     i32.shl
+     local.tee $1
+     i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $5
+     i32.store offset=12
+     local.get $9
+     local.get $5
+     i32.store
+     local.get $9
+     local.get $5
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $5
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $1
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=8
+     local.get $9
+     local.get $8
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store offset=4
+     loop $for-loop|01
+      local.get $3
+      local.get $8
+      i32.lt_s
+      if
+       local.get $6
+       local.get $3
+       i32.const 12
+       i32.mul
+       i32.add
+       local.tee $1
+       i32.load offset=8
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $9
+        i32.store
+        local.get $9
+        local.get $0
+        local.get $1
+        i32.load16_s
+        call $~lib/array/Array<i16>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|01
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $9
+     i32.store
+     local.get $9
+     local.get $0
+     call $~lib/array/Array<i16>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $9
+     br $"__inlined_func$~lib/map/Map<i16,i32>#keys$7"
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store
-   local.get $7
-   local.get $0
-   call $~lib/array/Array<i16>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $7
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#values"
-   local.tee $0
+   local.tee $1
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
@@ -21407,67 +21015,55 @@
    i32.const 24
    i32.const 14
    call $~lib/rt/itcms/__new
-   local.tee $4
+   local.tee $5
    i32.store
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 16
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 3
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
    i32.const 32
    call $~lib/arraybuffer/ArrayBuffer#constructor
-   local.set $5
+   local.set $6
    global.get $~lib/memory/__stack_pointer
-   local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    i32.store offset=8
-   local.get $4
    local.get $5
+   local.get $6
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $4
-   i32.store offset=4
-   local.get $4
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=16
    global.get $~lib/memory/__stack_pointer
    call $"~lib/map/Map<i32,i32>#constructor"
@@ -21475,15 +21071,15 @@
    i32.store offset=20
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $7
+    local.get $0
     i32.store offset=4
-    local.get $7
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
      i32.const 4
@@ -21497,10 +21093,10 @@
      i32.const 0
      i32.store
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $2
-     local.get $7
+     local.get $4
+     local.get $0
      i32.load offset=12
      i32.ge_u
      if
@@ -21512,32 +21108,32 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $7
+     local.get $0
      i32.store
-     local.get $7
+     local.get $0
      i32.load offset=4
-     local.get $2
+     local.get $4
      i32.const 1
      i32.shl
      i32.add
      i32.load16_s
-     local.set $5
+     local.set $6
      global.get $~lib/memory/__stack_pointer
      i32.const 4
      i32.add
      global.set $~lib/memory/__stack_pointer
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $1
      i32.store offset=4
-     local.get $0
-     local.get $2
+     local.get $1
+     local.get $4
      call $~lib/array/Array<i32>#__get
-     local.set $6
+     local.set $7
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $5
+     local.get $2
+     local.get $6
      call $"~lib/map/Map<i16,i32>#has"
      i32.eqz
      if
@@ -21549,10 +21145,10 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
-     local.get $1
-     local.get $6
+     local.get $2
+     local.get $7
      i32.const 20
      i32.sub
      call $"~lib/map/Map<i16,i32>#has"
@@ -21566,33 +21162,33 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $4
+     local.get $5
      i32.store offset=4
-     local.get $4
      local.get $5
-     local.get $5
+     local.get $6
+     local.get $6
      call $"~lib/map/Map<i16,i16>#set"
      global.get $~lib/memory/__stack_pointer
      local.get $3
      i32.store offset=4
      local.get $3
-     local.get $6
+     local.get $7
      i32.const 20
      i32.sub
-     local.tee $5
-     local.get $5
+     local.tee $6
+     local.get $6
      call $"~lib/map/Map<i32,i32>#set"
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $4
+   local.get $5
    i32.store offset=4
-   local.get $4
+   local.get $5
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 100
    i32.ne
@@ -21620,17 +21216,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|3
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      i32.eqz
      if
@@ -21642,12 +21238,12 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#get"
-     local.get $0
+     local.get $1
      i32.const 20
      i32.add
      i32.ne
@@ -21660,16 +21256,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      if
       i32.const 0
@@ -21679,17 +21275,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|3
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -21702,17 +21298,17 @@
     unreachable
    end
    i32.const 0
-   local.set $0
+   local.set $1
    loop $for-loop|4
-    local.get $0
+    local.get $1
     i32.const 50
     i32.lt_s
     if
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      if
       i32.const 0
@@ -21723,19 +21319,19 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
-     local.get $0
+     local.get $1
      i32.const 10
      i32.add
      call $"~lib/map/Map<i16,i32>#set"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      i32.eqz
      if
@@ -21747,16 +21343,16 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#delete"
      global.get $~lib/memory/__stack_pointer
-     local.get $1
+     local.get $2
      i32.store offset=4
+     local.get $2
      local.get $1
-     local.get $0
      call $"~lib/map/Map<i16,i32>#has"
      if
       i32.const 0
@@ -21766,17 +21362,17 @@
       call $~lib/builtins/abort
       unreachable
      end
-     local.get $0
+     local.get $1
      i32.const 1
      i32.add
-     local.set $0
+     local.set $1
      br $for-loop|4
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    i32.const 50
    i32.ne
@@ -21789,14 +21385,14 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#clear"
    global.get $~lib/memory/__stack_pointer
-   local.get $1
+   local.get $2
    i32.store offset=4
-   local.get $1
+   local.get $2
    call $"~lib/map/Map<i8,i32>#get:size"
    if
     i32.const 0
@@ -21904,18 +21500,6 @@
    local.get $0
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
@@ -22193,18 +21777,6 @@
    local.get $6
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
@@ -22650,18 +22222,6 @@
    i32.const 4
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=20
-   global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
@@ -22938,18 +22498,6 @@
    local.get $6
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add

--- a/tests/compiler/std/set.debug.wat
+++ b/tests/compiler/std/set.debug.wat
@@ -2367,16 +2367,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $~lib/set/Set<i8>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<i8>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $~lib/util/hash/HASH<i8> (param $key i32) (result i32)
   (local $key|1 i32)
   (local $len i32)
@@ -2487,6 +2477,16 @@
   local.get $this
   local.get $taggedNext
   i32.store offset=4
+ )
+ (func $~lib/set/Set<i8>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<i8>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
  )
  (func $~lib/array/Array<i8>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
@@ -2606,16 +2606,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $~lib/set/Set<u8>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<u8>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $~lib/util/hash/HASH<u8> (param $key i32) (result i32)
   (local $key|1 i32)
   (local $len i32)
@@ -2728,6 +2718,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $~lib/set/Set<u8>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<u8>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u8>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -2787,16 +2787,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<i16>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<i16>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<i16> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -2909,6 +2899,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $~lib/set/Set<i16>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<i16>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<i16>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -2968,16 +2968,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<u16>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<u16>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<u16> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -3091,6 +3081,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $~lib/set/Set<u16>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<u16>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u16>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3150,16 +3150,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<i32>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<i32>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<i32> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -3271,6 +3261,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $~lib/set/Set<i32>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<i32>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<i32>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3330,16 +3330,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<u32>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<u32>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<u32> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -3451,6 +3441,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $~lib/set/Set<u32>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<u32>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u32>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3510,16 +3510,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<i64>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<i64>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<i64> (param $key i64) (result i32)
   (local $key|1 i64)
@@ -3648,6 +3638,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $~lib/set/Set<i64>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<i64>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<i64>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3707,16 +3707,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<u64>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<u64>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<u64> (param $key i64) (result i32)
   (local $key|1 i64)
@@ -3845,6 +3835,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $~lib/set/Set<u64>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<u64>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<u64>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -3904,16 +3904,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<f32>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<f32>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<f32> (param $key f32) (result i32)
   (local $key|1 i32)
@@ -4026,6 +4016,16 @@
   local.get $taggedNext
   i32.store offset=4
  )
+ (func $~lib/set/Set<f32>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<f32>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $~lib/array/Array<f32>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
   local.get $buffer
@@ -4085,16 +4085,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $~lib/set/Set<f64>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $~lib/set/Set<f64>#set:entriesCount (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<f64> (param $key f64) (result i32)
   (local $key|1 i64)
@@ -4223,6 +4213,16 @@
   local.get $this
   local.get $taggedNext
   i32.store offset=8
+ )
+ (func $~lib/set/Set<f64>#set:entriesOffset (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $~lib/set/Set<f64>#set:entriesCount (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
  )
  (func $~lib/array/Array<f64>#set:buffer (param $this i32) (param $buffer i32)
   local.get $this
@@ -4798,22 +4798,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i8>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i8>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -5363,38 +5347,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i8>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 0
@@ -5424,7 +5376,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -5433,7 +5385,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -5446,7 +5398,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i8>#set:dataStart
@@ -5454,7 +5406,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i8>#set:byteLength
@@ -5462,7 +5414,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i8>#set:length_
@@ -6649,22 +6601,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u8>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u8>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -7216,38 +7152,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u8>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 0
@@ -7277,7 +7181,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -7286,7 +7190,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -7299,7 +7203,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u8>#set:dataStart
@@ -7307,7 +7211,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u8>#set:byteLength
@@ -7315,7 +7219,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u8>#set:length_
@@ -8383,22 +8287,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i16>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i16>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -8948,38 +8836,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i16>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 1
@@ -9009,7 +8865,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -9018,7 +8874,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -9031,7 +8887,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i16>#set:dataStart
@@ -9039,7 +8895,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i16>#set:byteLength
@@ -9047,7 +8903,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i16>#set:length_
@@ -10115,22 +9971,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u16>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u16>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -10682,38 +10522,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u16>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 1
@@ -10743,7 +10551,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -10752,7 +10560,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -10765,7 +10573,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u16>#set:dataStart
@@ -10773,7 +10581,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u16>#set:byteLength
@@ -10781,7 +10589,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u16>#set:length_
@@ -11849,22 +11657,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i32>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i32>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -12412,38 +12204,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -12473,7 +12233,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -12482,7 +12242,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -12495,7 +12255,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i32>#set:dataStart
@@ -12503,7 +12263,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i32>#set:byteLength
@@ -12511,7 +12271,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i32>#set:length_
@@ -13579,22 +13339,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u32>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u32>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -14142,38 +13886,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -14203,7 +13915,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -14212,7 +13924,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -14225,7 +13937,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u32>#set:dataStart
@@ -14233,7 +13945,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u32>#set:byteLength
@@ -14241,7 +13953,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u32>#set:length_
@@ -15309,22 +15021,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i64>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<i64>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -15872,38 +15568,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<i64>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 3
@@ -15933,7 +15597,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -15942,7 +15606,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -15955,7 +15619,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<i64>#set:dataStart
@@ -15963,7 +15627,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<i64>#set:byteLength
@@ -15971,7 +15635,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<i64>#set:length_
@@ -17040,22 +16704,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u64>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<u64>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -17603,38 +17251,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<u64>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 3
@@ -17664,7 +17280,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -17673,7 +17289,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -17686,7 +17302,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<u64>#set:dataStart
@@ -17694,7 +17310,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<u64>#set:byteLength
@@ -17702,7 +17318,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<u64>#set:length_
@@ -18771,22 +18387,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<f32>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<f32>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -19334,38 +18934,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f32>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 2
@@ -19395,7 +18963,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -19404,7 +18972,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -19417,7 +18985,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<f32>#set:dataStart
@@ -19425,7 +18993,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<f32>#set:byteLength
@@ -19433,7 +19001,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<f32>#set:length_
@@ -20502,22 +20070,6 @@
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<f64>#set:entriesOffset
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $~lib/set/Set<f64>#set:entriesCount
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -21065,38 +20617,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:buffer
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:dataStart
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:byteLength
-  local.get $this
-  local.set $6
-  global.get $~lib/memory/__stack_pointer
-  local.get $6
-  i32.store offset=4
-  local.get $6
-  i32.const 0
-  call $~lib/array/Array<f64>#set:length_
   local.get $length
   i32.const 1073741820
   i32.const 3
@@ -21126,7 +20646,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -21135,7 +20655,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   local.set $6
@@ -21148,7 +20668,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $buffer
   call $~lib/array/Array<f64>#set:dataStart
@@ -21156,7 +20676,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $bufferSize
   call $~lib/array/Array<f64>#set:byteLength
@@ -21164,7 +20684,7 @@
   local.set $6
   global.get $~lib/memory/__stack_pointer
   local.get $6
-  i32.store offset=4
+  i32.store offset=8
   local.get $6
   local.get $length
   call $~lib/array/Array<f64>#set:length_

--- a/tests/compiler/std/set.release.wat
+++ b/tests/compiler/std/set.release.wat
@@ -1219,7 +1219,7 @@
     select
     local.set $1
    end
-   block $__inlined_func$~lib/rt/itcms/__renew$893
+   block $__inlined_func$~lib/rt/itcms/__renew$833
     local.get $4
     i32.const 20
     i32.sub
@@ -1237,7 +1237,7 @@
      i32.store offset=16
      local.get $4
      local.set $2
-     br $__inlined_func$~lib/rt/itcms/__renew$893
+     br $__inlined_func$~lib/rt/itcms/__renew$833
     end
     local.get $1
     local.get $3
@@ -4586,7 +4586,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$904
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$846
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -4610,7 +4610,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$904
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$846
    end
    local.get $0
    i32.load offset=8
@@ -5252,18 +5252,6 @@
   i32.const 4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -5693,18 +5681,6 @@
   i32.const 4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -6107,18 +6083,6 @@
   local.get $0
   i32.const 4
   i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -6525,18 +6489,6 @@
   i32.const 4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -6940,18 +6892,6 @@
   local.get $0
   i32.const 4
   i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -7382,18 +7322,6 @@
   i32.const 4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -7796,18 +7724,6 @@
   local.get $0
   i32.const 4
   i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -8212,18 +8128,6 @@
   local.get $0
   i32.const 4
   i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -8660,18 +8564,6 @@
   i32.const 4
   i32.store offset=12
   global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
-  global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
   global.set $~lib/memory/__stack_pointer
@@ -9078,18 +8970,6 @@
   local.get $0
   i32.const 4
   i32.store offset=12
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=16
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=20
   global.get $~lib/memory/__stack_pointer
   i32.const 12
   i32.add
@@ -10383,8 +10263,8 @@
  (func $~lib/set/Set<f64>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f64)
+  (local $3 f64)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -10392,11 +10272,11 @@
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -10405,14 +10285,14 @@
    i32.store
    local.get $0
    i32.load offset=8
-   local.set $3
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
+   local.set $6
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.sub
@@ -10420,7 +10300,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -10431,36 +10311,9 @@
    i32.const 16
    i32.const 23
    call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
+   local.tee $2
    i32.store
    local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
    i32.const 134217727
    i32.gt_u
    if
@@ -10473,8 +10326,8 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $6
+   local.get $6
    i32.const 8
    i32.le_u
    select
@@ -10484,50 +10337,52 @@
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store offset=12
-   local.get $6
+   local.get $2
    local.get $7
    i32.store
-   local.get $6
+   local.get $2
    local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $7
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store offset=4
+   i32.const 0
+   local.set $0
    loop $for-loop|0
-    local.get $2
     local.get $5
+    local.get $6
     i32.lt_s
     if
-     local.get $3
-     local.get $2
+     local.get $4
+     local.get $5
      i32.const 4
      i32.shl
      i32.add
@@ -10538,16 +10393,16 @@
      i32.eqz
      if
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $1
-      local.tee $0
+      local.get $0
+      local.tee $1
       i32.const 1
       i32.add
-      local.set $1
+      local.set $0
       local.get $7
       f64.load
-      local.set $4
+      local.set $3
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.sub
@@ -10555,19 +10410,19 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1748
       i32.lt_s
-      br_if $folding-inner1
+      br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $0
-      local.get $6
+      local.get $1
+      local.get $2
       i32.load offset=12
       i32.ge_u
       if
-       local.get $0
+       local.get $1
        i32.const 0
        i32.lt_s
        if
@@ -10578,8 +10433,8 @@
         call $~lib/builtins/abort
         unreachable
        end
-       local.get $6
-       local.get $0
+       local.get $2
+       local.get $1
        i32.const 1
        i32.add
        local.tee $7
@@ -10587,46 +10442,46 @@
        i32.const 1
        call $~lib/array/ensureCapacity
        global.get $~lib/memory/__stack_pointer
-       local.get $6
+       local.get $2
        i32.store
-       local.get $6
+       local.get $2
        local.get $7
        i32.store offset=12
       end
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $6
+      local.get $2
       i32.load offset=4
-      local.get $0
+      local.get $1
       i32.const 3
       i32.shl
       i32.add
-      local.get $4
+      local.get $3
       f64.store
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.add
       global.set $~lib/memory/__stack_pointer
      end
-     local.get $2
+     local.get $5
      i32.const 1
      i32.add
-     local.set $2
+     local.set $5
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store
-   local.get $6
-   local.get $1
+   local.get $2
+   local.get $0
    call $~lib/array/Array<i64>#set:length
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    return
   end
   i32.const 34544
@@ -10639,8 +10494,8 @@
  (func $~lib/set/Set<f32>#values (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
-  (local $3 i32)
-  (local $4 f32)
+  (local $3 f32)
+  (local $4 i32)
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
@@ -10648,11 +10503,11 @@
   i32.const 8
   i32.sub
   global.set $~lib/memory/__stack_pointer
-  block $folding-inner1
+  block $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -10661,14 +10516,14 @@
    i32.store
    local.get $0
    i32.load offset=8
-   local.set $3
+   local.set $4
+   global.get $~lib/memory/__stack_pointer
    global.get $~lib/memory/__stack_pointer
    local.get $0
    i32.store
    local.get $0
    i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
+   local.set $6
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.sub
@@ -10676,7 +10531,7 @@
    global.get $~lib/memory/__stack_pointer
    i32.const 1748
    i32.lt_s
-   br_if $folding-inner1
+   br_if $folding-inner0
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
@@ -10687,36 +10542,9 @@
    i32.const 16
    i32.const 21
    call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
+   local.tee $2
    i32.store
    local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
    i32.const 268435455
    i32.gt_u
    if
@@ -10729,8 +10557,8 @@
    end
    global.get $~lib/memory/__stack_pointer
    i32.const 8
-   local.get $5
-   local.get $5
+   local.get $6
+   local.get $6
    i32.const 8
    i32.le_u
    select
@@ -10740,50 +10568,52 @@
    i32.const 1
    call $~lib/rt/itcms/__new
    local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
    i32.store offset=4
+   global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    local.get $7
    i32.store offset=12
-   local.get $6
+   local.get $2
    local.get $7
    i32.store
-   local.get $6
+   local.get $2
    local.get $7
    call $~lib/rt/itcms/__link
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $7
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
+   local.get $2
+   i32.store offset=8
+   local.get $2
    local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
    i32.const 16
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store offset=4
+   i32.const 0
+   local.set $0
    loop $for-loop|0
-    local.get $2
     local.get $5
+    local.get $6
     i32.lt_s
     if
-     local.get $3
-     local.get $2
+     local.get $4
+     local.get $5
      i32.const 3
      i32.shl
      i32.add
@@ -10794,16 +10624,16 @@
      i32.eqz
      if
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $1
-      local.tee $0
+      local.get $0
+      local.tee $1
       i32.const 1
       i32.add
-      local.set $1
+      local.set $0
       local.get $7
       f32.load
-      local.set $4
+      local.set $3
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.sub
@@ -10811,19 +10641,19 @@
       global.get $~lib/memory/__stack_pointer
       i32.const 1748
       i32.lt_s
-      br_if $folding-inner1
+      br_if $folding-inner0
       global.get $~lib/memory/__stack_pointer
       i32.const 0
       i32.store
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $0
-      local.get $6
+      local.get $1
+      local.get $2
       i32.load offset=12
       i32.ge_u
       if
-       local.get $0
+       local.get $1
        i32.const 0
        i32.lt_s
        if
@@ -10834,8 +10664,8 @@
         call $~lib/builtins/abort
         unreachable
        end
-       local.get $6
-       local.get $0
+       local.get $2
+       local.get $1
        i32.const 1
        i32.add
        local.tee $7
@@ -10843,46 +10673,46 @@
        i32.const 1
        call $~lib/array/ensureCapacity
        global.get $~lib/memory/__stack_pointer
-       local.get $6
+       local.get $2
        i32.store
-       local.get $6
+       local.get $2
        local.get $7
        i32.store offset=12
       end
       global.get $~lib/memory/__stack_pointer
-      local.get $6
+      local.get $2
       i32.store
-      local.get $6
+      local.get $2
       i32.load offset=4
-      local.get $0
+      local.get $1
       i32.const 2
       i32.shl
       i32.add
-      local.get $4
+      local.get $3
       f32.store
       global.get $~lib/memory/__stack_pointer
       i32.const 4
       i32.add
       global.set $~lib/memory/__stack_pointer
      end
-     local.get $2
+     local.get $5
      i32.const 1
      i32.add
-     local.set $2
+     local.set $5
      br $for-loop|0
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    i32.store
-   local.get $6
-   local.get $1
+   local.get $2
+   local.get $0
    call $~lib/array/Array<i32>#set:length
    global.get $~lib/memory/__stack_pointer
    i32.const 8
    i32.add
    global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.get $2
    return
   end
   i32.const 34544
@@ -10901,6 +10731,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -11046,213 +10877,191 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 7
-   call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
-   i32.const 1073741820
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $5
-   local.get $5
-   i32.const 8
-   i32.le_u
-   select
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $6
-   local.get $7
-   i32.store
-   local.get $6
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $2
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
+   block $__inlined_func$~lib/set/Set<u8>#values$3 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 7
+     call $~lib/rt/itcms/__new
      local.tee $7
-     i32.load offset=4
-     i32.const 1
-     i32.and
-     i32.eqz
+     i32.store
+     local.get $3
+     i32.const 1073741820
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $6
-      i32.store
-      local.get $6
-      local.get $0
-      local.get $7
-      i32.load8_u
-      call $~lib/array/Array<i8>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $3
+     local.get $3
+     i32.const 8
+     i32.le_u
+     select
+     local.tee $8
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $7
+     local.get $0
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $8
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $3
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $2
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=4
+     i32.const 0
+     local.set $0
+     loop $for-loop|00
+      local.get $2
+      local.get $3
+      i32.lt_s
+      if
+       local.get $5
+       local.get $2
+       i32.const 3
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=4
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        local.get $7
+        local.get $0
+        local.get $6
+        i32.load8_u
+        call $~lib/array/Array<i8>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $2
+       i32.const 1
+       i32.add
+       local.set $2
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/array/Array<i8>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     br $__inlined_func$~lib/set/Set<u8>#values$3
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store
-   local.get $6
-   local.get $0
-   call $~lib/array/Array<i8>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<u8>#constructor
-   local.tee $0
+   local.tee $2
    i32.store offset=12
-   i32.const 0
-   local.set $2
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $6
+    local.get $0
     i32.store offset=4
-    local.get $6
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $6
-     local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<u8>#__get
      call $~lib/set/Set<u8>#has
      i32.eqz
@@ -11265,27 +11074,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $2
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store offset=16
      local.get $0
-     local.get $6
+     i32.store offset=16
      local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<u8>#__get
      call $~lib/set/Set<u8>#add
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=4
-   local.get $0
+   local.get $2
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -11493,6 +11302,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -11638,213 +11448,191 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 19
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store
-   local.get $8
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=12
-   local.get $6
-   i32.const 134217727
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $6
-   local.get $6
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 3
-   i32.shl
-   local.tee $9
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $8
-   local.get $7
-   i32.store
-   local.get $8
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $9
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $6
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   loop $for-loop|00
-    local.get $3
-    local.get $6
-    i32.lt_s
-    if
-     local.get $5
-     local.get $3
-     i32.const 4
-     i32.shl
-     i32.add
-     local.tee $7
+   block $__inlined_func$~lib/set/Set<u64>#values$17 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
      i32.load offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 19
+     call $~lib/rt/itcms/__new
+     local.tee $10
+     i32.store
+     local.get $4
+     i32.const 134217727
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $8
-      i32.store
-      local.get $8
-      local.get $0
-      local.get $7
-      i64.load
-      call $~lib/array/Array<i64>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $4
+     local.get $4
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 3
+     i32.shl
+     local.tee $7
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $8
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $8
+     i32.store offset=12
+     local.get $10
+     local.get $8
+     i32.store
+     local.get $10
+     local.get $8
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $8
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $4
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=4
+     loop $for-loop|00
+      local.get $3
+      local.get $4
+      i32.lt_s
+      if
+       local.get $6
+       local.get $3
+       i32.const 4
+       i32.shl
+       i32.add
+       local.tee $7
+       i32.load offset=8
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $10
+        i32.store
+        local.get $10
+        local.get $0
+        local.get $7
+        i64.load
+        call $~lib/array/Array<i64>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store
+     local.get $10
+     local.get $0
+     call $~lib/array/Array<i64>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     br $__inlined_func$~lib/set/Set<u64>#values$17
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store
-   local.get $8
-   local.get $0
-   call $~lib/array/Array<i64>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<u64>#constructor
-   local.tee $0
+   local.tee $3
    i32.store offset=12
-   i32.const 0
-   local.set $3
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $0
     i32.store offset=4
-    local.get $8
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $3
+    local.get $5
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $8
-     local.get $3
+     local.get $0
+     local.get $5
      call $~lib/array/Array<u64>#__get
      call $~lib/set/Set<u64>#has
      i32.eqz
@@ -11857,27 +11645,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $3
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $8
-     i32.store offset=16
      local.get $0
-     local.get $8
+     i32.store offset=16
      local.get $3
+     local.get $0
+     local.get $5
      call $~lib/array/Array<u64>#__get
      call $~lib/set/Set<u64>#add
-     local.get $3
+     local.get $5
      i32.const 1
      i32.add
-     local.set $3
+     local.set $5
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $3
    i32.store offset=4
-   local.get $0
+   local.get $3
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -12083,6 +11871,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -12228,215 +12017,193 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 15
-   call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $5
-   local.get $5
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 2
-   i32.shl
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $6
-   local.get $7
-   i32.store
-   local.get $6
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $2
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
+   block $__inlined_func$~lib/set/Set<u32>#values$7 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 15
+     call $~lib/rt/itcms/__new
      local.tee $7
-     i32.load offset=4
-     i32.const 1
-     i32.and
-     i32.eqz
+     i32.store
+     local.get $3
+     i32.const 268435455
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $6
-      i32.store
-      local.get $6
-      local.get $0
-      local.get $7
-      i32.load
-      call $~lib/array/Array<i32>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $3
+     local.get $3
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 2
+     i32.shl
+     local.tee $8
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $7
+     local.get $0
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $8
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $3
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $2
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=4
+     i32.const 0
+     local.set $0
+     loop $for-loop|00
+      local.get $2
+      local.get $3
+      i32.lt_s
+      if
+       local.get $5
+       local.get $2
+       i32.const 3
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=4
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        local.get $7
+        local.get $0
+        local.get $6
+        i32.load
+        call $~lib/array/Array<i32>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $2
+       i32.const 1
+       i32.add
+       local.set $2
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/array/Array<i32>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     br $__inlined_func$~lib/set/Set<u32>#values$7
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store
-   local.get $6
-   local.get $0
-   call $~lib/array/Array<i32>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<u32>#constructor
-   local.tee $0
+   local.tee $2
    i32.store offset=12
-   i32.const 0
-   local.set $2
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $6
+    local.get $0
     i32.store offset=4
-    local.get $6
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $6
-     local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<u32>#__get
      call $~lib/set/Set<u32>#has
      i32.eqz
@@ -12449,27 +12216,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $2
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store offset=16
      local.get $0
-     local.get $6
+     i32.store offset=16
      local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<u32>#__get
      call $~lib/set/Set<u32>#add
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=4
-   local.get $0
+   local.get $2
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -12675,6 +12442,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -12820,215 +12588,193 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 11
-   call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
-   i32.const 536870910
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $5
-   local.get $5
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 1
-   i32.shl
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $6
-   local.get $7
-   i32.store
-   local.get $6
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $2
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
+   block $__inlined_func$~lib/set/Set<u16>#values$5 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 11
+     call $~lib/rt/itcms/__new
      local.tee $7
-     i32.load offset=4
-     i32.const 1
-     i32.and
-     i32.eqz
+     i32.store
+     local.get $3
+     i32.const 536870910
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $6
-      i32.store
-      local.get $6
-      local.get $0
-      local.get $7
-      i32.load16_u
-      call $~lib/array/Array<i16>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $3
+     local.get $3
+     i32.const 8
+     i32.le_u
+     select
      i32.const 1
+     i32.shl
+     local.tee $8
+     i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $7
+     local.get $0
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $8
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $3
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $2
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=4
+     i32.const 0
+     local.set $0
+     loop $for-loop|00
+      local.get $2
+      local.get $3
+      i32.lt_s
+      if
+       local.get $5
+       local.get $2
+       i32.const 3
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=4
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        local.get $7
+        local.get $0
+        local.get $6
+        i32.load16_u
+        call $~lib/array/Array<i16>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $2
+       i32.const 1
+       i32.add
+       local.set $2
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/array/Array<i16>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     br $__inlined_func$~lib/set/Set<u16>#values$5
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store
-   local.get $6
-   local.get $0
-   call $~lib/array/Array<i16>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<u16>#constructor
-   local.tee $0
+   local.tee $2
    i32.store offset=12
-   i32.const 0
-   local.set $2
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $6
+    local.get $0
     i32.store offset=4
-    local.get $6
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $6
-     local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<u16>#__get
      call $~lib/set/Set<u16>#has
      i32.eqz
@@ -13041,27 +12787,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $2
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store offset=16
      local.get $0
-     local.get $6
+     i32.store offset=16
      local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<u16>#__get
      call $~lib/set/Set<u16>#add
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=4
-   local.get $0
+   local.get $2
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -13267,6 +13013,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -13412,213 +13159,191 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 5
-   call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
-   i32.const 1073741820
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $5
-   local.get $5
-   i32.const 8
-   i32.le_u
-   select
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $6
-   local.get $7
-   i32.store
-   local.get $6
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $2
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
+   block $__inlined_func$~lib/set/Set<i8>#values$2 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 5
+     call $~lib/rt/itcms/__new
      local.tee $7
-     i32.load offset=4
-     i32.const 1
-     i32.and
-     i32.eqz
+     i32.store
+     local.get $3
+     i32.const 1073741820
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $6
-      i32.store
-      local.get $6
-      local.get $0
-      local.get $7
-      i32.load8_s
-      call $~lib/array/Array<i8>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $3
+     local.get $3
+     i32.const 8
+     i32.le_u
+     select
+     local.tee $8
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $7
+     local.get $0
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $8
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $3
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $2
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=4
+     i32.const 0
+     local.set $0
+     loop $for-loop|00
+      local.get $2
+      local.get $3
+      i32.lt_s
+      if
+       local.get $5
+       local.get $2
+       i32.const 3
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=4
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        local.get $7
+        local.get $0
+        local.get $6
+        i32.load8_s
+        call $~lib/array/Array<i8>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $2
+       i32.const 1
+       i32.add
+       local.set $2
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/array/Array<i8>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     br $__inlined_func$~lib/set/Set<i8>#values$2
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store
-   local.get $6
-   local.get $0
-   call $~lib/array/Array<i8>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<i8>#constructor
-   local.tee $0
+   local.tee $2
    i32.store offset=12
-   i32.const 0
-   local.set $2
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $6
+    local.get $0
     i32.store offset=4
-    local.get $6
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $6
-     local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<i8>#__get
      call $~lib/set/Set<i8>#has
      i32.eqz
@@ -13631,27 +13356,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $2
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store offset=16
      local.get $0
-     local.get $6
+     i32.store offset=16
      local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<i8>#__get
      call $~lib/set/Set<i8>#add
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=4
-   local.get $0
+   local.get $2
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -13859,6 +13584,7 @@
   (local $7 i32)
   (local $8 i32)
   (local $9 i32)
+  (local $10 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -14004,213 +13730,191 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $6
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 17
-   call $~lib/rt/itcms/__new
-   local.tee $8
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store
-   local.get $8
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   i32.const 0
-   i32.store offset=12
-   local.get $6
-   i32.const 134217727
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $6
-   local.get $6
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 3
-   i32.shl
-   local.tee $9
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $8
-   local.get $7
-   i32.store
-   local.get $8
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $9
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   local.get $8
-   local.get $6
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store offset=4
-   loop $for-loop|00
-    local.get $3
-    local.get $6
-    i32.lt_s
-    if
-     local.get $5
-     local.get $3
-     i32.const 4
-     i32.shl
-     i32.add
-     local.tee $7
+   block $__inlined_func$~lib/set/Set<i64>#values$12 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
      i32.load offset=8
-     i32.const 1
-     i32.and
-     i32.eqz
+     local.set $6
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $4
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 17
+     call $~lib/rt/itcms/__new
+     local.tee $10
+     i32.store
+     local.get $4
+     i32.const 134217727
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $8
-      i32.store
-      local.get $8
-      local.get $0
-      local.get $7
-      i64.load
-      call $~lib/array/Array<i64>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $4
+     local.get $4
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 3
+     i32.shl
+     local.tee $7
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $8
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $8
+     i32.store offset=12
+     local.get $10
+     local.get $8
+     i32.store
+     local.get $10
+     local.get $8
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $8
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=8
+     local.get $10
+     local.get $4
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $3
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store offset=4
+     loop $for-loop|00
+      local.get $3
+      local.get $4
+      i32.lt_s
+      if
+       local.get $6
+       local.get $3
+       i32.const 4
+       i32.shl
+       i32.add
+       local.tee $7
+       i32.load offset=8
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $10
+        i32.store
+        local.get $10
+        local.get $0
+        local.get $7
+        i64.load
+        call $~lib/array/Array<i64>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $3
+       i32.const 1
+       i32.add
+       local.set $3
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $10
+     i32.store
+     local.get $10
+     local.get $0
+     call $~lib/array/Array<i64>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $10
+     br $__inlined_func$~lib/set/Set<i64>#values$12
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $8
-   i32.store
-   local.get $8
-   local.get $0
-   call $~lib/array/Array<i64>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $8
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<i64>#constructor
-   local.tee $0
+   local.tee $3
    i32.store offset=12
-   i32.const 0
-   local.set $3
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $8
+    local.get $0
     i32.store offset=4
-    local.get $8
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $3
+    local.get $5
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $8
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $8
-     local.get $3
+     local.get $0
+     local.get $5
      call $~lib/array/Array<i64>#__get
      call $~lib/set/Set<i64>#has
      i32.eqz
@@ -14223,27 +13927,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $3
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $8
-     i32.store offset=16
      local.get $0
-     local.get $8
+     i32.store offset=16
      local.get $3
+     local.get $0
+     local.get $5
      call $~lib/array/Array<i64>#__get
      call $~lib/set/Set<i64>#add
-     local.get $3
+     local.get $5
      i32.const 1
      i32.add
-     local.set $3
+     local.set $5
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $3
    i32.store offset=4
-   local.get $0
+   local.get $3
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -14449,6 +14153,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -14594,215 +14299,193 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 13
-   call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
-   i32.const 268435455
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $5
-   local.get $5
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 2
-   i32.shl
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $6
-   local.get $7
-   i32.store
-   local.get $6
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $2
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
+   block $__inlined_func$~lib/set/Set<i32>#values$6 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 13
+     call $~lib/rt/itcms/__new
      local.tee $7
-     i32.load offset=4
-     i32.const 1
-     i32.and
-     i32.eqz
+     i32.store
+     local.get $3
+     i32.const 268435455
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $6
-      i32.store
-      local.get $6
-      local.get $0
-      local.get $7
-      i32.load
-      call $~lib/array/Array<i32>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $3
+     local.get $3
+     i32.const 8
+     i32.le_u
+     select
+     i32.const 2
+     i32.shl
+     local.tee $8
      i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $7
+     local.get $0
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $8
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $3
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $2
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=4
+     i32.const 0
+     local.set $0
+     loop $for-loop|00
+      local.get $2
+      local.get $3
+      i32.lt_s
+      if
+       local.get $5
+       local.get $2
+       i32.const 3
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=4
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        local.get $7
+        local.get $0
+        local.get $6
+        i32.load
+        call $~lib/array/Array<i32>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $2
+       i32.const 1
+       i32.add
+       local.set $2
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/array/Array<i32>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     br $__inlined_func$~lib/set/Set<i32>#values$6
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store
-   local.get $6
-   local.get $0
-   call $~lib/array/Array<i32>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<i32>#constructor
-   local.tee $0
+   local.tee $2
    i32.store offset=12
-   i32.const 0
-   local.set $2
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $6
+    local.get $0
     i32.store offset=4
-    local.get $6
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $6
-     local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<i32>#__get
      call $~lib/set/Set<i32>#has
      i32.eqz
@@ -14815,27 +14498,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $2
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store offset=16
      local.get $0
-     local.get $6
+     i32.store offset=16
      local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<i32>#__get
      call $~lib/set/Set<i32>#add
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=4
-   local.get $0
+   local.get $2
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer
@@ -15041,6 +14724,7 @@
   (local $5 i32)
   (local $6 i32)
   (local $7 i32)
+  (local $8 i32)
   global.get $~lib/memory/__stack_pointer
   i32.const 20
   i32.sub
@@ -15186,215 +14870,193 @@
     unreachable
    end
    global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store offset=4
    global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=8
-   local.set $4
-   global.get $~lib/memory/__stack_pointer
-   local.get $1
-   i32.store
-   local.get $1
-   i32.load offset=16
-   local.set $5
-   global.get $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.sub
-   global.set $~lib/memory/__stack_pointer
-   global.get $~lib/memory/__stack_pointer
-   i32.const 1748
-   i32.lt_s
-   br_if $folding-inner1
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store
-   global.get $~lib/memory/__stack_pointer
-   i64.const 0
-   i64.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.const 9
-   call $~lib/rt/itcms/__new
-   local.tee $6
-   i32.store
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store
-   local.get $6
-   i32.const 0
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   i32.const 0
-   i32.store offset=12
-   local.get $5
-   i32.const 536870910
-   i32.gt_u
-   if
-    i32.const 1456
-    i32.const 1616
-    i32.const 70
-    i32.const 60
-    call $~lib/builtins/abort
-    unreachable
-   end
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   local.get $5
-   local.get $5
-   i32.const 8
-   i32.le_u
-   select
-   i32.const 1
-   i32.shl
-   local.tee $0
-   i32.const 1
-   call $~lib/rt/itcms/__new
-   local.tee $7
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $7
-   i32.store offset=12
-   local.get $6
-   local.get $7
-   i32.store
-   local.get $6
-   local.get $7
-   call $~lib/rt/itcms/__link
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $7
-   i32.store offset=4
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $0
-   i32.store offset=8
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   local.get $6
-   local.get $5
-   i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   i32.const 16
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store offset=4
-   i32.const 0
-   local.set $0
-   loop $for-loop|00
-    local.get $2
-    local.get $5
-    i32.lt_s
-    if
-     local.get $4
-     local.get $2
-     i32.const 3
-     i32.shl
-     i32.add
+   block $__inlined_func$~lib/set/Set<i16>#values$4 (result i32)
+    global.get $~lib/memory/__stack_pointer
+    i32.const 8
+    i32.sub
+    global.set $~lib/memory/__stack_pointer
+    block $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=8
+     local.set $5
+     global.get $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     local.get $1
+     i32.store
+     local.get $1
+     i32.load offset=16
+     local.set $3
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.sub
+     global.set $~lib/memory/__stack_pointer
+     global.get $~lib/memory/__stack_pointer
+     i32.const 1748
+     i32.lt_s
+     br_if $folding-inner0
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store
+     global.get $~lib/memory/__stack_pointer
+     i64.const 0
+     i64.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
+     i32.const 9
+     call $~lib/rt/itcms/__new
      local.tee $7
-     i32.load offset=4
-     i32.const 1
-     i32.and
-     i32.eqz
+     i32.store
+     local.get $3
+     i32.const 536870910
+     i32.gt_u
      if
-      global.get $~lib/memory/__stack_pointer
-      local.get $6
-      i32.store
-      local.get $6
-      local.get $0
-      local.get $7
-      i32.load16_s
-      call $~lib/array/Array<i16>#__set
-      local.get $0
-      i32.const 1
-      i32.add
-      local.set $0
+      i32.const 1456
+      i32.const 1616
+      i32.const 70
+      i32.const 60
+      call $~lib/builtins/abort
+      unreachable
      end
-     local.get $2
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     local.get $3
+     local.get $3
+     i32.const 8
+     i32.le_u
+     select
      i32.const 1
+     i32.shl
+     local.tee $8
+     i32.const 1
+     call $~lib/rt/itcms/__new
+     local.tee $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $0
+     i32.store offset=12
+     local.get $7
+     local.get $0
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/rt/itcms/__link
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $0
+     i32.store offset=4
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $8
+     i32.store offset=8
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=8
+     local.get $7
+     local.get $3
+     i32.store offset=12
+     global.get $~lib/memory/__stack_pointer
+     i32.const 16
      i32.add
-     local.set $2
-     br $for-loop|00
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store offset=4
+     i32.const 0
+     local.set $0
+     loop $for-loop|00
+      local.get $2
+      local.get $3
+      i32.lt_s
+      if
+       local.get $5
+       local.get $2
+       i32.const 3
+       i32.shl
+       i32.add
+       local.tee $6
+       i32.load offset=4
+       i32.const 1
+       i32.and
+       i32.eqz
+       if
+        global.get $~lib/memory/__stack_pointer
+        local.get $7
+        i32.store
+        local.get $7
+        local.get $0
+        local.get $6
+        i32.load16_s
+        call $~lib/array/Array<i16>#__set
+        local.get $0
+        i32.const 1
+        i32.add
+        local.set $0
+       end
+       local.get $2
+       i32.const 1
+       i32.add
+       local.set $2
+       br $for-loop|00
+      end
+     end
+     global.get $~lib/memory/__stack_pointer
+     local.get $7
+     i32.store
+     local.get $7
+     local.get $0
+     call $~lib/array/Array<i16>#set:length
+     global.get $~lib/memory/__stack_pointer
+     i32.const 8
+     i32.add
+     global.set $~lib/memory/__stack_pointer
+     local.get $7
+     br $__inlined_func$~lib/set/Set<i16>#values$4
     end
+    br $folding-inner1
    end
-   global.get $~lib/memory/__stack_pointer
-   local.get $6
-   i32.store
-   local.get $6
-   local.get $0
-   call $~lib/array/Array<i16>#set:length
-   global.get $~lib/memory/__stack_pointer
-   i32.const 8
-   i32.add
-   global.set $~lib/memory/__stack_pointer
-   local.get $6
+   local.tee $0
    i32.store offset=8
    global.get $~lib/memory/__stack_pointer
    call $~lib/set/Set<i16>#constructor
-   local.tee $0
+   local.tee $2
    i32.store offset=12
-   i32.const 0
-   local.set $2
    loop $for-loop|2
     global.get $~lib/memory/__stack_pointer
-    local.get $6
+    local.get $0
     i32.store offset=4
-    local.get $6
+    local.get $0
     call $~lib/array/Array<i8>#get:length
-    local.get $2
+    local.get $4
     i32.gt_s
     if
      global.get $~lib/memory/__stack_pointer
      local.get $1
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
+     local.get $0
      i32.store offset=16
      local.get $1
-     local.get $6
-     local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<i16>#__get
      call $~lib/set/Set<i16>#has
      i32.eqz
@@ -15407,27 +15069,27 @@
       unreachable
      end
      global.get $~lib/memory/__stack_pointer
-     local.get $0
+     local.get $2
      i32.store offset=4
      global.get $~lib/memory/__stack_pointer
-     local.get $6
-     i32.store offset=16
      local.get $0
-     local.get $6
+     i32.store offset=16
      local.get $2
+     local.get $0
+     local.get $4
      call $~lib/array/Array<i16>#__get
      call $~lib/set/Set<i16>#add
-     local.get $2
+     local.get $4
      i32.const 1
      i32.add
-     local.set $2
+     local.set $4
      br $for-loop|2
     end
    end
    global.get $~lib/memory/__stack_pointer
-   local.get $0
+   local.get $2
    i32.store offset=4
-   local.get $0
+   local.get $2
    call $~lib/set/Set<i8>#get:size
    local.set $0
    global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/symbol.debug.wat
+++ b/tests/compiler/std/symbol.debug.wat
@@ -2403,16 +2403,6 @@
   local.get $entriesCapacity
   i32.store offset=12
  )
- (func $"~lib/map/Map<~lib/string/String,usize>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<~lib/string/String,usize>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
- )
  (func $~lib/rt/common/OBJECT#get:rtSize (param $this i32) (result i32)
   local.get $this
   i32.load offset=16
@@ -2581,6 +2571,16 @@
   local.get $taggedNext
   i32.store offset=8
  )
+ (func $"~lib/map/Map<~lib/string/String,usize>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<~lib/string/String,usize>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
+ )
  (func $"~lib/map/Map<usize,~lib/string/String>#set:buckets" (param $this i32) (param $buckets i32)
   local.get $this
   local.get $buckets
@@ -2608,16 +2608,6 @@
   local.get $this
   local.get $entriesCapacity
   i32.store offset=12
- )
- (func $"~lib/map/Map<usize,~lib/string/String>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
-  local.get $this
-  local.get $entriesOffset
-  i32.store offset=16
- )
- (func $"~lib/map/Map<usize,~lib/string/String>#set:entriesCount" (param $this i32) (param $entriesCount i32)
-  local.get $this
-  local.get $entriesCount
-  i32.store offset=20
  )
  (func $~lib/util/hash/HASH<usize> (param $key i32) (result i32)
   (local $key|1 i32)
@@ -2737,6 +2727,16 @@
   local.get $this
   local.get $taggedNext
   i32.store offset=8
+ )
+ (func $"~lib/map/Map<usize,~lib/string/String>#set:entriesOffset" (param $this i32) (param $entriesOffset i32)
+  local.get $this
+  local.get $entriesOffset
+  i32.store offset=16
+ )
+ (func $"~lib/map/Map<usize,~lib/string/String>#set:entriesCount" (param $this i32) (param $entriesCount i32)
+  local.get $this
+  local.get $entriesCount
+  i32.store offset=20
  )
  (func $~lib/rt/__visit_globals (param $0 i32)
   (local $1 i32)
@@ -2960,22 +2960,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<~lib/string/String,usize>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<~lib/string/String,usize>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<~lib/string/String,usize>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer
@@ -4066,22 +4050,6 @@
   local.get $1
   i32.const 4
   call $"~lib/map/Map<usize,~lib/string/String>#set:entriesCapacity"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<usize,~lib/string/String>#set:entriesOffset"
-  local.get $this
-  local.set $1
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
-  call $"~lib/map/Map<usize,~lib/string/String>#set:entriesCount"
   local.get $this
   local.set $1
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/std/symbol.release.wat
+++ b/tests/compiler/std/symbol.release.wat
@@ -294,7 +294,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$88
+   block $__inlined_func$~lib/util/string/compareImpl$86
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -314,7 +314,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$88
+      br_if $__inlined_func$~lib/util/string/compareImpl$86
       local.get $2
       i32.const 2
       i32.add
@@ -1543,7 +1543,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$246
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$242
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -1567,7 +1567,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$246
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$242
    end
    local.get $0
    i32.load offset=8
@@ -2170,7 +2170,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$253
+   block $__inlined_func$~lib/string/String#concat$249
     local.get $1
     i32.const 20
     i32.sub
@@ -2189,7 +2189,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1888
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$253
+     br $__inlined_func$~lib/string/String#concat$249
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -3921,18 +3921,6 @@
    i32.const 4
    i32.store offset=12
    global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=20
-   global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add
    global.set $~lib/memory/__stack_pointer
@@ -4002,18 +3990,6 @@
    local.get $0
    i32.const 4
    i32.store offset=12
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=16
-   global.get $~lib/memory/__stack_pointer
-   local.get $0
-   i32.store offset=4
-   local.get $0
-   i32.const 0
-   i32.store offset=20
    global.get $~lib/memory/__stack_pointer
    i32.const 12
    i32.add

--- a/tests/compiler/std/typedarray.debug.wat
+++ b/tests/compiler/std/typedarray.debug.wat
@@ -12958,30 +12958,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:buffer
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:dataStart
-  local.get $this
-  local.set $4
-  global.get $~lib/memory/__stack_pointer
-  local.get $4
-  i32.store offset=4
-  local.get $4
-  i32.const 0
-  call $~lib/arraybuffer/ArrayBufferView#set:byteLength
   local.get $length
   i32.const 1073741820
   local.get $alignLog2
@@ -13003,7 +12979,7 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $buffer
-  i32.store offset=8
+  i32.store offset=4
   i32.const 2
   global.get $~lib/shared/runtime/Runtime.Incremental
   i32.ne
@@ -13012,7 +12988,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   local.set $4
@@ -13025,7 +13001,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $buffer
   call $~lib/arraybuffer/ArrayBufferView#set:dataStart
@@ -13033,7 +13009,7 @@
   local.set $4
   global.get $~lib/memory/__stack_pointer
   local.get $4
-  i32.store offset=4
+  i32.store offset=8
   local.get $4
   local.get $length
   call $~lib/arraybuffer/ArrayBufferView#set:byteLength

--- a/tests/compiler/std/typedarray.release.wat
+++ b/tests/compiler/std/typedarray.release.wat
@@ -2278,7 +2278,7 @@
      end
     end
    end
-   block $__inlined_func$~lib/util/string/compareImpl$714
+   block $__inlined_func$~lib/util/string/compareImpl$711
     loop $while-continue|1
      local.get $0
      local.tee $3
@@ -2298,7 +2298,7 @@
       local.get $4
       local.get $5
       i32.ne
-      br_if $__inlined_func$~lib/util/string/compareImpl$714
+      br_if $__inlined_func$~lib/util/string/compareImpl$711
       local.get $2
       i32.const 2
       i32.add
@@ -4354,27 +4354,6 @@
    local.tee $0
    i32.store
   end
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store
-  local.get $0
-  i32.const 0
-  call $~lib/rt/itcms/__link
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=4
-  global.get $~lib/memory/__stack_pointer
-  local.get $0
-  i32.store offset=4
-  local.get $0
-  i32.const 0
-  i32.store offset=8
   local.get $1
   i32.const 1073741820
   local.get $2
@@ -4396,10 +4375,10 @@
   i32.const 1
   call $~lib/rt/itcms/__new
   local.tee $2
-  i32.store offset=8
+  i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   global.get $~lib/memory/__stack_pointer
   local.get $2
   i32.store offset=12
@@ -4411,13 +4390,13 @@
   call $~lib/rt/itcms/__link
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   local.get $0
   local.get $2
   i32.store offset=4
   global.get $~lib/memory/__stack_pointer
   local.get $0
-  i32.store offset=4
+  i32.store offset=8
   local.get $0
   local.get $1
   i32.store offset=8
@@ -8268,7 +8247,7 @@
   i32.lt_s
   select
   local.set $0
-  block $__inlined_func$~lib/util/bytes/FILL<u32>$202
+  block $__inlined_func$~lib/util/bytes/FILL<u32>$199
    local.get $1
    i32.eqz
    local.get $1
@@ -8293,7 +8272,7 @@
      i32.shl
      memory.fill
     end
-    br $__inlined_func$~lib/util/bytes/FILL<u32>$202
+    br $__inlined_func$~lib/util/bytes/FILL<u32>$199
    end
    loop $for-loop|0
     local.get $0
@@ -10974,7 +10953,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1419
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1416
     local.get $0
     i32.const 1
     i32.sub
@@ -10988,7 +10967,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1419
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1416
     end
     local.get $6
     i32.eqz
@@ -11001,7 +10980,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1419
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1416
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -11094,7 +11073,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1419
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u8>$1416
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -12620,7 +12599,7 @@
    local.get $1
    global.set $~lib/rt/itcms/iter
   end
-  block $__inlined_func$~lib/rt/itcms/Object#unlink$1413
+  block $__inlined_func$~lib/rt/itcms/Object#unlink$1410
    local.get $0
    i32.load offset=4
    i32.const -4
@@ -12644,7 +12623,7 @@
      call $~lib/builtins/abort
      unreachable
     end
-    br $__inlined_func$~lib/rt/itcms/Object#unlink$1413
+    br $__inlined_func$~lib/rt/itcms/Object#unlink$1410
    end
    local.get $0
    i32.load offset=8
@@ -18301,7 +18280,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1423
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1420
     local.get $0
     i32.const 1
     i32.sub
@@ -18315,7 +18294,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1423
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1420
     end
     local.get $6
     i32.eqz
@@ -18328,7 +18307,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1423
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1420
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -18425,7 +18404,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1423
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u32>$1420
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -19024,7 +19003,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1421
+   block $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1418
     local.get $0
     i32.const 1
     i32.sub
@@ -19038,7 +19017,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1421
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1418
     end
     local.get $6
     i32.eqz
@@ -19051,7 +19030,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1421
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1418
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -19148,7 +19127,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1421
+     br $__inlined_func$~lib/util/string/joinIntegerArray<u16>$1418
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -19994,7 +19973,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1418
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1415
     local.get $0
     i32.const 1
     i32.sub
@@ -20008,7 +19987,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1418
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1415
     end
     local.get $6
     i32.eqz
@@ -20021,7 +20000,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1418
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1415
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -20114,7 +20093,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1418
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i8>$1415
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -22313,7 +22292,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1422
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1419
     local.get $0
     i32.const 1
     i32.sub
@@ -22327,7 +22306,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1422
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1419
     end
     local.get $6
     i32.eqz
@@ -22340,7 +22319,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1422
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1419
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -22437,7 +22416,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1422
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i32>$1419
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -23491,7 +23470,7 @@
    global.get $~lib/memory/__stack_pointer
    i64.const 0
    i64.store
-   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1420
+   block $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1417
     local.get $0
     i32.const 1
     i32.sub
@@ -23505,7 +23484,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 7776
      local.set $0
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1420
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1417
     end
     local.get $6
     i32.eqz
@@ -23518,7 +23497,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1420
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1417
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 9584
@@ -23615,7 +23594,7 @@
      i32.const 8
      i32.add
      global.set $~lib/memory/__stack_pointer
-     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1420
+     br $__inlined_func$~lib/util/string/joinIntegerArray<i16>$1417
     end
     global.get $~lib/memory/__stack_pointer
     i32.const 8
@@ -26452,7 +26431,7 @@
      global.get $~lib/memory/__stack_pointer
      i32.const 0
      i32.store
-     block $__inlined_func$~lib/util/number/utoa64$749
+     block $__inlined_func$~lib/util/number/utoa64$746
       local.get $3
       i64.eqz
       if
@@ -26462,7 +26441,7 @@
        global.set $~lib/memory/__stack_pointer
        i32.const 8000
        local.set $1
-       br $__inlined_func$~lib/util/number/utoa64$749
+       br $__inlined_func$~lib/util/number/utoa64$746
       end
       local.get $3
       i64.const 4294967295

--- a/tests/compiler/switch.debug.wat
+++ b/tests/compiler/switch.debug.wat
@@ -3304,14 +3304,6 @@
   local.get $2
   i32.store offset=4
   local.get $2
-  i32.const 0
-  call $switch/FooClass#set:value
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
   local.get $value
   call $switch/FooClass#set:value
   local.get $this
@@ -3465,14 +3457,6 @@
    local.tee $this
    i32.store
   end
-  local.get $this
-  local.set $2
-  global.get $~lib/memory/__stack_pointer
-  local.get $2
-  i32.store offset=4
-  local.get $2
-  i32.const 0
-  call $switch/BarClass#set:value
   local.get $this
   local.set $2
   global.get $~lib/memory/__stack_pointer

--- a/tests/compiler/switch.release.wat
+++ b/tests/compiler/switch.release.wat
@@ -112,7 +112,7 @@
    global.get $~lib/memory/__stack_pointer
    local.get $1
    i32.store
-   block $__inlined_func$~lib/string/String#concat$191
+   block $__inlined_func$~lib/string/String#concat$189
     local.get $1
     i32.const 20
     i32.sub
@@ -131,7 +131,7 @@
      global.set $~lib/memory/__stack_pointer
      i32.const 1296
      local.set $0
-     br $__inlined_func$~lib/string/String#concat$191
+     br $__inlined_func$~lib/string/String#concat$189
     end
     global.get $~lib/memory/__stack_pointer
     local.get $0
@@ -535,7 +535,7 @@
     local.get $0
     global.set $~lib/rt/itcms/iter
    end
-   block $__inlined_func$~lib/rt/itcms/Object#unlink$186
+   block $__inlined_func$~lib/rt/itcms/Object#unlink$184
     local.get $1
     i32.load offset=4
     i32.const -4
@@ -559,7 +559,7 @@
       call $~lib/builtins/abort
       unreachable
      end
-     br $__inlined_func$~lib/rt/itcms/Object#unlink$186
+     br $__inlined_func$~lib/rt/itcms/Object#unlink$184
     end
     local.get $1
     i32.load offset=8
@@ -679,12 +679,6 @@
   local.get $1
   i32.store offset=4
   local.get $1
-  i32.const 0
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
   local.get $0
   i32.store
   global.get $~lib/memory/__stack_pointer
@@ -718,12 +712,6 @@
   i32.const 5
   call $~lib/rt/itcms/__new
   local.tee $1
-  i32.store
-  global.get $~lib/memory/__stack_pointer
-  local.get $1
-  i32.store offset=4
-  local.get $1
-  i32.const 0
   i32.store
   global.get $~lib/memory/__stack_pointer
   local.get $1


### PR DESCRIPTION
- Reduce unnecessary zero-initialization memory in the constructor
- According to wasm-spec, grown memories should initialized with value 0x00

- [x] I've read the contributing guidelines
- [x] I've added my name and email to the NOTICE file
